### PR TITLE
Fix double-click detection (from real logs) + clean event entity names; 1.1.0b5

### DIFF
--- a/blueprints/automation/junghome/button_gestures.yaml
+++ b/blueprints/automation/junghome/button_gestures.yaml
@@ -98,14 +98,24 @@ conditions:
          and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 
 actions:
-  # 1) Wait for this press to end (the next state change is its release). If no
-  #    change arrives within the hold time, the button is still down → HOLD.
+  # First press seen. Wait up to the hold time for the NEXT event of any kind.
+  # JUNG alternates a button between its up/down events and can report the second
+  # press *before* the first release, so we react to whatever comes next rather
+  # than assuming a release:
+  #   - nothing within hold_time  → still held              → HOLD
+  #   - another 'pressed'         → a second click          → DOUBLE
+  #   - a 'depressed' (release)   → maybe single / slow double → check below
   - wait_for_trigger:
       - trigger: state
         entity_id: !input button
     timeout:
       seconds: !input hold_time
     continue_on_timeout: true
+  - variables:
+      evt: >-
+        {{ wait.trigger.to_state.attributes.get('event_type')
+           if (wait.trigger is not none and wait.trigger.to_state is not none)
+           else none }}
 
   - choose:
       # ---- HOLD: nothing happened within the hold time → still held ----
@@ -115,12 +125,18 @@ actions:
           - choose: []
             default: !input hold_action
 
-    # ---- Released in time: decide SINGLE vs DOUBLE ----
+      # ---- DOUBLE: a second press arrived before the first released ----
+      - conditions:
+          - "{{ evt == 'pressed' }}"
+        sequence:
+          - choose: []
+            default: !input double_action
+
+    # ---- The first press was released: SINGLE, or a slower double ----
     default:
-      # 2) Wait for the next event. A fresh `pressed` within the window is a
-      #    second click → DOUBLE; otherwise (timeout, or a stray release) it was
-      #    a SINGLE. This catches the second press even when JUNG reports it on a
-      #    different (up/down) entity than the first.
+      # Wait once more for a second press within the double-click window. This
+      # catches double-clicks where the first release lands before the second
+      # press.
       - wait_for_trigger:
           - trigger: state
             entity_id: !input button

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -11,6 +11,16 @@ from .const import DOMAIN, device_slug, stable_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Short, human-readable names per rocker datapoint type. With
+# `_attr_has_entity_name = True`, Home Assistant prepends the device name, so the
+# label is no longer baked into the entity name (which previously produced
+# duplicated entity_ids like `event.<label>_<label>_up_request_event`).
+_EVENT_NAMES = {
+    "up_request": "Up",
+    "down_request": "Down",
+    "trigger_request": "Press",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
@@ -52,13 +62,15 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
     """Event entity for Jung Home button presses."""
 
     _attr_event_types = ["pressed", "depressed"]
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, device, datapoint):
         """Initialize the event entity."""
         super().__init__(coordinator)
         self._device = device
         self._datapoint = datapoint
-        self._attr_name = f"{device.get('label', 'Jung Button')}_{datapoint.get('type', 'Unknown')}_event"
+        dp_type = datapoint.get("type", "Unknown")
+        self._attr_name = _EVENT_NAMES.get(dp_type, dp_type)
         self._attr_unique_id = stable_unique_id(device, datapoint, "event")
         self._attr_icon = "mdi:gesture-tap-button"
         self._attr_available = True

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0b4"
+  "version": "1.1.0b5"
 }

--- a/docs/example-button-automation.md
+++ b/docs/example-button-automation.md
@@ -124,16 +124,23 @@ If you want **one physical button to do three different things** depending on ho
 it's pressed, you have to measure timing yourself. The whole thing fits in **one
 automation, with no helper entities**, using `wait_for_trigger`:
 
-- **Hold** — pressed and *not released* within 2 s.
-- **Double** — pressed, released, then pressed again within 0.4 s.
+- **Hold** — pressed and *nothing else happens* within 2 s (still held).
+- **Double** — a second press arrives within ~0.4 s (before *or* after the first
+  release).
 - **Single** — pressed and released, with no second press.
 
 List **all** of the button's events under `entity_id:` (e.g. both the
-`up_request` and `down_request` events) — JUNG often alternates between them, and
-this automation treats any of them as the same button. We trigger on *any* state
-change and filter with a condition rather than `attribute: event_type` /
-`to: pressed`, because the `to:` form silently misses repeated/alternating
-`pressed` events (this is exactly what makes double-clicks misfire as singles).
+`up_request` and `down_request` events) — JUNG alternates between them on
+consecutive presses, and this automation treats any of them as the same button.
+We trigger on *any* state change and filter with a condition rather than
+`attribute: event_type` / `to: pressed`, because the `to:` form silently misses
+repeated/alternating `pressed` events.
+
+The key detail (confirmed from real device logs): on a double-click JUNG can
+report the **second press before the first release**, e.g.
+`DOWN pressed → UP pressed → DOWN depressed → UP depressed`. So instead of
+assuming "press, then release, then maybe a second press", we just wait for the
+*next event of any kind* and branch on it.
 
 ```yaml
 alias: R1 B - single / double / hold
@@ -148,8 +155,10 @@ conditions:
   - condition: template
     value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
 actions:
-  # 1) Wait for the next state change (the press's release). If nothing happens
-  #    within 2 s, the button is still held → HOLD.
+  # Wait up to 2 s for the NEXT event of any kind:
+  #   nothing      → still held        → HOLD
+  #   another press → second click      → DOUBLE
+  #   a release     → single/slow double → checked below
   - wait_for_trigger:
       - trigger: state
         entity_id:
@@ -157,6 +166,10 @@ actions:
           - event.living_room_r1_b_down_request_event
     timeout: "00:00:02"
     continue_on_timeout: true
+  - variables:
+      evt: >-
+        {{ wait.trigger.to_state.attributes.event_type
+           if wait.trigger is not none else none }}
 
   - choose:
       # ---- HOLD: nothing arrived in time → still held ----
@@ -167,10 +180,17 @@ actions:
             data:
               message: R1 B held (2s)
 
-    # ---- Released within 2 s: decide SINGLE vs DOUBLE ----
+      # ---- DOUBLE: a second press came before the first release ----
+      - conditions:
+          - "{{ evt == 'pressed' }}"
+        sequence:
+          - action: notify.pushover
+            data:
+              message: R1 B double click
+
+    # ---- First press released: SINGLE, or a slower double ----
     default:
-      # 2) Wait for the next event. A fresh 'pressed' within the window is a
-      #    second click → DOUBLE; otherwise → SINGLE.
+      # Wait once more for a second press within the double-click window.
       - wait_for_trigger:
           - trigger: state
             entity_id:
@@ -266,9 +286,40 @@ Either:
   sure your device actually sends a separate `depressed` (release) event — hold
   detection depends on press and release being reported separately, which JUNG
   rockers do.
-- **One press registers as a double-click.** This happens if a single physical
-  press fires *both* the `up_request` and `down_request` events at once. Watch
-  both in *Developer Tools → States*: if they always fire together, select only
-  one of them in the blueprint; if they fire interchangeably (sometimes up,
-  sometimes down), select both.
+- **Double-clicks register as single (or vice-versa).** Make sure you selected
+  **all** of the button's events (both `up_request` and `down_request`) — JUNG
+  alternates between them, so with only one selected, every other click is
+  invisible. If genuine double-clicks are still missed, widen the **double-click
+  window**; if singles are seen as doubles, shorten it. Use the debug logger
+  below to see your actual timing.
+
+### Debug logger — capture the raw event stream
+
+To see exactly what your button emits (and the timing between events), add this
+**automation** — not a Developer Tools → Template snippet; `trigger` only exists
+inside an automation. Replace the entity IDs with your own:
+
+```yaml
+alias: JUNG button debug logger
+mode: queued
+max: 100
+triggers:
+  - trigger: state
+    entity_id:
+      - event.living_room_r1_b_up_request_event
+      - event.living_room_r1_b_down_request_event
+actions:
+  - action: system_log.write
+    data:
+      level: warning
+      logger: jung_button_debug
+      message: >-
+        {{ trigger.entity_id }} = {{ trigger.to_state.attributes.event_type }}
+        @ {{ trigger.to_state.last_changed.timestamp() | round(3) }}
+```
+
+Do one single-click, one double-click and one hold, then read the lines from the
+Home Assistant log (`grep jung_button_debug` in `home-assistant.log`). The
+`@ <epoch>` timestamps let you measure the gaps and tune the hold time and
+double-click window.
 


### PR DESCRIPTION
## Double-click fix (functional)
Real device logs revealed two things the previous logic didn't handle:
1. JUNG **alternates** a button between its `up_request` and `down_request` events on consecutive presses.
2. On a double-click it can report the **second press before the first release**: `DOWN pressed → UP pressed → DOWN depressed → UP depressed`.

The old "wait for release, then look for a second press" flow saw a *press* where it expected a *release* and fell through to **single** — the reported symptom.

Reworked the blueprint as a state machine: after the first press, wait up to `hold_time` for the **next event of any kind** —
- nothing → **HOLD**
- another press → **DOUBLE**
- a release → wait once more within the double-click window for a second press (slow double), else **SINGLE**.

Verified against the captured single/double/hold traces (all classify correctly). Recipe 3 in the docs gets the same logic, plus a permanent debug-logger snippet.

## Event entity naming (cosmetic)
Event entities baked the device label into their own name while also sitting on a device named with that label → duplicated ids like `event.<label>_<label>_up_request_event`. Set `_attr_has_entity_name = True` with short names (Up / Down / Press) so HA composes `<device> <name>` once.

`unique_id` is unchanged, so **existing** entities keep their (sticky) id; **new** installs get clean ids like `event.<label>_up`. Existing users who want the clean id can delete the two event entities and let them re-create.

Bump manifest to `1.1.0b5` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)