### PR TITLE
Log WebSocket (re)connect at INFO for soak observability; 1.2.0b5

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -106,9 +106,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         async with session.ws_connect(url, headers=headers, heartbeat=30) as ws:
             self.websocket = ws
             # Connected: reset the backoff and resync state we may have missed
-            # while disconnected.
+            # while disconnected. Logged at INFO (paired with the WARNING on
+            # disconnect) so the drop/recover story is visible without enabling
+            # debug logging during a long soak.
             self._reconnect_delay = INITIAL_RECONNECT_DELAY
-            _LOGGER.debug("WebSocket connected (aiohttp)")
+            _LOGGER.info("Jung Home WebSocket connected")
             await self.async_request_refresh()
             try:
                 async for msg in ws:

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b4"
+  "version": "1.2.0b5"
 }


### PR DESCRIPTION
Pre-soak observability tweak: WebSocket recovery logged only at DEBUG, so a 24/7 test couldn't confirm self-healing without enabling debug logging (which logs every datapoint message). Promote the connect log to INFO — paired with the existing WARNING on disconnect, the drop→recover timeline is visible at the default log level.

One-line change. Bump to `1.2.0b5` → HACS pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)