### PR TITLE
Static color modes, availability fixes, reauth flow; 1.2.0b2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Behind the scenes this calls the gateway's `POST /api/junghome/register`
 endpoint; the issued token is stored in the config entry. Devices added or
 removed in the Jung Home app afterwards are picked up automatically.
 
+# Button automations (rocker switches)
+
+Rocker buttons show up as Home Assistant **event entities** (one per up/down
+side). The gateway only reports raw press/release, so single/double/hold gestures
+are derived in an automation — a ready-made **blueprint** does this for you:
+
+- Blueprint: [`blueprints/automation/junghome/button_gestures.yaml`](blueprints/automation/junghome/button_gestures.yaml)
+- Full guide + copy-paste recipes: [`docs/example-button-automation.md`](docs/example-button-automation.md)
+
+Import the blueprint by URL (Settings → Automations & scenes → Blueprints →
+Import), select **all** of the button's event entities (JUNG alternates between
+the up/down events), and assign actions for single / double / hold.
+
 # Gateway internals (for contributors)
 
 The local gateway API (REST + WebSocket), its registration flow, and the

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -98,6 +98,49 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={"base": self._error},
         )
 
+    async def async_step_reauth(self, entry_data):
+        """Start reauth when the gateway rejects the stored token."""
+        self._host = entry_data[CONF_HOST]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Re-register with the gateway to obtain a fresh token."""
+        if self._register_task is None:
+            self._register_task = self.hass.async_create_task(self._async_register())
+
+        if not self._register_task.done():
+            return self.async_show_progress(
+                step_id="reauth_confirm",
+                progress_action="waiting_for_approval",
+                progress_task=self._register_task,
+            )
+
+        try:
+            self._token = self._register_task.result()
+        except Exception:
+            self._register_task = None
+            return self.async_show_progress_done(next_step_id="reauth_failed")
+
+        self._register_task = None
+        return self.async_show_progress_done(next_step_id="reauth_finish")
+
+    async def async_step_reauth_finish(self, user_input=None):
+        """Store the fresh token on the existing entry and reload it."""
+        return self.async_update_reload_and_abort(
+            self._get_reauth_entry(),
+            data_updates={CONF_TOKEN: self._token},
+        )
+
+    async def async_step_reauth_failed(self, user_input=None):
+        """Show the failure reason and allow retrying the reauth."""
+        if user_input is not None:
+            return await self.async_step_reauth_confirm()
+        return self.async_show_form(
+            step_id="reauth_failed",
+            data_schema=vol.Schema({}),
+            errors={"base": self._error},
+        )
+
     async def _async_register(self) -> str:
         """
         POST the registration request and return the issued token.

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -5,8 +5,9 @@ from datetime import timedelta
 
 import aiohttp
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,17 +38,22 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             response = await self._fetch_devices_from_api(
                 self.config["host"], self.config["token"]
             )
-            if response is None:
-                _LOGGER.error("Received None response from API")
-                return []  # Returning empty list ensures entities don't break
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403):
+                # Token revoked/expired — trigger Home Assistant's reauth flow.
+                raise ConfigEntryAuthFailed(
+                    "Jung Home gateway rejected the token"
+                ) from err
+            raise UpdateFailed(f"Error fetching data from Jung Home: {err}") from err
+        except aiohttp.ClientError as err:
+            raise UpdateFailed(f"Error connecting to Jung Home: {err}") from err
 
-            _LOGGER.debug("API Response: %s", response)
-            return (
-                response  # `async_set_updated_data` is automatically called with this
-            )
-        except Exception as e:
-            _LOGGER.error("Error fetching data from Jung Home API: %s", e)
-            raise  # Raising exception allows Home Assistant to handle errors properly
+        if response is None:
+            _LOGGER.error("Received None response from API")
+            return []  # Returning empty list ensures entities don't break
+        _LOGGER.debug("API Response: %s", response)
+        # `async_set_updated_data` is automatically called with this.
+        return response
 
     async def _fetch_devices_from_api(self, host, token):
         """Fetch devices from the Jung Home API."""

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -73,7 +73,9 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
         self._attr_name = _EVENT_NAMES.get(dp_type, dp_type)
         self._attr_unique_id = stable_unique_id(device, datapoint, "event")
         self._attr_icon = "mdi:gesture-tap-button"
-        self._attr_available = True
+        # Availability is inherited from CoordinatorEntity (tracks the gateway
+        # connection); don't pin it True or it stays "available" when the
+        # gateway is down.
         self._last_press_time = 0
         self._last_value = self._get_state_from_datapoint(datapoint)
 

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -106,6 +106,20 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
             self._brightness = None
             self._color_temp = None
 
+        # Color mode is fixed by the device's capabilities (datapoints), not by
+        # the current value. Home Assistant requires supported_color_modes to be
+        # a stable set, so decide it once here. COLOR_TEMP already implies
+        # brightness support.
+        if self._color_temp_datapoint_id:
+            self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+            self._attr_color_mode = ColorMode.COLOR_TEMP
+        elif device["type"] == "ColorLight":
+            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+            self._attr_color_mode = ColorMode.BRIGHTNESS
+        else:
+            self._attr_supported_color_modes = {ColorMode.ONOFF}
+            self._attr_color_mode = ColorMode.ONOFF
+
     @property
     def unique_id(self):
         """Return a unique ID for the light."""
@@ -125,21 +139,6 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
     def color_temp_kelvin(self):
         """Return the color temperature in Kelvin (device-native)."""
         return self._color_temp
-
-    @property
-    def supported_color_modes(self):
-        """Return the supported color modes (only the current mode, per HA 2025.3+)."""
-        return {self.color_mode}
-
-    @property
-    def color_mode(self):
-        """Return the currently active color mode."""
-        if self._device["type"] == "ColorLight":
-            # If color_temp is set, prefer COLOR_TEMP, else BRIGHTNESS
-            if self._color_temp is not None:
-                return ColorMode.COLOR_TEMP
-            return ColorMode.BRIGHTNESS
-        return ColorMode.ONOFF
 
     @property
     def device_info(self):

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b1"
+  "version": "1.2.0b2"
 }

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -14,6 +14,14 @@
       "register_failed": {
         "title": "Registration failed",
         "description": "The access request was not approved in time or the gateway could not be reached. Submit to try again, then approve the request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+      },
+      "reauth_confirm": {
+        "title": "Reauthorize Jung Home",
+        "description": "The gateway no longer accepts the stored access token. Approve the new access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+      },
+      "reauth_failed": {
+        "title": "Reauthorization failed",
+        "description": "The access request was not approved in time or the gateway could not be reached. Submit to try again, then approve the request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
       }
     },
     "progress": {
@@ -25,7 +33,8 @@
       "register_failed": "Registration was not completed. Make sure you approve the request in the app."
     },
     "abort": {
-      "already_configured": "This Jung Home gateway is already configured."
+      "already_configured": "This Jung Home gateway is already configured.",
+      "reauth_successful": "Re-authentication was successful."
     }
   }
 }

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -134,25 +134,6 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
         """Return if the device is available."""
         return self.coordinator.last_update_success
 
-    async def async_update(self):
-        """Update the socket's state."""
-        await self.coordinator.async_request_refresh()
-        device = next(
-            (d for d in self.coordinator.data if d["id"] == self._device["id"]), None
-        )
-        if device:
-            datapoint = next(
-                (
-                    dp
-                    for dp in device.get("datapoints", [])
-                    if dp["id"] == self._datapoint["id"]
-                ),
-                None,
-            )
-            if datapoint:
-                self._is_on = self._get_state_from_datapoint(datapoint)
-                self.async_write_ha_state()
-
     def _get_state_from_datapoint(self, datapoint):
         """Extract the state of the socket from its datapoint."""
         for value in datapoint.get("values", []):
@@ -174,7 +155,8 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
         self._device = device
         self._datapoint = datapoint
         self._attr_unique_id = stable_unique_id(device, datapoint, "switch")
-        self._attr_available = coordinator.last_update_success
+        # Availability is inherited from CoordinatorEntity (tracks the gateway
+        # connection); don't snapshot it here or it never updates.
         self._attr_is_on = self._get_state_from_datapoint(datapoint)
 
     @property

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -14,6 +14,14 @@
       "register_failed": {
         "title": "Registration failed",
         "description": "The access request was not approved in time or the gateway could not be reached. Submit to try again, then approve the request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+      },
+      "reauth_confirm": {
+        "title": "Reauthorize Jung Home",
+        "description": "The gateway no longer accepts the stored access token. Approve the new access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+      },
+      "reauth_failed": {
+        "title": "Reauthorization failed",
+        "description": "The access request was not approved in time or the gateway could not be reached. Submit to try again, then approve the request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
       }
     },
     "progress": {
@@ -25,7 +33,8 @@
       "register_failed": "Registration was not completed. Make sure you approve the request in the app."
     },
     "abort": {
-      "already_configured": "This Jung Home gateway is already configured."
+      "already_configured": "This Jung Home gateway is already configured.",
+      "reauth_successful": "Re-authentication was successful."
     }
   }
 }


### PR DESCRIPTION
Second `1.2.0` beta — correctness fixes (A–C), docs (D), and a reauth flow (E).

## A. Light color modes are now stable
`supported_color_modes` was `{self.color_mode}` and `color_mode` flipped between `COLOR_TEMP` and `BRIGHTNESS` based on the *current* value — a runtime-changing set that HA discourages and warns about. It's now decided **once** from the device's datapoints: color-temp datapoint → `{COLOR_TEMP}` (implies brightness), else brightness → `{BRIGHTNESS}`, else `{ONOFF}`.

## B. Availability fixes
- `event.py` hardcoded `available = True` → buttons showed available even when the gateway was down.
- `switch.py` status LED snapshotted availability **once** at startup.

Both now inherit `CoordinatorEntity` availability (tracks the gateway link).

## C. Cleanup
Removed the dead `socket.async_update` (never called — `should_poll` is `False`).

## D. README
New "Button automations" section pointing at the blueprint + docs guide.

## E. Reauth flow
- Coordinator raises `ConfigEntryAuthFailed` on a `401/403` from the gateway → HA starts reauth.
- `config_flow` gains `reauth` / `reauth_confirm` / `reauth_finish` / `reauth_failed` steps that re-run the app-approval registration and update the entry token via `async_update_reload_and_abort`. Verified the helpers exist in HA 2026.6.
- Reauth strings added (`strings.json` + `translations/en.json` in sync).

Local: ruff clean, 7 tests pass. Bump to `1.2.0b2` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)