### PR TITLE
Reconfigure flow + PARALLEL_UPDATES + diagnostics; 1.2.0b4

### DIFF
--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -141,6 +141,37 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={"base": self._error},
         )
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Let the user update the gateway address (e.g. after an IP change).
+
+        The existing token still works for the same gateway at a new address; if
+        it points at a different gateway, the next refresh triggers reauth.
+        """
+        entry = self._get_reconfigure_entry()
+        errors = {}
+        if user_input is not None:
+            host = _normalize_host(user_input[CONF_HOST])
+            if not host:
+                errors["base"] = "invalid_host"
+            elif any(
+                other.entry_id != entry.entry_id and other.data.get(CONF_HOST) == host
+                for other in self._async_current_entries()
+            ):
+                return self.async_abort(reason="already_configured")
+            else:
+                await self.async_set_unique_id(host)
+                return self.async_update_reload_and_abort(
+                    entry, data_updates={CONF_HOST: host}, unique_id=host
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, {CONF_HOST: entry.data.get(CONF_HOST)}
+            ),
+            errors=errors,
+        )
+
     async def _async_register(self) -> str:
         """
         POST the registration request and return the issued token.

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -1,0 +1,33 @@
+"""Diagnostics support for Jung Home."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_TOKEN
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+# The gateway token is a bearer credential; never include it in a downloadable
+# report. Datapoint values/labels are not secret and are kept for debugging.
+TO_REDACT = {CONF_TOKEN, "token"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    return {
+        "entry": {
+            "data": async_redact_data(entry.data, TO_REDACT),
+            "title": entry.title,
+        },
+        "device_count": len(coordinator.data or []),
+        "devices": coordinator.data or [],
+    }

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -11,6 +11,9 @@ from .const import DOMAIN, device_slug, stable_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only platform; no update serialisation needed.
+PARALLEL_UPDATES = 0
+
 # Short, human-readable names per rocker datapoint type. With
 # `_attr_has_entity_name = True`, Home Assistant prepends the device name, so the
 # label is no longer baked into the entity name (which previously produced

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -10,6 +10,9 @@ from .const import DOMAIN, device_slug, stable_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Commands are cheap async WebSocket sends; don't serialise them.
+PARALLEL_UPDATES = 0
+
 DEFAULT_MIN_KELVIN = 2700
 DEFAULT_MAX_KELVIN = 6500
 

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b3"
+  "version": "1.2.0b4"
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -21,6 +21,9 @@ from .const import DOMAIN, device_slug, stable_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only platform; no update serialisation needed.
+PARALLEL_UPDATES = 0
+
 _MEAS = SensorStateClass.MEASUREMENT
 _TOTAL = SensorStateClass.TOTAL_INCREASING
 

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -22,6 +22,16 @@
       "reauth_failed": {
         "title": "Reauthorization failed",
         "description": "The access request was not approved in time or the gateway could not be reached. Submit to try again, then approve the request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+      },
+      "reconfigure": {
+        "title": "Reconfigure Jung Home",
+        "description": "Update the address of your Jung Home gateway, for example after its IP address changed.",
+        "data": {
+          "host": "Host"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local)."
+        }
       }
     },
     "progress": {
@@ -34,7 +44,8 @@
     },
     "abort": {
       "already_configured": "This Jung Home gateway is already configured.",
-      "reauth_successful": "Re-authentication was successful."
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "The gateway address was updated."
     }
   }
 }

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -9,6 +9,9 @@ from .const import DOMAIN, device_slug, stable_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Commands are cheap async WebSocket sends; don't serialise them.
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -22,6 +22,16 @@
       "reauth_failed": {
         "title": "Reauthorization failed",
         "description": "The access request was not approved in time or the gateway could not be reached. Submit to try again, then approve the request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+      },
+      "reconfigure": {
+        "title": "Reconfigure Jung Home",
+        "description": "Update the address of your Jung Home gateway, for example after its IP address changed.",
+        "data": {
+          "host": "Host"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local)."
+        }
       }
     },
     "progress": {
@@ -34,7 +44,8 @@
     },
     "abort": {
       "already_configured": "This Jung Home gateway is already configured.",
-      "reauth_successful": "Re-authentication was successful."
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "The gateway address was updated."
     }
   }
 }


### PR DESCRIPTION
Idiomatic-completeness pass.

- **Reconfigure flow** (`async_step_reconfigure`): update the gateway address in place (e.g. after an IP change) instead of removing and re-adding the integration. The existing token keeps working for the same gateway; pointing at a different gateway triggers reauth on the next refresh. Guards against colliding with another configured entry. Strings added (`strings.json` + `translations/en.json` in sync).
- **`PARALLEL_UPDATES = 0`** on all platforms — commands are cheap async WebSocket sends; read-only platforms (sensor/event) need no serialisation.
- **`diagnostics.py`** — downloadable config-entry diagnostics (device list + entry data) with the gateway **token redacted**.

Verified the config-flow / diagnostics helpers exist in HA 2026.6. Local: ruff clean, 7 tests pass, modules import cleanly. Bump to `1.2.0b4` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)