### PR TITLE
Fix double-click for alternating up/down events; 1.1.0b3

### DIFF
--- a/blueprints/automation/junghome/button_gestures.yaml
+++ b/blueprints/automation/junghome/button_gestures.yaml
@@ -12,8 +12,8 @@ blueprint:
     Pick the `event.*` entity (or entities) for one physical button and fill in
     the actions you want for each gesture — leave a gesture empty to ignore it.
     JUNG sometimes exposes a button as separate `up_request` and `down_request`
-    events; select **all** the events that belong to the same button so any of
-    them drives the same gesture.
+    events, and may alternate between them on consecutive presses; select **all**
+    the events that belong to the same button so any of them drives the gesture.
   domain: automation
   author: junghome
   source_url: https://github.com/ernetas/junghome/blob/main/blueprints/automation/junghome/button_gestures.yaml
@@ -23,10 +23,10 @@ blueprint:
       description: >
         The JUNG HOME event entity (or entities) for one physical button. JUNG
         sometimes splits a single button into `up_request` and `down_request`
-        events — select all of them so any one driving a press/release feeds the
-        same gesture logic. Find them under Developer Tools → States, filtered by
-        `event.`; the `event_type` attribute flips between `pressed` and
-        `depressed` when you press the button.
+        events and alternates between them — select all of them so any one
+        driving a press/release feeds the same gesture logic. Find them under
+        Developer Tools → States, filtered by `event.`; the `event_type`
+        attribute flips between `pressed` and `depressed` when you press.
       selector:
         entity:
           multiple: true
@@ -54,7 +54,7 @@ blueprint:
       selector:
         number:
           min: 100
-          max: 1000
+          max: 1500
           step: 50
           unit_of_measurement: milliseconds
           mode: box
@@ -77,73 +77,66 @@ blueprint:
       selector:
         action: {}
 
-# Ignore re-triggers while we are still measuring a gesture.
+# Ignore re-triggers while we are still measuring a gesture; the second press of
+# a double-click is caught by wait_for_trigger below, not by re-triggering.
 mode: single
 max_exceeded: silent
 
+# Trigger on ANY change of the selected event entities, then keep only press
+# edges. We deliberately do NOT use `attribute: event_type` / `to: pressed`:
+# an event entity's state is a timestamp, so a `to:`-style trigger silently
+# misses repeated `pressed` event_types (e.g. JUNG alternating up/down), which
+# is what made double-clicks register as singles.
 triggers:
   - trigger: state
     entity_id: !input button
-    attribute: event_type
-    to: pressed
+
+conditions:
+  - condition: template
+    value_template: >
+      {{ trigger.to_state is not none
+         and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 
 actions:
-  # 1) Wait for the release. If it never comes in time → HOLD.
+  # 1) Wait for this press to end (the next state change is its release). If no
+  #    change arrives within the hold time, the button is still down → HOLD.
   - wait_for_trigger:
       - trigger: state
         entity_id: !input button
-        attribute: event_type
-        to: depressed
     timeout:
       seconds: !input hold_time
     continue_on_timeout: true
 
   - choose:
-      # ---- HOLD: release did not arrive within the hold time ----
+      # ---- HOLD: nothing happened within the hold time → still held ----
       - conditions:
           - "{{ wait.trigger is none }}"
         sequence:
           - choose: []
             default: !input hold_action
-          # Swallow the eventual release so a long hold isn't mistaken for the
-          # start of a new gesture.
-          - wait_for_trigger:
-              - trigger: state
-                entity_id: !input button
-                attribute: event_type
-                to: depressed
-            timeout:
-              seconds: 10
-            continue_on_timeout: true
 
     # ---- Released in time: decide SINGLE vs DOUBLE ----
     default:
-      # 2) Wait briefly for a second press.
+      # 2) Wait for the next event. A fresh `pressed` within the window is a
+      #    second click → DOUBLE; otherwise (timeout, or a stray release) it was
+      #    a SINGLE. This catches the second press even when JUNG reports it on a
+      #    different (up/down) entity than the first.
       - wait_for_trigger:
           - trigger: state
             entity_id: !input button
-            attribute: event_type
-            to: pressed
         timeout:
           milliseconds: !input double_click_window
         continue_on_timeout: true
       - choose:
-          # No second press → SINGLE
           - conditions:
-              - "{{ wait.trigger is none }}"
+              - >
+                {{ wait.trigger is not none
+                   and wait.trigger.to_state is not none
+                   and wait.trigger.to_state.attributes.get('event_type') == 'pressed' }}
             sequence:
               - choose: []
-                default: !input single_action
-        # Second press arrived → DOUBLE
+                default: !input double_action
+        # No second press in the window → SINGLE
         default:
           - choose: []
-            default: !input double_action
-          # Swallow the release of the second press.
-          - wait_for_trigger:
-              - trigger: state
-                entity_id: !input button
-                attribute: event_type
-                to: depressed
-            timeout:
-              seconds: !input hold_time
-            continue_on_timeout: true
+            default: !input single_action

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0b2"
+  "version": "1.1.0b3"
 }

--- a/docs/example-button-automation.md
+++ b/docs/example-button-automation.md
@@ -58,18 +58,23 @@ mode: single
 triggers:
   - trigger: state
     entity_id: event.living_room_r1_b_up_request_event
-    attribute: event_type
-    to: pressed
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
   - action: light.toggle
     target:
       entity_id: light.living_room_lamp
 ```
 
-Why `attribute: event_type` / `to: pressed`? An event entity's *state* is just a
-timestamp that changes on **both** press and release. Triggering on the
-`event_type` attribute becoming `pressed` makes the automation fire **once per
-press** (and never on release).
+Why trigger on *any* state change and filter with a condition, instead of
+`attribute: event_type` / `to: pressed`? An event entity's *state* is just a
+timestamp that changes on **both** press and release, and a `to:`-style trigger
+only fires when the attribute *changes value* — so it silently misses a repeated
+`pressed` (which happens when JUNG reports the same button twice, or alternates
+between `up_request` and `down_request`). Triggering on the state change and
+checking `event_type == 'pressed'` in a condition fires reliably **once per
+press** and never on release.
 
 > Want it to react to **either** side of the rocker? List both entities under
 > `entity_id:`.
@@ -87,8 +92,9 @@ mode: single
 triggers:
   - trigger: state
     entity_id: event.living_room_r1_b_up_request_event
-    attribute: event_type
-    to: pressed
+conditions:
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
   - if:
       - condition: state
@@ -118,73 +124,71 @@ automation, with no helper entities**, using `wait_for_trigger`:
 - **Double** — pressed, released, then pressed again within 0.4 s.
 - **Single** — pressed and released, with no second press.
 
+List **all** of the button's events under `entity_id:` (e.g. both the
+`up_request` and `down_request` events) — JUNG often alternates between them, and
+this automation treats any of them as the same button. We trigger on *any* state
+change and filter with a condition rather than `attribute: event_type` /
+`to: pressed`, because the `to:` form silently misses repeated/alternating
+`pressed` events (this is exactly what makes double-clicks misfire as singles).
+
 ```yaml
 alias: R1 B - single / double / hold
 mode: single  # important: ignore re-triggers while we're measuring a gesture
 triggers:
   - trigger: state
-    entity_id: event.living_room_r1_b_up_request_event
-    attribute: event_type
-    to: pressed
+    entity_id:
+      - event.living_room_r1_b_up_request_event
+      - event.living_room_r1_b_down_request_event
+conditions:
+  # Only start on a press edge; ignore release ('depressed') state changes.
+  - condition: template
+    value_template: "{{ trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
-  # 1) Wait up to 2 s for the release. If it never comes → it's a HOLD.
+  # 1) Wait for the next state change (the press's release). If nothing happens
+  #    within 2 s, the button is still held → HOLD.
   - wait_for_trigger:
       - trigger: state
-        entity_id: event.living_room_r1_b_up_request_event
-        attribute: event_type
-        to: depressed
+        entity_id:
+          - event.living_room_r1_b_up_request_event
+          - event.living_room_r1_b_down_request_event
     timeout: "00:00:02"
     continue_on_timeout: true
 
   - choose:
-      # ---- HOLD: the release didn't arrive in time ----
+      # ---- HOLD: nothing arrived in time → still held ----
       - conditions:
           - "{{ wait.trigger is none }}"
         sequence:
           - action: notify.pushover
             data:
               message: R1 B held (2s)
-          # Optional: wait for the eventual release so a long hold doesn't
-          # immediately look like the start of a new gesture.
-          - wait_for_trigger:
-              - trigger: state
-                entity_id: event.living_room_r1_b_up_request_event
-                attribute: event_type
-                to: depressed
-            timeout: "00:00:10"
-            continue_on_timeout: true
 
     # ---- Released within 2 s: decide SINGLE vs DOUBLE ----
     default:
-      # 2) Wait briefly for a second press.
+      # 2) Wait for the next event. A fresh 'pressed' within the window is a
+      #    second click → DOUBLE; otherwise → SINGLE.
       - wait_for_trigger:
           - trigger: state
-            entity_id: event.living_room_r1_b_up_request_event
-            attribute: event_type
-            to: pressed
+            entity_id:
+              - event.living_room_r1_b_up_request_event
+              - event.living_room_r1_b_down_request_event
         timeout: "00:00:00.4"
         continue_on_timeout: true
       - choose:
-          # No second press → SINGLE
+          # A second press arrived → DOUBLE
           - conditions:
-              - "{{ wait.trigger is none }}"
+              - >
+                {{ wait.trigger is not none
+                   and wait.trigger.to_state.attributes.event_type == 'pressed' }}
             sequence:
               - action: notify.pushover
                 data:
-                  message: R1 B single click
-        # A second press arrived → DOUBLE
+                  message: R1 B double click
+        # No second press in the window → SINGLE
         default:
           - action: notify.pushover
             data:
-              message: R1 B double click
-          # Consume the release of that second press.
-          - wait_for_trigger:
-              - trigger: state
-                entity_id: event.living_room_r1_b_up_request_event
-                attribute: event_type
-                to: depressed
-            timeout: "00:00:02"
-            continue_on_timeout: true
+              message: R1 B single click
 ```
 
 ### Tuning


### PR DESCRIPTION
Fixes double-click detection in the button-gesture blueprint when JUNG alternates a button between `up_request` and `down_request` events.

## Root cause
The triggers used `attribute: event_type` + `to: pressed` / `to: depressed`. An event entity's *state* is a timestamp, so a `to:`-style trigger only fires when the attribute **changes value** — it silently drops a repeated `pressed`. With JUNG alternating up/down, the second click frequently wasn't seen, so double-clicks fell through to **single**.

## Fix
Trigger on **any** state change of the selected entities and filter press edges with a template condition (`trigger.to_state.attributes.event_type == 'pressed'`); detect the second press the same way. This is the pattern the original working "edge capture" automation used.

- `button_gestures.yaml`: rewritten detection (no `to:`/attribute triggers); widened the double-click window max to 1500 ms.
- docs: Recipes 1–3 updated to the same robust trigger pattern.
- Bump manifest to `1.1.0b3` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)