### PR TITLE
Add release automation + HACS install docs; enable brand validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+# Cut a GitHub release when a vX.Y.Z tag is pushed. HACS installs the latest
+# release, so each tag becomes an installable version.
+#
+#   1. bump "version" in custom_components/junghome/manifest.json
+#   2. git tag vX.Y.Z && git push origin vX.Y.Z
+#
+# This workflow fails if the tag doesn't match the manifest version, to keep
+# them in sync.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify tag matches manifest version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          manifest="$(python3 -c "import json;print(json.load(open('custom_components/junghome/manifest.json'))['version'])")"
+          echo "tag=$tag manifest=$manifest"
+          if [ "$tag" != "$manifest" ]; then
+            echo "::error::Tag ($tag) does not match manifest version ($manifest)."
+            exit 1
+          fi
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,5 +32,3 @@ jobs:
         uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: integration
-          # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-          ignore: brands

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # What?
 
+[![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![GitHub release](https://img.shields.io/github/v/release/ernetas/junghome)](https://github.com/ernetas/junghome/releases)
+
 This is a custom Jung Home integration based on WebSocket communication with Jung Home Gateway. A gateway is required.
 
 Currently functional things:
@@ -17,6 +20,23 @@ All communication is via WebSockets. I've managed to reliably automate:
 - Hold
 
 Any feedback is welcome, this is my first integration with HomeAssistant.
+
+# Installation
+
+## HACS (recommended)
+
+Until this is in the HACS default store, add it as a custom repository:
+
+[![Open your Home Assistant instance and open this repository inside HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ernetas&repository=junghome&category=integration)
+
+1. HACS → ⋮ (top right) → **Custom repositories**.
+2. Repository: `https://github.com/ernetas/junghome`, Category: **Integration**. Add.
+3. Find **Jung Home** in HACS, **Download** the latest release, then restart Home Assistant.
+4. Settings → Devices & Services → **Add Integration** → Jung Home (see [Setup](#setup)).
+
+## Manual
+
+Copy `custom_components/junghome/` into your Home Assistant `config/custom_components/` directory and restart.
 
 # Setup
 
@@ -39,7 +59,8 @@ removed in the Jung Home app afterwards are picked up automatically.
 # Gateway internals (for contributors)
 
 The local gateway API (REST + WebSocket), its registration flow, and the
-device-mesh architecture are documented in **[docs/](docs/README.md)**.
+device-mesh architecture are documented in **[docs/](docs/README.md)**. Release
+and HACS-publishing steps are in **[docs/publishing.md](docs/publishing.md)**.
 
 # TODO
 - Make setup easier.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,63 @@
+# Publishing & releasing
+
+How this integration is distributed through HACS, and how to get it into the
+HACS **default store**.
+
+## Cutting a release
+
+HACS installs the latest GitHub **release**. With no releases, it falls back to
+the default branch and shows a commit SHA instead of a version — so always tag.
+
+1. Bump `"version"` in `custom_components/junghome/manifest.json`.
+2. Tag and push:
+   ```sh
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+3. `.github/workflows/release.yml` then creates the GitHub release automatically
+   (it fails if the tag doesn't match the manifest version, to keep them in sync).
+
+The tag name (minus the leading `v`) is the version HACS offers.
+
+## Custom repository (works today)
+
+Users add `https://github.com/ernetas/junghome` as a HACS custom repository,
+category **Integration**. See the README. Nothing else required.
+
+## Getting into the HACS default store
+
+So users find "Jung Home" without adding a custom repo. Status:
+
+Done:
+- ✅ Public repo, MIT license, `custom_components/junghome/` layout
+- ✅ `manifest.json` (`documentation`, `issue_tracker`, `codeowners`, `version`, `iot_class`)
+- ✅ `hacs.json` with `name`
+- ✅ Repo **description** and **topics** set
+- ✅ A GitHub **release** (`v1.0.0`)
+- ✅ **Brand icons** merged into home-assistant/brands and live at
+  <https://brands.home-assistant.io/junghome/icon.png> (the `ignore: brands` line
+  has been removed from `.github/workflows/validate.yml`)
+
+Remaining, in order:
+
+### 1. Make validation green
+
+The `Validate` workflow runs hassfest + the HACS action on every push/PR to
+`main`. Confirm both pass now that brands are live and the `ignore` is removed.
+
+### 2. PR to hacs/default
+
+Add the repo to the [hacs/default](https://github.com/hacs/default) list:
+
+```sh
+gh repo fork hacs/default --clone
+cd default
+# add "ernetas/junghome" to the `integration` file (JSON array), keeping it sorted
+git checkout -b add-junghome
+git commit -am "Add ernetas/junghome"
+git push -u origin add-junghome
+gh pr create --repo hacs/default --fill
+```
+
+The HACS bot validates the repo on the PR; brands must already be merged or it
+fails. After the PR is merged, "Jung Home" appears in the default store.


### PR DESCRIPTION
- `.github/workflows/release.yml`: auto-create a GitHub release when a `vX.Y.Z` tag is pushed (fails if the tag and manifest version disagree).
- README: HACS install instructions + badges (custom-repo + My Home Assistant button).
- `docs/publishing.md`: release process and the HACS default-store checklist (brands + hacs/default PR steps).
- `validate.yml`: removed `ignore: brands` now that the brand icons are live at https://brands.home-assistant.io/junghome/icon.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)