### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Cut a release off the now-green `main` (brands live, `ignore: brands` removed, Lint passing) for the HACS default-store submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)