### PR TITLE
Release 1.1.0 (stable) + align hacs.json name

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0b6"
+  "version": "1.1.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Jung HOME",
+    "name": "Jung Home",
     "homeassistant": "2025.12.4",
     "hacs": "2.0.5"
 }


### PR DESCRIPTION
Promotes the `1.1.0` line from beta to a **stable** release — a plain `vX.Y.Z` tag is published as a normal (non-pre-release) release, so it reaches all HACS users.

## What 1.1.0 ships (since 1.0.1)
- **Button gestures**: a Home Assistant blueprint deriving single / double / hold from JUNG rocker `event` entities, robust to the gateway alternating up/down events and reporting the second press before the first release (verified against real device logs).
- **User docs**: `docs/example-button-automation.md` with copy-paste recipes + a debug logger.
- **Clean entity naming**: `_attr_has_entity_name = True` across light / switch / sensor / event, so the device label is no longer baked into entity names (no more `event.<label>_<label>_…`). New installs get clean ids; existing ids stay sticky.
- **Release tooling**: suffixed versions auto-publish as GitHub pre-releases (HACS betas).

## Also here
- Align `hacs.json` `"name"` casing (`Jung HOME` → `Jung Home`) with the manifest.

After merge: tag `v1.1.0` → `release.yml` cuts the stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)