### PR TITLE
Robust setup: first-refresh + config_entry; 1.2.0b3

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -21,19 +21,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Jung Home from a config entry."""
-    if DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]:
-        return False
-
     host = entry.data.get("host")
     token = entry.data.get("token")
 
     # Initialize the coordinator with the host and token
-    coordinator = JungHomeDataUpdateCoordinator(hass, {"host": host, "token": token})
+    coordinator = JungHomeDataUpdateCoordinator(
+        hass, {"host": host, "token": token}, entry
+    )
+
+    # Fetch initial data; raises ConfigEntryNotReady (retry) if the gateway is
+    # unreachable, or ConfigEntryAuthFailed (reauth) if the token is rejected.
+    await coordinator.async_config_entry_first_refresh()
 
     # Store the coordinator in hass data for later use
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coordinator}
 
-    # Start the coordinator (fetch initial data and connect to WebSocket)
+    # Connect to the WebSocket for live updates
     await coordinator.start()
 
     # One-time migration of registry entries from the gateway's volatile device

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -19,7 +19,7 @@ MAX_RECONNECT_DELAY = 60
 class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the Jung Home API."""
 
-    def __init__(self, hass: HomeAssistant, config: dict):
+    def __init__(self, hass: HomeAssistant, config: dict, config_entry):
         """Initialize the coordinator."""
         self.hass = hass
         self.config = config
@@ -28,7 +28,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self._closing = False
         self._reconnect_delay = INITIAL_RECONNECT_DELAY
         super().__init__(
-            hass, _LOGGER, name="Jung Home", update_interval=timedelta(minutes=1)
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Jung Home",
+            update_interval=timedelta(minutes=1),
         )
 
     async def _async_update_data(self):
@@ -178,12 +182,14 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
     async def start(self):
-        """Start the coordinator by fetching initial data and connecting to the WebSocket."""
-        _LOGGER.debug(
-            "Starting coordinator: fetching initial data and connecting to WebSocket"
-        )
+        """Connect to the WebSocket.
+
+        Initial device data is fetched separately during setup via
+        async_config_entry_first_refresh() so that a failure aborts setup
+        correctly (retry on connection error, reauth on a rejected token).
+        """
+        _LOGGER.debug("Starting coordinator: connecting to WebSocket")
         self._closing = False
-        await self.async_refresh()
         self._ws_task = self.hass.loop.create_task(self._websocket_loop())
 
     async def stop(self):

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b2"
+  "version": "1.2.0b3"
 }


### PR DESCRIPTION
Completes the reauth story by making setup fail correctly.

## Problem
`coordinator.start()` fetched initial data via `async_refresh()`, which **swallows** errors:
- Gateway unreachable at startup → setup "succeeds" with empty data, **no retry** until a manual reload.
- Bad token at setup → reauth **not** triggered (only the later 60 s poll would catch it).

## Fix
- Use `await coordinator.async_config_entry_first_refresh()` during setup → `ConfigEntryNotReady` on connection failure (HA retries with backoff), `ConfigEntryAuthFailed` on a rejected token (routes into the b2 reauth flow).
- Pass `config_entry=entry` into the `DataUpdateCoordinator` constructor (required by `first_refresh`; also clears HA 2026's missing-`config_entry` warning). Verified both exist in HA 2026.6.
- `start()` now only opens the WebSocket; the initial REST fetch happens once via `first_refresh`.
- Remove the dead `return False` guard at the top of `async_setup_entry` (returning `False` signals setup failure).

Local: ruff clean, 7 tests pass. Bump to `1.2.0b3` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)