### PR TITLE
Blueprint: select multiple events per button; 1.1.0b2

### DIFF
--- a/blueprints/automation/junghome/button_gestures.yaml
+++ b/blueprints/automation/junghome/button_gestures.yaml
@@ -9,21 +9,27 @@ blueprint:
     within the hold time is a *hold*; a press, release and second press within
     the double-click window is a *double*; anything else is a *single*.
 
-    Create one automation per button side. Pick the `event.*` entity for the side
-    you want (e.g. `event.living_room_r1_b_up_request_event`) and fill in the
-    actions you want for each gesture — leave a gesture empty to ignore it.
+    Pick the `event.*` entity (or entities) for one physical button and fill in
+    the actions you want for each gesture — leave a gesture empty to ignore it.
+    JUNG sometimes exposes a button as separate `up_request` and `down_request`
+    events; select **all** the events that belong to the same button so any of
+    them drives the same gesture.
   domain: automation
   author: junghome
   source_url: https://github.com/ernetas/junghome/blob/main/blueprints/automation/junghome/button_gestures.yaml
   input:
     button:
-      name: Button (event entity)
+      name: Button (event entities)
       description: >
-        The JUNG HOME event entity for the button side to watch. Find it under
-        Developer Tools → States, filtered by `event.` — its `event_type`
-        attribute flips between `pressed` and `depressed` when you press it.
+        The JUNG HOME event entity (or entities) for one physical button. JUNG
+        sometimes splits a single button into `up_request` and `down_request`
+        events — select all of them so any one driving a press/release feeds the
+        same gesture logic. Find them under Developer Tools → States, filtered by
+        `event.`; the `event_type` attribute flips between `pressed` and
+        `depressed` when you press the button.
       selector:
         entity:
+          multiple: true
           filter:
             - domain: event
               integration: junghome

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0b1"
+  "version": "1.1.0b2"
 }

--- a/docs/example-button-automation.md
+++ b/docs/example-button-automation.md
@@ -216,7 +216,10 @@ button by **filling in a form** instead of editing YAML:
 
 It exposes:
 
-- **Button (event entity)** — the `event.*` entity for the side to watch.
+- **Button (event entities)** — the `event.*` entity (or entities) for one
+  physical button. JUNG sometimes splits a button into separate `up_request` and
+  `down_request` events; select **all** of them so whichever one fires drives the
+  same gesture.
 - **Hold time** and **Double-click window** — the two timing thresholds.
 - **Single / Double / Hold action** — what to run for each gesture; leave any of
   them empty to ignore that gesture.
@@ -255,5 +258,9 @@ Either:
   sure your device actually sends a separate `depressed` (release) event — hold
   detection depends on press and release being reported separately, which JUNG
   rockers do.
-```
+- **One press registers as a double-click.** This happens if a single physical
+  press fires *both* the `up_request` and `down_request` events at once. Watch
+  both in *Developer Tools → States*: if they always fire together, select only
+  one of them in the blueprint; if they fire interchangeably (sometimes up,
+  sometimes down), select both.
 


### PR DESCRIPTION
Follow-up to the button-gesture blueprint beta.

JUNG sometimes splits a single physical button into separate `up_request` and `down_request` events, so the blueprint's single-entity picker was too restrictive. The button input now accepts **multiple** event entities — select all events belonging to one button and any of them drives the same single/double/hold gesture (the state trigger and `wait_for_trigger` steps already accept a list of entity IDs unchanged).

- `button_gestures.yaml`: `selector.entity.multiple: true`; updated names/description.
- docs: note multi-event selection + a troubleshooting entry for presses that look like double-clicks when both events fire together.
- Bump manifest to `1.1.0b2` → cut as a HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)