### PR TITLE
Fix 'trigger is undefined' in button blueprint; 1.1.0b4

### DIFF
--- a/blueprints/automation/junghome/button_gestures.yaml
+++ b/blueprints/automation/junghome/button_gestures.yaml
@@ -94,7 +94,7 @@ triggers:
 conditions:
   - condition: template
     value_template: >
-      {{ trigger.to_state is not none
+      {{ trigger is defined and trigger.to_state is not none
          and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 
 actions:

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0b3"
+  "version": "1.1.0b4"
 }

--- a/docs/example-button-automation.md
+++ b/docs/example-button-automation.md
@@ -60,7 +60,7 @@ triggers:
     entity_id: event.living_room_r1_b_up_request_event
 conditions:
   - condition: template
-    value_template: "{{ trigger.to_state.attributes.event_type == 'pressed' }}"
+    value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
   - action: light.toggle
     target:
@@ -75,6 +75,10 @@ only fires when the attribute *changes value* — so it silently misses a repeat
 between `up_request` and `down_request`). Triggering on the state change and
 checking `event_type == 'pressed'` in a condition fires reliably **once per
 press** and never on release.
+
+The `trigger is defined` guard keeps Home Assistant from logging a
+*"'trigger' is undefined"* warning when it renders the condition outside a
+trigger context (e.g. when you save the automation or run it manually).
 
 > Want it to react to **either** side of the rocker? List both entities under
 > `entity_id:`.
@@ -94,7 +98,7 @@ triggers:
     entity_id: event.living_room_r1_b_up_request_event
 conditions:
   - condition: template
-    value_template: "{{ trigger.to_state.attributes.event_type == 'pressed' }}"
+    value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
   - if:
       - condition: state
@@ -142,7 +146,7 @@ triggers:
 conditions:
   # Only start on a press edge; ignore release ('depressed') state changes.
   - condition: template
-    value_template: "{{ trigger.to_state.attributes.event_type == 'pressed' }}"
+    value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
   # 1) Wait for the next state change (the press's release). If nothing happens
   #    within 2 s, the button is still held → HOLD.


### PR DESCRIPTION
The press-edge condition referenced `trigger.to_state` directly. Home Assistant logs **"'trigger' is undefined"** when it renders that condition outside a trigger context (saving the automation, or running it manually). Guard the template with `trigger is defined`; at real trigger-time it's defined, so behaviour is unchanged.

- `button_gestures.yaml`: condition now `trigger is defined and trigger.to_state is not none and ...`.
- docs: Recipes 1–3 get the same guard, plus a one-line explanation.
- Bump manifest to `1.1.0b4` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)