### PR TITLE
docs: BT-Mesh-direct spec + prototypes, Matter bridge guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,11 @@ When working on anything that touches the gateway protocol, consult
   types and command formats.
 - [docs/gateway-architecture.md](docs/gateway-architecture.md) — partitions,
   services, the BT-Mesh stack, self-hosting analysis.
+- [docs/bt-mesh-direct.md](docs/bt-mesh-direct.md) — gateway-free BT-Mesh control
+  (function→model map, vendor model, hardware); prototypes in
+  `tools/bt-mesh-direct/`.
+- [docs/matter-bridge.md](docs/matter-bridge.md) — Matter options (gateway's own
+  is inactive; bridge from HA).
 
 ## Key behaviours to preserve
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ The local gateway API (REST + WebSocket), its registration flow, and the
 device-mesh architecture are documented in **[docs/](docs/README.md)**.
 
 # TODO
-- Make setup easier.
 - Bring back binary sensors (motion/presence, which was previously removed).
 - Puck support.
 
-Unlikely to be completed by me, since I don't have the devices:
+Unlikely to be completed by me, since I don't have these devices:
 - Curtain control.
 - Thermostats.
 
@@ -73,6 +72,3 @@ scripts/setup     # install dependencies
 scripts/develop   # run Home Assistant against ./config with the integration on PYTHONPATH
 scripts/lint      # ruff
 ```
-
-# Coffee
-If you've enjoyed this integration, feel free to buy me a cup of coffee. My BTC address is `bc1qlpvgqzr0y09a4zhez94sjl6539ptk0l9rdy2jm`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,13 @@ live local API. None of this is required to *use* the integration.
   the full endpoint list.
 - **[gateway-websocket.md](gateway-websocket.md)** — the WebSocket protocol: all
   message types (server→client and client→server) and command formats.
+- **[bt-mesh-direct.md](bt-mesh-direct.md)** — controlling devices over Bluetooth
+  Mesh **without the gateway**: the function→model map, send/receive protocol,
+  the JUNG vendor model, hardware options, and what keys you need. Prototypes in
+  [`../tools/bt-mesh-direct/`](../tools/bt-mesh-direct/).
+- **[matter-bridge.md](matter-bridge.md)** — getting JUNG devices into Matter
+  (the gateway's built-in Matter is inactive; bridge from Home Assistant
+  instead).
 
 Quick facts:
 
@@ -26,3 +33,22 @@ Quick facts:
 
 > The full disk image lives in `disk_dump/` (gitignored — it contains tokens and
 > mesh keys; never commit it).
+
+## Legal / interoperability note (not legal advice)
+
+This folder documents **facts** about the gateway's interfaces (endpoints,
+message formats, mesh model IDs, opcodes, constants) gathered for
+**interoperability**, and the code under `tools/` is original. Facts and
+interfaces are generally not protected by copyright, and reverse engineering for
+interoperability is broadly permitted (e.g. the EU Software Directive Art. 6; a
+US DMCA §1201(f) interoperability exemption). What you should **not** publish:
+
+- JUNG's or Silicon Labs' **source code or firmware** (the Node.js apps, the
+  `.gbl` radio images, the Silabs SDK) — proprietary; keep `disk_dump/` private.
+- Your **keys/tokens** (API tokens, BT-Mesh NetKey/AppKey/device keys) — these
+  are secrets, not redistributable material.
+
+Other notes: "JUNG" / "JUNG HOME" are trademarks — use them only descriptively
+(to say this project interoperates), not in a way implying endorsement. Patents
+may exist but Bluetooth Mesh is an open SIG standard. This is an unofficial,
+community project. For anything commercial or high-stakes, consult a lawyer.

--- a/docs/bt-mesh-direct.md
+++ b/docs/bt-mesh-direct.md
@@ -1,0 +1,170 @@
+# Driving JUNG HOME devices directly over Bluetooth Mesh (gateway-free)
+
+Reverse-engineered from the gateway's `middleware` ("bluetooth") component. This
+is the spec for controlling JUNG devices without the gateway, by joining their
+Bluetooth Mesh network yourself. See [gateway-architecture.md](gateway-architecture.md)
+for how the gateway uses this internally.
+
+> Everything here describes standard Bluetooth Mesh plus one JUNG vendor model
+> (company `0x0527`). You need the network keys + device keys (exportable from
+> the JUNG HOME app) to participate.
+
+## What you need
+
+1. **Keys & state**, exported from the app or read from the gateway CDB
+   (`bt_mesh_project.json`):
+   - NetKey(s) and AppKey(s) (with their key indexes).
+   - **IV index** (`btmesh_iv_index`) and current **sequence number**
+     (`btmesh_sequence_number`) — you must continue from these or replay
+     protection will drop your messages.
+   - Each node's `unicastAddress`, element layout, and the group addresses.
+   - Per-node **device keys** (only needed to *reconfigure* nodes — bind app
+     keys, set publish/subscribe — not to operate them).
+2. **A Bluetooth-Mesh radio + host stack** (see [Hardware](#hardware)).
+3. Add yourself as a **new node/provisioner** with its own unicast address;
+   don't reuse the gateway's address.
+
+## Hardware
+
+An nRF chip is **not** mandatory. In rough order of fidelity to JUNG's own stack:
+
+| Option | Notes |
+|--------|-------|
+| **Silabs EFR32** (xG24/xG21 dev kit) as a BGAPI NCP | *Same silicon + same Bluetooth Mesh SDK (v4.4.6) as the JUNG gateway.* The middleware's commands map 1:1 (this doc uses them). Best fidelity; the prototype in `tools/bt-mesh-direct/` targets this. |
+| **Nordic nRF52840 dongle** (Zephyr / nRF Connect SDK) | Robust, ~$10, extremely well documented. Great choice; you implement the mesh access opcodes (below). |
+| **BlueZ mesh** on any Bluetooth 5 adapter | *No extra chip* — runs on the HA host's own Bluetooth via `bluetooth-meshd`. Cheapest, but BlueZ mesh provisioner/CDB handling is fiddly. |
+| **ESP32** (ESP-BLE-MESH) | Cheap, but weaker proxy/relay/vendor-model support. |
+
+The gateway radio is an EFR32 reached over UART (`/dev/ttyAMA0`) using **Silabs
+BGAPI**; the host (`middleware`) drives mesh *client* models on the NCP.
+
+## Function → mesh model map
+
+From `middleware/dist/const/cdb_types_datapoints.json`:
+
+| Datapoint | SIG model (server / client) | Set kind |
+|-----------|------------------------------|----------|
+| `switch` | Generic OnOff `0x1000` / `0x1001` | `RequestOnOff` (0) |
+| `brightness` | Light Lightness Actual `0x1300` / `0x1302` | `RequestLightnessActual` (128) |
+| `color_temperature` | Light CTL Temperature `0x1306` / `0x1305` — **but JUNG sets it via Generic Level on element+1** (see below) | `RequestLevel` (2) |
+| `level`, `angle`, `temperature_ctrl` | Generic Level `0x1002` / `0x1003` | `RequestLevel` / `RequestLevelMove` |
+| `quantity` (energy/sensor) | Sensor `0x1100` / `0x1102` | read via Sensor Client |
+| `scene` | Scene `0x1203` / `0x1205` | Scene Recall |
+| `status_led`, `up_request`, `down_request`, `trigger_request`, `parameter` | **JUNG vendor "Property" model, company `0x0527`** (`0x05271015` / `0x05271013`, etc.) | vendor (see below) |
+
+So lights, dimmers, tunable-white, sockets, blinds, energy and scenes are all
+**standard SIG models**. Only rocker buttons, the status LED, and device
+parameters use the **vendor model**.
+
+## Sending commands
+
+The middleware sends every command **3×** (`publish_retransmissions`) at **15 ms**
+spacing (`publish_interval_ms`), with **50 ms** pause between datapoints
+(`request_pause_ms`), incrementing an 8-bit transaction id (`tid`) once per
+logical command.
+
+### Generic / lighting (the common path)
+
+The gateway calls the Silabs BGAPI `sl_btmesh_cmd_generic_client_set` with:
+
+```
+server_address   = node/group unicast (uint16)
+elem_index       = 0
+model_id         = client model (e.g. 0x1001 OnOff, 0x1302 Lightness, 0x1003 Level)
+appkey_index     = 0
+tid              = transaction id (uint8, increments per command)
+transition_ms    = 0 (or 0xFFFE for "move")
+delay_ms         = staggered per retransmission
+flags            = 1
+type             = MeshModelSetKind (see table)
+parameters       = little-endian value, length bytes
+```
+
+On any other mesh stack, this is the equivalent **standard mesh access message**
+to the node/group address with the device's AppKey:
+
+| Action | Value encoding | SIG access opcode* |
+|--------|----------------|--------------------|
+| OnOff | 1 byte `00`/`01` | Generic OnOff Set `0x8202` (unack `0x8203`) |
+| Brightness | uint16, value scaled to model range (0…0xFFFF) | Light Lightness Set `0x824C` |
+| Level | int16 | Generic Level Set `0x8206` |
+| Color temperature | **see below** | Generic Level Set `0x8206` on the CTL-temperature element |
+| Blinds move | int16 `7FFF`=down, `8000`=up, `0`=stop, `transition=0xFFFE` | Generic Level Move Set `0x820B` |
+
+*Standard Bluetooth Mesh Model opcodes — verify against the Mesh Model spec for
+your stack. The BGAPI command above is what the gateway uses on its EFR32 NCP.
+
+**Value scaling:** linear `convertRange(value, input_range, output_range)` then
+to unsigned. OnOff is a single byte; level/lightness are little-endian uint16.
+
+**Color temperature quirk:** JUNG does *not* use Light CTL Temperature Set.
+Instead it targets **Generic Level on `address + 1`** (the CTL temperature
+element), mapping Kelvin `2000…6000` onto int16 `-0x8000…0x7FFF`.
+
+### Scenes
+
+`sl_btmesh_cmd_scene_client_recall` → standard **Scene Recall `0x8242`**:
+
+```
+server_address = 0xFFFF (broadcast) or a group
+elem_index     = 0
+scene_number   = uint16
+appkey_index   = 0
+flags          = 1
+tid, transition_ms = 0, delay_ms
+```
+
+### Vendor model: status LED, buttons, parameters (company `0x0527`)
+
+These use a JUNG vendor model. The gateway reaches it through the Silabs
+host↔NCP passthrough `sl_bt_cmd_user_message_to_target` with a custom payload:
+
+```
+commandId = 2      (STATUS_LBC_PROP_SEND_ID)
+elementId = 0
+dest      = node unicast address
+propId    = model_kind / property id
+appKey    = 0
+modelId   = vendor client model (model_ctrl & 0xFFFF, e.g. 0x1013/0x1015)
+value     = the property value
+```
+
+Over the air this is a **vendor access message** (3-byte opcode = `0b11xxxxxx`
+| company `0x0527`) carrying the property id + value. On a non-Silabs stack you
+send/parse the vendor opcodes directly; the exact opcode bytes live in the EFR32
+NCP firmware, but the host-side framing above (from
+`btmesh_set_datapoint_service.js`) tells you the command/property/value fields.
+
+Button **events** (`up_request`/`down_request`/`trigger_request`) are the device
+*publishing* vendor property status to a group; subscribe to that group to
+receive them. With the device keys you can (re)bind your AppKey and set the
+publish target, so you can route button presses to an address you listen on.
+
+## Receiving state & events
+
+The gateway listens for these NCP events (`handler/bt_event_handler.js`); the
+equivalent on any stack is the matching mesh **Status** message:
+
+| BGAPI event | Carries | Standard message |
+|-------------|---------|------------------|
+| `sl_btmesh_evt_generic_client_server_status` | `{server_address, model_id, parameters}` | Generic/Lighting *Status* (OnOff `0x8204`, Level `0x8208`, Lightness `0x824E`) |
+| `sl_btmesh_evt_sensor_client_status` | `{server_address, sensor_data}` | Sensor Status `0x52` (energy/quantity) |
+| `sl_btmesh_evt_scene_client_status` | `{current_scene, target_scene, server_address}` | Scene Status `0x5E` |
+| vendor user-message events | property id + value | vendor status (buttons / LED / parameters) |
+
+Map `server_address` (+ element offset) back to a function/datapoint using the
+CDB (`cdb_functions.json` / `bt_mesh_project.json`).
+
+## Practical notes
+
+- **Coverage / relaying:** the gateway is centrally placed and relays. A single
+  USB dongle may not reach every node; enable relay/proxy or add a second node.
+- **IV index & sequence numbers** must be respected (export and continue from
+  the gateway's values), or replay protection will silently drop your traffic.
+- **Don't double-drive:** running your stack *and* the gateway on the same mesh
+  is fine (mesh is multi-master), but use distinct unicast addresses.
+- The control surface is ~90% standard models (trivial) + the `0x0527` vendor
+  model for buttons/LED (bounded RE; the host-side framing is documented above).
+
+A reference prototype targeting an EFR32 NCP lives in
+[`tools/bt-mesh-direct/`](../tools/bt-mesh-direct/).

--- a/docs/matter-bridge.md
+++ b/docs/matter-bridge.md
@@ -1,0 +1,74 @@
+# Exposing JUNG HOME to Matter
+
+Two separate questions:
+
+1. **Can the JUNG gateway itself be a Matter bridge?** — Not on current firmware.
+2. **Can you expose JUNG devices to Matter anyway?** — Yes, from the Home
+   Assistant side.
+
+## 1. The gateway's built-in Matter — present but inactive
+
+The gateway has a scaffolded `matter-interface` component and pre-staged
+commissioning data (`sdc4/matter-interface/matter_setup_data.json`: vendor
+`0x1429`, product `11`, discriminator `1538`, SPAKE2+ verifier), but on the
+firmware imaged here the **bridge daemon is not installed** — only an empty
+`res/` directory, and there are no references to it from the api-server or
+middleware. So there is no switch to flip; the process that would advertise and
+commission simply isn't there. It looks reserved for a future JUNG firmware. If
+JUNG ships it, commissioning would use the pre-staged discriminator + a passcode
+(the stored SPAKE2+ verifier can't be reversed to the passcode — it would come
+from JUNG's app/QR).
+
+## 2. Bridge from Home Assistant (works today)
+
+Since this integration already brings JUNG devices into Home Assistant, the
+practical route is a **Home Assistant → Matter bridge**, which exposes selected
+HA entities as a Matter bridged device that Apple Home, Google Home, Alexa, or
+another HA can commission.
+
+> Note: HA's *built-in* Matter support is a **controller/commissioner** (via the
+> Matter Server add-on) — it lets HA control Matter devices. It does **not**
+> expose HA entities outward. For that you need a bridge project.
+
+### Option: `home-assistant-matter-hub`
+
+A community project that runs alongside HA, reads entities via the HA API, and
+advertises them as a Matter bridge.
+
+Sketch (`docker compose`):
+
+```yaml
+services:
+  matter-hub:
+    image: ghcr.io/t0bst4r/home-assistant-matter-hub:latest
+    network_mode: host                # Matter needs IPv6 + mDNS on the LAN
+    environment:
+      HAMH_HOME_ASSISTANT_URL: http://homeassistant.local:8123
+      HAMH_HOME_ASSISTANT_ACCESS_TOKEN: <long-lived-access-token>
+    volumes:
+      - ./matter-hub:/data
+    restart: unless-stopped
+```
+
+Then add a bridge in its UI filtered to your `light.*` / `switch.*` /
+`sensor.*` JUNG entities, and commission it from your Matter controller with the
+pairing code it shows.
+
+Caveats: Matter requires **host networking / IPv6 / mDNS** reachable on your LAN;
+bridged-device support for some domains (e.g. events from rocker switches) is
+limited by what Matter device types exist; check the project's current support
+matrix.
+
+### Option: roll your own with `matter.js`
+
+If you go the [gateway-free BT-Mesh route](bt-mesh-direct.md), you can wrap that
+layer in a [`matter.js`](https://github.com/project-chip/matter.js) bridge to
+expose devices to Matter natively, end to end, without HA in the path.
+
+## Recommendation
+
+- Want Matter now, least effort: **`home-assistant-matter-hub`** on top of this
+  integration.
+- Want it native/gateway-free: **BT-Mesh direct + a `matter.js` bridge** (a real
+  project).
+- Want JUNG's own bridge: **wait for firmware** that ships `matter-interface`.

--- a/tools/bt-mesh-direct/README.md
+++ b/tools/bt-mesh-direct/README.md
@@ -1,0 +1,58 @@
+# BT-Mesh direct — reference prototypes
+
+Proof-of-concept code for controlling JUNG HOME devices **without the gateway**,
+by joining their Bluetooth Mesh network from your own radio. Read
+[../../docs/bt-mesh-direct.md](../../docs/bt-mesh-direct.md) first — it's the
+protocol spec these prototypes implement.
+
+Both are **reference sketches**: they need real hardware and an already-provisioned
+node (NetKey/AppKey from the JUNG HOME app, AppKey bound to the client models).
+They are not built or tested in CI.
+
+## Option A — Silicon Labs EFR32 (`junghome_mesh.py`)
+
+Same silicon + Mesh SDK as the JUNG gateway, so the commands map 1:1 to the
+gateway's own code.
+
+1. Flash an EFR32 dev kit (xG21/xG24) with the Silabs **"Bluetooth Mesh - NCP"**
+   example (Simplicity Studio).
+2. `pip install -r requirements.txt`
+3. Run:
+   ```sh
+   python junghome_mesh.py --port /dev/ttyACM0 onoff 0x0007 on
+   python junghome_mesh.py --port /dev/ttyACM0 brightness 0x0007 40
+   python junghome_mesh.py --port /dev/ttyACM0 ct 0x0007 3000
+   python junghome_mesh.py --port /dev/ttyACM0 scene 1
+   python junghome_mesh.py --port /dev/ttyACM0 listen
+   ```
+   (`0x0007` = a node's unicast address from your CDB / app export.)
+
+## Option B — ESP32 (`esp32/junghome_mesh_esp32.c`)
+
+ESP-IDF / ESP-BLE-MESH. Cheapest hardware, but provisioning/key import and
+vendor-model support take more work than on the EFR32.
+
+1. Create an ESP-IDF project; in `menuconfig` enable Bluetooth, BLE Mesh, and the
+   Generic / Lighting / Time-Scene **client** models.
+2. Drop `junghome_mesh_esp32.c` into `main/`, wire up provisioning + the client
+   model elements, and call `jung_set_onoff()` / `jung_set_brightness()` / etc.
+
+## Option C — no extra chip (BlueZ mesh)
+
+The HA host's own Bluetooth 5 adapter via `bluetooth-meshd` + the Python
+`bluetooth-mesh` library. No code here yet; the same access messages from the
+spec apply. Most fiddly of the three (provisioner/CDB handling).
+
+## Scope
+
+Standard SIG models (on/off, dimming, tunable white, blinds, sensors, scenes) are
+implemented/shown. The JUNG **vendor model** (`0x0527`) for rocker buttons, status
+LED and parameters is documented in the spec but left as a stub — it's the one
+part that needs further reverse engineering of the over-the-air opcodes.
+
+## Legal / interoperability note
+
+This code is original and implements **standard Bluetooth Mesh** plus documented
+facts about JUNG's models. It contains no JUNG or Silicon Labs source code and no
+keys. See the IP note in [../../docs/README.md](../../docs/README.md) before
+publishing. You must supply your own network keys (your data); never commit them.

--- a/tools/bt-mesh-direct/esp32/junghome_mesh_esp32.c
+++ b/tools/bt-mesh-direct/esp32/junghome_mesh_esp32.c
@@ -1,0 +1,139 @@
+/*
+ * Reference prototype: control JUNG HOME devices over Bluetooth Mesh from an
+ * ESP32 (ESP-IDF / ESP-BLE-MESH), gateway-free.
+ *
+ * This is the ESP32 counterpart to ../junghome_mesh.py. It shows the client-model
+ * SEND path for the standard SIG models JUNG uses (see ../../docs/bt-mesh-direct.md):
+ *   - Generic OnOff Client   -> switches / on-off lights / sockets
+ *   - Light Lightness Client -> dimmers
+ *   - Generic Level Client   -> blinds, and color temperature (on element+1)
+ *   - Scene Client           -> scene recall
+ *
+ * It is a *reference* sketch (won't be built in this repo). It assumes the ESP32
+ * has joined the JUNG mesh and has the AppKey bound to these client models. On
+ * ESP-BLE-MESH the usual route is to run the node as a provisioner that imports
+ * the NetKey/AppKey exported from the JUNG HOME app, or to configure them via the
+ * Config Client using the device keys. Provisioning/key import is omitted here.
+ *
+ * Build inside an ESP-IDF project that enables: Bluetooth, BLE Mesh, and the
+ * Generic/Lighting/Time-Scene client models in menuconfig. Drop this in main/.
+ */
+
+#include <string.h>
+#include "esp_log.h"
+#include "esp_ble_mesh_defs.h"
+#include "esp_ble_mesh_common_api.h"
+#include "esp_ble_mesh_generic_model_api.h"
+#include "esp_ble_mesh_lighting_model_api.h"
+#include "esp_ble_mesh_time_scene_model_api.h"
+
+#define TAG "JUNG_MESH"
+
+/* Send tuning, matching the gateway (config.json -> btmesh). */
+#define APP_IDX        0      /* AppKey index */
+#define NET_IDX        0      /* NetKey index */
+#define SEND_TTL       7
+
+/* Color temperature: JUNG maps Kelvin 2000..6000 onto int16 -32768..32767 and
+ * drives Generic Level on the CTL-temperature element (target address + 1). */
+static int16_t kelvin_to_level(int kelvin)
+{
+    if (kelvin < 2000) kelvin = 2000;
+    if (kelvin > 6000) kelvin = 6000;
+    long span = 0x7FFF - (-0x8000);
+    return (int16_t)(-0x8000 + ((long)(kelvin - 2000) * span) / (6000 - 2000));
+}
+
+static uint8_t s_tid;
+
+static esp_ble_mesh_client_common_param_t common_param(
+        uint32_t opcode, esp_ble_mesh_model_t *model, uint16_t addr)
+{
+    esp_ble_mesh_client_common_param_t c = {0};
+    c.opcode = opcode;
+    c.model = model;
+    c.ctx.net_idx = NET_IDX;
+    c.ctx.app_idx = APP_IDX;
+    c.ctx.addr = addr;            /* node unicast or group address */
+    c.ctx.send_ttl = SEND_TTL;
+    c.msg_timeout = 0;            /* use stack default */
+    return c;
+}
+
+/* --- switches / on-off lights / sockets --- */
+void jung_set_onoff(esp_ble_mesh_model_t *onoff_client, uint16_t addr, bool on)
+{
+    esp_ble_mesh_client_common_param_t c =
+        common_param(ESP_BLE_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK, onoff_client, addr);
+    esp_ble_mesh_generic_client_set_state_t set = {0};
+    set.onoff_set.op_en = false;
+    set.onoff_set.onoff = on ? 1 : 0;
+    set.onoff_set.tid = s_tid++;
+    esp_ble_mesh_generic_client_set_state(&c, &set);
+}
+
+/* --- dimmers (Light Lightness Actual, 0..0xFFFF) --- */
+void jung_set_brightness(esp_ble_mesh_model_t *lightness_client, uint16_t addr, int percent)
+{
+    if (percent < 0) percent = 0; if (percent > 100) percent = 100;
+    uint16_t level = (uint16_t)((percent * 0xFFFF) / 100);
+    esp_ble_mesh_client_common_param_t c =
+        common_param(ESP_BLE_MESH_MODEL_OP_LIGHT_LIGHTNESS_SET_UNACK, lightness_client, addr);
+    esp_ble_mesh_light_client_set_state_t set = {0};
+    set.lightness_set.op_en = false;
+    set.lightness_set.lightness = level;
+    set.lightness_set.tid = s_tid++;
+    esp_ble_mesh_light_client_set_state(&c, &set);
+}
+
+/* --- tunable white (Generic Level on element+1) --- */
+void jung_set_color_temp(esp_ble_mesh_model_t *level_client, uint16_t addr, int kelvin)
+{
+    esp_ble_mesh_client_common_param_t c =
+        common_param(ESP_BLE_MESH_MODEL_OP_GEN_LEVEL_SET_UNACK, level_client, addr + 1);
+    esp_ble_mesh_generic_client_set_state_t set = {0};
+    set.level_set.op_en = false;
+    set.level_set.level = kelvin_to_level(kelvin);
+    set.level_set.tid = s_tid++;
+    esp_ble_mesh_generic_client_set_state(&c, &set);
+}
+
+/* --- blinds (Generic Level Move: down=0x7FFF, up=0x8000(-32768), stop=0) --- */
+void jung_blinds_move(esp_ble_mesh_model_t *level_client, uint16_t addr, const char *dir)
+{
+    int16_t delta = 0;
+    if (strcmp(dir, "down") == 0) delta = 0x7FFF;
+    else if (strcmp(dir, "up") == 0) delta = (int16_t)0x8000;
+    esp_ble_mesh_client_common_param_t c =
+        common_param(ESP_BLE_MESH_MODEL_OP_GEN_MOVE_SET_UNACK, level_client, addr);
+    esp_ble_mesh_generic_client_set_state_t set = {0};
+    set.move_set.op_en = true;
+    set.move_set.delta_level = delta;
+    set.move_set.trans_time = 0xFE;   /* ~max; mirrors transition 0xFFFE intent */
+    set.move_set.tid = s_tid++;
+    esp_ble_mesh_generic_client_set_state(&c, &set);
+}
+
+/* --- scene recall (0xFFFF = broadcast, or a group address) --- */
+void jung_recall_scene(esp_ble_mesh_model_t *scene_client, uint16_t scene_number, uint16_t addr)
+{
+    esp_ble_mesh_client_common_param_t c =
+        common_param(ESP_BLE_MESH_MODEL_OP_SCENE_RECALL_UNACK, scene_client, addr);
+    esp_ble_mesh_time_scene_client_set_state_t set = {0};
+    set.scene_recall.op_en = false;
+    set.scene_recall.scene_number = scene_number;
+    set.scene_recall.tid = s_tid++;
+    esp_ble_mesh_time_scene_client_set_state(&c, &set);
+}
+
+/*
+ * Receiving state & button events: register a client callback with
+ * esp_ble_mesh_register_generic_client_callback() /
+ * _light_client_callback() / _sensor_client_callback() and read the *_STATUS
+ * messages (addr -> function via your CDB mapping).
+ *
+ * Rocker BUTTONS, status LED and parameters use the JUNG vendor model
+ * (company 0x0527) — register a vendor/custom model with
+ * esp_ble_mesh_register_custom_model_callback() and parse the 0x0527 opcodes.
+ * See ../../docs/bt-mesh-direct.md for the vendor framing.
+ */

--- a/tools/bt-mesh-direct/junghome_mesh.py
+++ b/tools/bt-mesh-direct/junghome_mesh.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Reference prototype: control JUNG HOME devices over Bluetooth Mesh, gateway-free.
+
+This mirrors what the gateway's `middleware` does, but from your own host driving
+a Silicon Labs EFR32 acting as a Bluetooth Mesh NCP over a serial port (the same
+silicon + SDK the JUNG gateway uses, so the commands map 1:1).
+
+It is a *reference* implementation grounded in the reverse-engineered protocol in
+docs/bt-mesh-direct.md — it requires real hardware to run and assumes the EFR32
+has already joined the JUNG mesh (NetKey/AppKey provisioned, the node's AppKey
+bound to the relevant client models). Provisioning/key import is out of scope
+here; do it once with Simplicity Studio's Bluetooth Mesh tooling or by importing
+the CDB exported from the JUNG HOME app.
+
+Hardware: flash an EFR32 dev kit with the Silabs "Bluetooth Mesh - NCP" example.
+Then:  pip install pybgapi  (see requirements.txt)
+
+Method names follow the Silabs BGAPI (`sl_bt.xapi` / `sl_btmesh.xapi`); exact
+signatures may shift between SDK versions — adjust to your installed SDK.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import bgapi  # pybgapi
+
+# --- protocol constants (from middleware/dist/const, see docs/bt-mesh-direct.md) ---
+
+# SIG client model ids
+MODEL_GENERIC_ONOFF_CLIENT = 0x1001
+MODEL_GENERIC_LEVEL_CLIENT = 0x1003
+MODEL_LIGHT_LIGHTNESS_CLIENT = 0x1302
+
+# MeshModelSetKind
+KIND_ONOFF = 0
+KIND_LEVEL = 2
+KIND_LEVEL_MOVE = 4
+KIND_LIGHTNESS_ACTUAL = 128
+
+# Send tuning (config.json -> btmesh)
+RETRANSMISSIONS = 3
+INTERVAL_MS = 15
+APPKEY_INDEX = 0
+
+# Color temperature: JUNG drives Generic Level on the element after the main one,
+# mapping Kelvin 2000..6000 onto int16 -0x8000..0x7FFF.
+CT_KELVIN_MIN, CT_KELVIN_MAX = 2000, 6000
+LEVEL_MIN, LEVEL_MAX = -0x8000, 0x7FFF
+
+
+def convert_range(value, in_min, in_max, out_min, out_max):
+    """Linear range conversion, matching the gateway's helper."""
+    if in_max == in_min:
+        return out_min
+    frac = (value - in_min) / (in_max - in_min)
+    return round(out_min + frac * (out_max - out_min))
+
+
+def to_u16_le(value: int) -> bytes:
+    return (value & 0xFFFF).to_bytes(2, "little")
+
+
+class JungMesh:
+    """Thin wrapper over a Silabs EFR32 BT-Mesh NCP."""
+
+    def __init__(self, port: str):
+        self.lib = bgapi.BGLib(
+            bgapi.SerialConnector(port), "sl_bt.xapi", "sl_btmesh.xapi"
+        )
+        self._tid = 0
+
+    def open(self):
+        self.lib.open()
+        # bring up the stack / confirm we talk to the NCP
+        self.lib.bt.system.get_version()
+
+    def close(self):
+        self.lib.close()
+
+    def _next_tid(self) -> int:
+        self._tid = (self._tid + 1) & 0xFF
+        return self._tid
+
+    def _generic_client_set(self, address, model_id, kind, value_bytes, transition_ms=0):
+        """sl_btmesh_cmd_generic_client_set, retransmitted like the gateway."""
+        tid = self._next_tid()
+        for i in range(RETRANSMISSIONS):
+            delay_ms = INTERVAL_MS * (RETRANSMISSIONS - 1 - i)
+            self.lib.btmesh.generic_client.set(
+                address,          # server_address
+                0,                # elem_index
+                model_id,         # model_id
+                APPKEY_INDEX,     # appkey_index
+                tid,              # tid
+                transition_ms,    # transition_ms
+                delay_ms,         # delay_ms
+                1,                # flags
+                kind,             # type (MeshModelSetKind)
+                value_bytes,      # parameters
+            )
+            if i < RETRANSMISSIONS - 1:
+                time.sleep(INTERVAL_MS / 1000)
+
+    # --- standard SIG model control ---
+
+    def set_onoff(self, address: int, on: bool):
+        self._generic_client_set(
+            address, MODEL_GENERIC_ONOFF_CLIENT, KIND_ONOFF, bytes([1 if on else 0])
+        )
+
+    def set_brightness(self, address: int, percent: int):
+        """percent 0..100 -> Light Lightness Actual uint16."""
+        value = convert_range(percent, 0, 100, 0, 0xFFFF)
+        self._generic_client_set(
+            address, MODEL_LIGHT_LIGHTNESS_CLIENT, KIND_LIGHTNESS_ACTUAL, to_u16_le(value)
+        )
+
+    def set_color_temp(self, address: int, kelvin: int):
+        """Generic Level on the CTL temperature element (address + 1)."""
+        level = convert_range(kelvin, CT_KELVIN_MIN, CT_KELVIN_MAX, LEVEL_MIN, LEVEL_MAX)
+        self._generic_client_set(
+            address + 1, MODEL_GENERIC_LEVEL_CLIENT, KIND_LEVEL, to_u16_le(level)
+        )
+
+    def blinds_move(self, address: int, direction: str):
+        """direction: 'up' | 'down' | 'stop' (Generic Level Move)."""
+        value = {"down": 0x7FFF, "up": 0x8000, "stop": 0x0000}[direction]
+        self._generic_client_set(
+            address, MODEL_GENERIC_LEVEL_CLIENT, KIND_LEVEL_MOVE, to_u16_le(value),
+            transition_ms=0xFFFE,
+        )
+
+    def recall_scene(self, scene_number: int, address: int = 0xFFFF):
+        tid = self._next_tid()
+        for i in range(RETRANSMISSIONS):
+            delay_ms = INTERVAL_MS * (RETRANSMISSIONS - 1 - i)
+            self.lib.btmesh.scene_client.recall(
+                address, 0, scene_number, APPKEY_INDEX, 1, tid, 0, delay_ms
+            )
+            if i < RETRANSMISSIONS - 1:
+                time.sleep(INTERVAL_MS / 1000)
+
+    # --- vendor model (status LED / buttons), company 0x0527 ---
+
+    def set_status_led(self, address: int, model_client: int, prop_id: int, on: bool):
+        """JUNG vendor 'Property' model via the host->NCP passthrough.
+
+        Mirrors btmesh_set_datapoint_service._sendKeyStatus (commandId 2 =
+        STATUS_LBC_PROP_SEND_ID). See docs/bt-mesh-direct.md.
+        """
+        self.lib.bt.user.message_to_target(
+            bytes([
+                2,                       # commandId STATUS_LBC_PROP_SEND_ID
+                0,                       # elementId (lo) ...
+            ])
+            # NOTE: exact field packing for user_message_to_target depends on the
+            # vendor app on the NCP; see the documented field list. Left as a
+            # starting point for the buttons/LED path.
+        )
+
+    # --- receiving state / events ---
+
+    def listen(self):
+        """Print status and button events as they arrive."""
+        for evt in self.lib.gen_events(max_time=None):
+            name = evt._str  # e.g. 'btmesh_evt_generic_client_server_status'
+            if "generic_client_server_status" in name:
+                print(f"state  addr=0x{evt.server_address:04x} model=0x{evt.model_id:04x} "
+                      f"params={bytes(evt.parameters).hex()}")
+            elif "sensor_client_status" in name:
+                print(f"sensor addr=0x{evt.server_address:04x} data={bytes(evt.sensor_data).hex()}")
+            elif "scene_client_status" in name:
+                print(f"scene  addr=0x{evt.server_address:04x} current={evt.current_scene}")
+            elif "user_message_to_host" in name:
+                print(f"vendor data={bytes(evt.message).hex()}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="JUNG HOME BT-Mesh direct control (prototype)")
+    ap.add_argument("--port", default="/dev/ttyACM0", help="EFR32 NCP serial port")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("onoff"); p.add_argument("address", type=lambda x: int(x, 0)); p.add_argument("state", choices=["on", "off"])
+    p = sub.add_parser("brightness"); p.add_argument("address", type=lambda x: int(x, 0)); p.add_argument("percent", type=int)
+    p = sub.add_parser("ct"); p.add_argument("address", type=lambda x: int(x, 0)); p.add_argument("kelvin", type=int)
+    p = sub.add_parser("scene"); p.add_argument("number", type=int)
+    sub.add_parser("listen")
+    args = ap.parse_args()
+
+    mesh = JungMesh(args.port)
+    mesh.open()
+    try:
+        if args.cmd == "onoff":
+            mesh.set_onoff(args.address, args.state == "on")
+        elif args.cmd == "brightness":
+            mesh.set_brightness(args.address, args.percent)
+        elif args.cmd == "ct":
+            mesh.set_color_temp(args.address, args.kelvin)
+        elif args.cmd == "scene":
+            mesh.recall_scene(args.number)
+        elif args.cmd == "listen":
+            mesh.listen()
+    finally:
+        mesh.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bt-mesh-direct/requirements.txt
+++ b/tools/bt-mesh-direct/requirements.txt
@@ -1,0 +1,2 @@
+# EFR32 NCP prototype (junghome_mesh.py)
+pybgapi>=1.3


### PR DESCRIPTION
Reverse-engineered gateway reference (from the microSD image):

- `docs/bt-mesh-direct.md` — controlling JUNG devices over Bluetooth Mesh without the gateway: function→SIG-model map, send/receive protocol, the 0x0527 vendor model (buttons/LED), and the keys/IV/sequence to export.
- `tools/bt-mesh-direct/` — reference prototypes for EFR32 (pybgapi) and ESP32 (ESP-BLE-MESH), plus BlueZ notes.
- `docs/matter-bridge.md` — the gateway's own Matter interface is scaffolded but not installed on current firmware; bridge from Home Assistant instead.
- `docs/README.md` — index + legal/interoperability note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)