### PR TITLE
Use entry.runtime_data instead of hass.data; 1.2.0b6

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -1,13 +1,12 @@
 import logging
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, datapoint_suffix, device_slug
-from .coordinator import JungHomeDataUpdateCoordinator
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:
     """Set up Jung Home from a config entry."""
     host = entry.data.get("host")
     token = entry.data.get("token")
@@ -33,8 +32,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # unreachable, or ConfigEntryAuthFailed (reauth) if the token is rejected.
     await coordinator.async_config_entry_first_refresh()
 
-    # Store the coordinator in hass data for later use
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coordinator}
+    # Expose the coordinator as runtime data for the platforms.
+    entry.runtime_data = coordinator
 
     # Connect to the WebSocket for live updates
     await coordinator.start()
@@ -55,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 def _migrate_to_stable_ids(
-    hass: HomeAssistant, entry: ConfigEntry, coordinator
+    hass: HomeAssistant, entry: JungHomeConfigEntry, coordinator
 ) -> None:
     """
     Re-point existing id-based registry entries to label-based stable ids.
@@ -126,19 +125,17 @@ def _migrate_to_stable_ids(
         _LOGGER.exception("Jung Home: failed to migrate registry to stable ids")
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    if unload_ok and DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]:
-        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-        await coordinator.stop()
-        del hass.data[DOMAIN][entry.entry_id]
+    if unload_ok:
+        await entry.runtime_data.stop()
 
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_reload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:
     """Reload a config entry."""
     await async_unload_entry(hass, entry)
     return await async_setup_entry(hass, entry)

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -4,6 +4,7 @@ import logging
 from datetime import timedelta
 
 import aiohttp
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -15,11 +16,14 @@ _LOGGER = logging.getLogger(__name__)
 INITIAL_RECONNECT_DELAY = 1
 MAX_RECONNECT_DELAY = 60
 
+# Config entry carrying the coordinator as runtime_data.
+type JungHomeConfigEntry = ConfigEntry[JungHomeDataUpdateCoordinator]
+
 
 class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the Jung Home API."""
 
-    def __init__(self, hass: HomeAssistant, config: dict, config_entry):
+    def __init__(self, hass: HomeAssistant, config: dict, config_entry: ConfigEntry):
         """Initialize the coordinator."""
         self.hass = hass
         self.config = config

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_TOKEN
 
-from .const import DOMAIN
-
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+    from .coordinator import JungHomeConfigEntry
 
 # The gateway token is a bearer credential; never include it in a downloadable
 # report. Datapoint values/labels are not secret and are kept for debugging.
@@ -19,10 +18,10 @@ TO_REDACT = {CONF_TOKEN, "token"}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: JungHomeConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator = entry.runtime_data
     return {
         "entry": {
             "data": async_redact_data(entry.data, TO_REDACT),

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -2,12 +2,12 @@ import logging
 import time
 
 from homeassistant.components.event import EventEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, device_slug, stable_unique_id
+from .coordinator import JungHomeConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,10 +26,10 @@ _EVENT_NAMES = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant, entry: JungHomeConfigEntry, async_add_entities
 ):
     """Set up Jung Home event entities from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator = entry.runtime_data
     known: set[str] = set()
 
     @callback

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -2,11 +2,11 @@ import logging
 import time
 
 from homeassistant.components.light import ColorMode, LightEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
+from .coordinator import JungHomeConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ DEFAULT_MAX_KELVIN = 6500
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant, config_entry: JungHomeConfigEntry, async_add_entities
 ):
     """Set up Jung Home lights from a config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    coordinator = config_entry.runtime_data
     known: set[str] = set()
 
     @callback

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b5"
+  "version": "1.2.0b6"
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -5,7 +5,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -18,6 +17,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
+from .coordinator import JungHomeConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,10 +44,10 @@ _UNIT_MAP = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant, entry: JungHomeConfigEntry, async_add_entities
 ):
     """Set up Jung Home sensors from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator = entry.runtime_data
     known: set[str] = set()
 
     @callback

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -1,11 +1,11 @@
 import logging
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
+from .coordinator import JungHomeConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,10 +14,10 @@ PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+    hass: HomeAssistant, entry: JungHomeConfigEntry, async_add_entities
 ):
     """Set up Jung Home switches from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator = entry.runtime_data
     known: set[str] = set()
 
     @callback


### PR DESCRIPTION
Quality-scale `runtime-data`: store the coordinator on `entry.runtime_data` with a typed `JungHomeConfigEntry = ConfigEntry[JungHomeDataUpdateCoordinator]` alias, read from the entry in every platform and in diagnostics, and drop the `hass.data[DOMAIN]` bookkeeping. Modern HA pattern; removes the `hass.data` nitpick.

Local: ruff clean, whole package imports, 7 tests pass. Bump to `1.2.0b6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)