### PR TITLE
Cross-platform entity naming (has_entity_name); 1.1.0b6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,15 @@ JUNG HOME Gateway over its REST API and WebSocket.
   - `const.py` — `DOMAIN` and the stable-ID helpers (`device_slug`,
     `datapoint_suffix`, `stable_unique_id`).
   - `light.py`, `switch.py`, `sensor.py`, `event.py` — platforms (each does live
-    discovery of devices added at runtime).
-- `docs/` — **reverse-engineered gateway reference** (see below).
+    discovery of devices added at runtime). `event.py` exposes RockerSwitch
+    buttons; the gateway only reports raw `pressed` / `depressed` edges (no
+    native single/double/hold) and alternates a button between its `up_request`
+    and `down_request` events on consecutive presses.
+- `blueprints/automation/junghome/button_gestures.yaml` — shipped HA blueprint
+  deriving single/double/hold from those raw edges. Users import it by URL; it is
+  **not** distributed by HACS (HACS only installs `custom_components/`).
+- `docs/` — **reverse-engineered gateway reference** plus
+  `docs/example-button-automation.md` (user-facing button-automation guide).
 - `config/`, `docker-compose.yml`, `scripts/` — local test harness.
 - `disk_dump/` — gateway microSD image, **gitignored** (contains tokens + mesh
   keys; never commit it).
@@ -42,6 +49,12 @@ When working on anything that touches the gateway protocol, consult
   updates, so entity `unique_id`s and device identifiers are derived from the
   device **label** + datapoint **suffix** (`stable_unique_id`), never the raw id.
   Don't reintroduce id-based identifiers.
+- **Entity naming.** Entities set `_attr_has_entity_name = True` and a short
+  `_attr_name` (or `None` for a device's main feature, e.g. light/socket). The
+  **device** carries the label; never bake the label into the entity name — doing
+  so makes Home Assistant compose the label twice (the old
+  `event.<label>_<label>_..._event` bug). Naming changes only affect new entities;
+  existing `entity_id`s are sticky.
 - **Registration.** Tokens are obtained via `POST /api/junghome/register`
   (`{"user_name": ...}`), which blocks up to 180 s until the user approves the
   request in the JUNG HOME app (Settings → Gateway → Access Permissions → Open

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -60,6 +60,12 @@ async def async_setup_entry(
 class JungHomeLight(CoordinatorEntity, LightEntity):
     """Representation of a Jung Home light."""
 
+    # The light is the device's main feature, so it adopts the device name. With
+    # has_entity_name the entity_id is `light.<device>` instead of the old
+    # `light.<device>_<device>` (label was previously baked into the name too).
+    _attr_has_entity_name = True
+    _attr_name = None
+
     def __init__(self, coordinator, device, datapoint):
         """Initialize the light."""
         super().__init__(coordinator)
@@ -113,11 +119,6 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         else:
             self._brightness = None
             self._color_temp = None
-
-    @property
-    def name(self):
-        """Return the name of the light."""
-        return self._name
 
     @property
     def unique_id(self):

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0b5"
+  "version": "1.1.0b6"
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -58,12 +58,18 @@ async def async_setup_entry(
 class JungHomeQuantity(CoordinatorEntity, SensorEntity):
     """Representation of a Jung Home quantity."""
 
+    # Secondary entity on the device; HA prepends the device name, so the
+    # entity_id becomes `sensor.<device>_<quantity>` (the label is no longer
+    # baked into the entity name).
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator, device, datapoint, label, unit):
         """Initialize the quantity."""
         super().__init__(coordinator)
         self._device = device
         self._datapoint = datapoint
-        self._name = f"{device.get('label', 'Jung Device')} {label}"
+        self._attr_name = label
+        self._name = f"{device.get('label', 'Jung Device')} {label}"  # for logging
         # Firmware-stable id derived from the label, not the volatile device id.
         self._unique_id = stable_unique_id(
             device, datapoint, label.replace(" ", "_").lower()
@@ -73,8 +79,8 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self):
-        """Return the name of the quantity."""
-        return self._name
+        """Return the entity name (the measured quantity; HA adds the device)."""
+        return self._attr_name
 
     @property
     def unique_id(self):

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -46,6 +46,11 @@ async def async_setup_entry(
 class JungHomeSocket(CoordinatorEntity, SwitchEntity):
     """Representation of a Jung Home socket."""
 
+    # The socket is the device's main feature, so it adopts the device name
+    # (entity_id `switch.<device>`, not the old `switch.<device>_<device>`).
+    _attr_has_entity_name = True
+    _attr_name = None
+
     def __init__(self, coordinator, device, datapoint):
         """Initialize the socket."""
         super().__init__(coordinator)
@@ -55,11 +60,6 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
         # Firmware-stable id derived from the label, not the volatile device id.
         self._unique_id = stable_unique_id(device, datapoint)
         self._is_on = self._get_state_from_datapoint(datapoint)
-
-    @property
-    def name(self):
-        """Return the name of the socket."""
-        return self._name
 
     @property
     def unique_id(self):
@@ -164,11 +164,15 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
 class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
     """Representation of a Jung Home status LED as a switch entity."""
 
+    # Secondary entity on the rocker device; HA prepends the device name, so the
+    # entity_id becomes `switch.<device>_status_led`.
+    _attr_has_entity_name = True
+    _attr_name = "Status LED"
+
     def __init__(self, coordinator, device, datapoint):
         super().__init__(coordinator)
         self._device = device
         self._datapoint = datapoint
-        self._attr_name = f"{device.get('label', 'Jung Status LED')}_{datapoint.get('type', 'Unknown')}"
         self._attr_unique_id = stable_unique_id(device, datapoint, "switch")
         self._attr_available = coordinator.last_update_success
         self._attr_is_on = self._get_state_from_datapoint(datapoint)


### PR DESCRIPTION
Extends the `event`-entity naming fix (b5) to **light, switch and sensor**, so the device label is no longer baked into entity names — which made Home Assistant compose it twice (e.g. `light.<label>_<label>`).

- **light / socket** — the device's main feature, so `_attr_name = None`; the entity adopts the device name → `light.<device>` / `switch.<device>`.
- **status LED switch** — `_attr_name = "Status LED"` → `switch.<device>_status_led`.
- **sensor** — `_attr_name = <quantity>` → `sensor.<device>_<quantity>`.

`unique_id` is unchanged, so **existing** entity_ids stay (sticky) and only **new** installs get clean ids. No automatic entity_id rename — that would break automations referencing the current ids (HA-idiomatic: fix naming for new entities, leave existing).

Also documents the naming convention + button/blueprint behaviour in `CLAUDE.md`. Bump manifest to `1.1.0b6` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)