### PR TITLE
Coordinator reliability + sensor/light modernization + tests; 1.2.0b1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+permissions: {}
+
+jobs:
+  pytest:
+    name: "pytest"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+          cache: "pip"
+
+      - name: Install requirements
+        run: python3 -m pip install -r requirements_test.txt
+
+      - name: Run tests
+        run: python3 -m pytest -q

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -39,6 +39,12 @@ ignore = [
 [lint.per-file-ignores]
 # Reference prototypes: CLI-style scripts, intentional prints / passthroughs.
 "tools/**" = ["T201", "SLF001", "EXE001", "INP001"]
+# Tests: asserts are the point; private-member access is fine.
+"tests/**" = ["S101", "S105", "S106", "SLF001", "INP001"]
+"conftest.py" = ["INP001"]
+
+[lint.isort]
+known-first-party = ["custom_components"]
 
 [lint.flake8-pytest-style]
 fixture-parentheses = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,4 +65,10 @@ When working on anything that touches the gateway protocol, consult
 - Match Home Assistant integration patterns; keep `strings.json` and
   `translations/en.json` in sync (no `<...>` in text — it breaks the translation
   parser).
+- Reuse the shared aiohttp session via `async_get_clientsession(hass,
+  verify_ssl=False)` (the gateway's cert is self-signed); don't create
+  per-request `ClientSession`s or build SSL contexts on the event loop.
 - Validate with hassfest + HACS (see `.github/workflows/validate.yml`).
+- Tests for the pure helpers live in `tests/` (`pytest`, needs the pinned
+  `homeassistant`; uses Python 3.14 like the other workflows). Run `pytest`;
+  it's wired into `.github/workflows/test.yml`.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+"""Make the repository root importable so `custom_components...` resolves in tests."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -1,11 +1,11 @@
 import asyncio
 import logging
-import ssl
 
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 
@@ -105,18 +105,19 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Blocks until the user approves the request in the app or the gateway
         times out (~180s).
         """
-        ssl_context = await self.hass.async_add_executor_job(_build_ssl_context)
+        # Shared HA session; verify_ssl=False tolerates the gateway's self-signed
+        # cert without building an SSL context on the event loop.
+        session = async_get_clientsession(self.hass, verify_ssl=False)
         url = f"https://{self._host}/api/junghome/register"
         timeout = aiohttp.ClientTimeout(total=REGISTER_TIMEOUT)
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(
-                    url, json={"user_name": REGISTER_USER_NAME}, ssl=ssl_context
-                ) as response:
-                    if response.status != 200:
-                        self._error = "register_failed"
-                        raise CannotRegister(f"HTTP {response.status}")
-                    data = await response.json()
+            async with session.post(
+                url, json={"user_name": REGISTER_USER_NAME}, timeout=timeout
+            ) as response:
+                if response.status != 200:
+                    self._error = "register_failed"
+                    raise CannotRegister(f"HTTP {response.status}")
+                data = await response.json()
         except (TimeoutError, aiohttp.ClientError) as err:
             self._error = "cannot_connect"
             raise CannotRegister(str(err)) from err
@@ -126,11 +127,3 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._error = "register_failed"
             raise CannotRegister("No token in response")
         return token
-
-
-def _build_ssl_context() -> ssl.SSLContext:
-    """Build an SSL context that tolerates the gateway's self-signed cert."""
-    ssl_context = ssl.create_default_context()
-    ssl_context.check_hostname = False
-    ssl_context.verify_mode = ssl.CERT_NONE
-    return ssl_context

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -1,14 +1,18 @@
 import asyncio
 import json
 import logging
-import ssl
 from datetime import timedelta
 
 import aiohttp
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# WebSocket reconnect backoff bounds (seconds).
+INITIAL_RECONNECT_DELAY = 1
+MAX_RECONNECT_DELAY = 60
 
 
 class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
@@ -20,6 +24,8 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self.config = config
         self.websocket = None
         self._ws_task = None
+        self._closing = False
+        self._reconnect_delay = INITIAL_RECONNECT_DELAY
         super().__init__(
             hass, _LOGGER, name="Jung Home", update_interval=timedelta(minutes=1)
         )
@@ -45,64 +51,81 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _fetch_devices_from_api(self, host, token):
         """Fetch devices from the Jung Home API."""
-        ssl_context = await asyncio.to_thread(ssl.create_default_context)
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-
+        # Shared HA session; verify_ssl=False tolerates the gateway's self-signed
+        # cert without building an SSL context on the event loop.
+        session = async_get_clientsession(self.hass, verify_ssl=False)
         url = f"https://{host}/api/junghome/functions"
         headers = {"token": f"{token}", "Content-Type": "application/json"}
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers, ssl=ssl_context) as response:
-                response.raise_for_status()
-                data = await response.json()
+        async with session.get(url, headers=headers) as response:
+            response.raise_for_status()
+            data = await response.json()
 
         # Keep the full device payload so any firmware-stable identifier
         # (serial / address / etc.) is available for building unique IDs,
         # and is visible in the debug log above for inspection.
         return list(data)
 
-    async def _connect_websocket(self):
-        """Connect to the WebSocket and handle incoming messages using aiohttp."""
+    async def _websocket_loop(self):
+        """Keep a WebSocket connection alive, reconnecting with backoff on drop.
+
+        The gateway pushes state via WebSocket; without this loop a single
+        network blip would silently stop live updates until the next command.
+        """
+        self._reconnect_delay = INITIAL_RECONNECT_DELAY
+        while not self._closing:
+            try:
+                await self._run_websocket()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                _LOGGER.warning("Jung Home WebSocket disconnected: %s", err)
+            if self._closing:
+                break
+            _LOGGER.debug(
+                "Reconnecting to Jung Home WebSocket in %ss", self._reconnect_delay
+            )
+            await asyncio.sleep(self._reconnect_delay)
+            self._reconnect_delay = min(self._reconnect_delay * 2, MAX_RECONNECT_DELAY)
+
+    async def _run_websocket(self):
+        """Open one WebSocket session and pump messages until it closes."""
+        session = async_get_clientsession(self.hass, verify_ssl=False)
         url = f"wss://{self.config['host']}/ws"
         headers = {"token": f"{self.config['token']}"}
-        ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.ws_connect(
-                    url, headers=headers, ssl=ssl_context
-                ) as ws:
-                    self.websocket = ws
-                    _LOGGER.debug("WebSocket connected (aiohttp)")
-                    async for msg in ws:
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            _LOGGER.debug("Received WebSocket message: %s", msg.data)
-                            try:
-                                data = json.loads(msg.data)
-                                if isinstance(data, list):
-                                    _LOGGER.error(
-                                        "Received WebSocket message is a list: %s", data
-                                    )
-                                    continue
-                                if data.get("type") in ["message", "version"]:
-                                    _LOGGER.debug("Received initial message: %s", data)
-                                    continue
-                                self._handle_websocket_message(data)
-                            except json.JSONDecodeError as e:
-                                _LOGGER.error("Error decoding WebSocket message: %s", e)
-                            except Exception as e:
+        async with session.ws_connect(url, headers=headers, heartbeat=30) as ws:
+            self.websocket = ws
+            # Connected: reset the backoff and resync state we may have missed
+            # while disconnected.
+            self._reconnect_delay = INITIAL_RECONNECT_DELAY
+            _LOGGER.debug("WebSocket connected (aiohttp)")
+            await self.async_request_refresh()
+            try:
+                async for msg in ws:
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        _LOGGER.debug("Received WebSocket message: %s", msg.data)
+                        try:
+                            data = json.loads(msg.data)
+                            if isinstance(data, list):
                                 _LOGGER.error(
-                                    "Unexpected error handling WebSocket message: %s", e
+                                    "Received WebSocket message is a list: %s", data
                                 )
-                                _LOGGER.error("Message content: %s", msg.data)
-                        elif msg.type == aiohttp.WSMsgType.ERROR:
-                            _LOGGER.error("WebSocket error: %s", msg)
-                            break
-        except Exception as e:
-            _LOGGER.error("Error connecting to WebSocket (aiohttp): %s", e)
-            self.websocket = None
+                                continue
+                            if data.get("type") in ["message", "version"]:
+                                _LOGGER.debug("Received initial message: %s", data)
+                                continue
+                            self._handle_websocket_message(data)
+                        except json.JSONDecodeError as e:
+                            _LOGGER.error("Error decoding WebSocket message: %s", e)
+                        except Exception as e:
+                            _LOGGER.error(
+                                "Unexpected error handling WebSocket message: %s", e
+                            )
+                            _LOGGER.error("Message content: %s", msg.data)
+                    elif msg.type == aiohttp.WSMsgType.ERROR:
+                        raise ConnectionError(f"WebSocket error frame: {msg}")
+            finally:
+                self.websocket = None
 
     def _handle_websocket_message(self, message):
         """Handle incoming WebSocket messages."""
@@ -141,14 +164,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 _LOGGER.warning("No matching datapoint found for id %s", datapoint_id)
         elif isinstance(data, list):
-            if msg_type == "groups":
-                self.groups = data
-                _LOGGER.debug("Updated groups: %s", data)
-            elif msg_type == "scenes":
-                self.scenes = data
-                _LOGGER.debug("Updated scenes: %s", data)
-            self.async_set_updated_data(self.data)
-        elif not isinstance(data, dict):
+            # groups / scenes broadcasts — not consumed by any entity; ignore.
+            _LOGGER.debug("Received %s broadcast (%d items)", msg_type, len(data))
+        else:
             _LOGGER.warning(
                 "Received WebSocket message with unknown data type: %s", message
             )
@@ -158,12 +176,14 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(
             "Starting coordinator: fetching initial data and connecting to WebSocket"
         )
+        self._closing = False
         await self.async_refresh()
-        self._ws_task = self.hass.loop.create_task(self._connect_websocket())
+        self._ws_task = self.hass.loop.create_task(self._websocket_loop())
 
     async def stop(self):
         """Stop the coordinator and close the WebSocket connection."""
         _LOGGER.debug("Stopping coordinator and closing WebSocket")
+        self._closing = True
         if self._ws_task is not None:
             self._ws_task.cancel()
             try:
@@ -185,11 +205,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             except Exception as e:
                 _LOGGER.error("Error sending WebSocket message: %s", e)
         else:
+            # The reconnect loop in _websocket_loop() will restore the connection;
+            # this command is dropped rather than queued.
             _LOGGER.error(
-                "WebSocket is not connected or is closed. Attempting to reconnect..."
+                "WebSocket is not connected; command dropped (reconnect in progress)"
             )
-            # Try to reconnect
-            self._ws_task = self.hass.loop.create_task(self._connect_websocket())
 
     async def turn_on_switch(self, datapoint_id):
         """Turn on the switch."""

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -14,20 +14,6 @@ DEFAULT_MIN_KELVIN = 2700
 DEFAULT_MAX_KELVIN = 6500
 
 
-def kelvin_to_mired(kelvin: int) -> int:
-    try:
-        return round(1000000 / kelvin)
-    except Exception:
-        return round(1000000 / DEFAULT_MIN_KELVIN)
-
-
-def mired_to_kelvin(mired: int) -> int:
-    try:
-        return round(1000000 / mired)
-    except Exception:
-        return DEFAULT_MIN_KELVIN
-
-
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
 ):
@@ -136,22 +122,9 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         return self._brightness
 
     @property
-    def color_temp(self):
-        """Return the color temperature of the light."""
-        # Home Assistant expects color_temp in mireds; device reports Kelvin
-        if self._color_temp is None:
-            return None
-        return kelvin_to_mired(self._color_temp)
-
-    @property
-    def min_mireds(self) -> int:
-        """Return minimum mireds supported."""
-        return kelvin_to_mired(DEFAULT_MAX_KELVIN)
-
-    @property
-    def max_mireds(self) -> int:
-        """Return maximum mireds supported."""
-        return kelvin_to_mired(DEFAULT_MIN_KELVIN)
+    def color_temp_kelvin(self):
+        """Return the color temperature in Kelvin (device-native)."""
+        return self._color_temp
 
     @property
     def supported_color_modes(self):
@@ -301,9 +274,8 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
             if "brightness" in kwargs:
                 brightness = kwargs["brightness"]
                 await self._set_brightness(brightness)
-            if "color_temp" in kwargs:
-                color_temp = kwargs["color_temp"]
-                await self._set_color_temp(color_temp)
+            if "color_temp_kelvin" in kwargs:
+                await self._set_color_temp(kwargs["color_temp_kelvin"])
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
@@ -343,13 +315,6 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
                 # Device reports 0-100; convert linearly to HA 0-255
                 return round(raw * 255 / 100)
         return 0
-
-    def _raw_to_ha_brightness(self, raw: int) -> int:
-        """Convert device raw brightness (0-100) to Home Assistant 0-255 scale."""
-        try:
-            return round(raw * 255 / 100)
-        except Exception:
-            return 0
 
     def _ha_to_raw_brightness(self, ha_brightness: int) -> int:
         """Convert Home Assistant 0-255 brightness to device raw scale (0-100)."""
@@ -396,25 +361,17 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         self._brightness = brightness
         self.async_write_ha_state()
 
-    async def _set_color_temp(self, color_temp):
-        """Set the color temperature of the light."""
-        _LOGGER.debug(
-            "Setting color temperature for light %s to %s", self._name, color_temp
-        )
+    async def _set_color_temp(self, kelvin):
+        """Set the color temperature of the light (Kelvin, device-native)."""
         if not self._color_temp_datapoint_id:
             _LOGGER.warning(
                 "No color_temperature datapoint id for light %s", self._name
             )
             return
-        # Home Assistant supplies mireds; convert to Kelvin for device
-        kelvin = mired_to_kelvin(int(color_temp))
+        kelvin = int(kelvin)
         _LOGGER.debug(
-            "Converted HA color_temp %s mired -> %s K for %s",
-            color_temp,
-            kelvin,
-            self._name,
+            "Setting color temperature for light %s to %sK", self._name, kelvin
         )
         await self.coordinator.set_color_temp(self._color_temp_datapoint_id, kelvin)
-        # store Kelvin locally
         self._color_temp = kelvin
         self.async_write_ha_state()

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "1.2.0b1"
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -1,13 +1,43 @@
 import logging
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
 
 _LOGGER = logging.getLogger(__name__)
+
+_MEAS = SensorStateClass.MEASUREMENT
+_TOTAL = SensorStateClass.TOTAL_INCREASING
+
+# Map a device-reported unit (normalised: stripped + lowercased) to
+# (device_class, state_class, Home Assistant unit). Energy is TOTAL_INCREASING so
+# it feeds the energy dashboard; the rest are MEASUREMENT. Unknown units fall
+# back to a plain string sensor with no class.
+_UNIT_MAP = {
+    "w": (SensorDeviceClass.POWER, _MEAS, UnitOfPower.WATT),
+    "kw": (SensorDeviceClass.POWER, _MEAS, UnitOfPower.KILO_WATT),
+    "wh": (SensorDeviceClass.ENERGY, _TOTAL, UnitOfEnergy.WATT_HOUR),
+    "kwh": (SensorDeviceClass.ENERGY, _TOTAL, UnitOfEnergy.KILO_WATT_HOUR),
+    "v": (SensorDeviceClass.VOLTAGE, _MEAS, UnitOfElectricPotential.VOLT),
+    "a": (SensorDeviceClass.CURRENT, _MEAS, UnitOfElectricCurrent.AMPERE),
+    "hz": (SensorDeviceClass.FREQUENCY, _MEAS, UnitOfFrequency.HERTZ),
+    "°c": (SensorDeviceClass.TEMPERATURE, _MEAS, UnitOfTemperature.CELSIUS),
+}
 
 
 async def async_setup_entry(
@@ -74,7 +104,12 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
         self._unique_id = stable_unique_id(
             device, datapoint, label.replace(" ", "_").lower()
         )
-        self._unit = unit
+        device_class, state_class, ha_unit = _UNIT_MAP.get(
+            unit.strip().lower(), (None, None, unit)
+        )
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
+        self._attr_native_unit_of_measurement = ha_unit
         self._value = self._get_value_from_datapoint(datapoint)
 
     @property
@@ -88,14 +123,16 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
         return self._unique_id
 
     @property
-    def state(self):
-        """Return the state of the quantity."""
+    def native_value(self):
+        """Return the measured value (numeric when the unit has a state class)."""
+        if self._value is None:
+            return None
+        if self._attr_state_class is not None:
+            try:
+                return float(self._value)
+            except (TypeError, ValueError):
+                return None
         return self._value
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of the quantity."""
-        return self._unit
 
     @property
     def device_info(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,16 @@
+"""Tests for the config-flow host normalisation helper."""
+
+from custom_components.junghome.config_flow import _normalize_host
+
+
+def test_normalize_host_strips_scheme_whitespace_and_slash():
+    cases = {
+        "192.168.1.10": "192.168.1.10",
+        "  192.168.1.10  ": "192.168.1.10",
+        "https://junghome.local": "junghome.local",
+        "http://junghome.local/": "junghome.local",
+        "HTTPS://Gateway/": "Gateway",  # host casing is preserved
+        "gateway/": "gateway",
+    }
+    for raw, expected in cases.items():
+        assert _normalize_host(raw) == expected

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,46 @@
+"""Tests for the firmware-stable identity helpers in const.py.
+
+These guard the core invariant the whole integration relies on: identity is
+derived from the device label + datapoint suffix, never the gateway's volatile
+device id.
+"""
+
+from custom_components.junghome.const import (
+    datapoint_suffix,
+    device_slug,
+    stable_unique_id,
+)
+
+
+def test_datapoint_suffix_returns_trailing_element_index():
+    assert datapoint_suffix("id5f09764942a70ce-001") == "001"
+    assert datapoint_suffix("idabc-00e") == "00e"
+
+
+def test_datapoint_suffix_without_dash_returns_whole():
+    assert datapoint_suffix("noindex") == "noindex"
+
+
+def test_device_slug_from_label():
+    assert device_slug({"label": "Living Room R1 B"}) == "living_room_r1_b"
+
+
+def test_device_slug_falls_back_to_id_then_default():
+    assert device_slug({"id": "id123"}) == "id123"
+    assert device_slug({}) == "jung"
+
+
+def test_stable_unique_id_combines_slug_suffix_and_qualifier():
+    device = {"label": "Living Room R1 B"}
+    datapoint = {"id": "idXYZ-001"}
+    assert stable_unique_id(device, datapoint) == "living_room_r1_b_001"
+    assert stable_unique_id(device, datapoint, "event") == "living_room_r1_b_001_event"
+
+
+def test_stable_unique_id_is_independent_of_the_gateway_device_id():
+    """Same label + datapoint suffix must yield the same id even after the
+    gateway regenerates the device id on a firmware update."""
+    device = {"label": "Kitchen Light"}
+    before = {"id": "idAAAA1111-010"}
+    after = {"id": "idBBBB2222-010"}
+    assert stable_unique_id(device, before) == stable_unique_id(device, after)


### PR DESCRIPTION
First `1.2.0` beta — the reliability/modernization pass.

## 🔴 Reliability (`coordinator.py`)
- **WebSocket auto-reconnect** with exponential backoff, owned by `start()`/`stop()`. Previously a single drop set `websocket = None` and returned, silently stopping all live state updates until the next command. On (re)connect it resets backoff and resyncs via a refresh.
- **Shared aiohttp session** (`async_get_clientsession(hass, verify_ssl=False)`) for REST, WS and registration instead of a fresh `ClientSession` per call — which also removes the blocking `ssl.create_default_context()` from the event loop.
- Drop the dead `self.groups` / `self.scenes` writes.

## 🟠 Modernization (clears 2026.6 deprecation warnings)
- **Sensors**: `native_value` / `native_unit_of_measurement` + `device_class` and `state_class` (energy → `TOTAL_INCREASING` so it feeds the energy dashboard; power/voltage/current/etc. → `MEASUREMENT`). Unknown units fall back to a plain string sensor.
- **Lights**: Kelvin color temperature (`color_temp_kelvin`) instead of deprecated mireds; mired conversions removed.

## 🟡 Cleanup
- Remove the unused `light._raw_to_ha_brightness`.

## ✅ Tests / CI
- `tests/` with pytest for the stable-id helpers and host normalisation (verified locally: 7 passed).
- New **Tests** workflow (Python 3.14, installs the pinned `homeassistant`).
- `pytest.ini` confines collection to `tests/`; ruff per-file ignores for tests.

Skipped #7 (status LED → `EntityCategory.CONFIG`) per your call to keep it a primary, controllable switch.

Bump to `1.2.0b1` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)