### PR TITLE
Entity name translations; 1.2.0b7

### DIFF
--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -14,14 +14,14 @@ _LOGGER = logging.getLogger(__name__)
 # Read-only platform; no update serialisation needed.
 PARALLEL_UPDATES = 0
 
-# Short, human-readable names per rocker datapoint type. With
-# `_attr_has_entity_name = True`, Home Assistant prepends the device name, so the
-# label is no longer baked into the entity name (which previously produced
-# duplicated entity_ids like `event.<label>_<label>_up_request_event`).
-_EVENT_NAMES = {
-    "up_request": "Up",
-    "down_request": "Down",
-    "trigger_request": "Press",
+# Translation keys per rocker datapoint type. With `_attr_has_entity_name`, HA
+# prepends the device name; the entity name itself comes from the
+# `entity.event.*` translations (strings.json), so it's localisable rather than
+# hardcoded.
+_EVENT_TRANSLATION_KEYS = {
+    "up_request": "up",
+    "down_request": "down",
+    "trigger_request": "press",
 }
 
 
@@ -73,7 +73,11 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
         self._device = device
         self._datapoint = datapoint
         dp_type = datapoint.get("type", "Unknown")
-        self._attr_name = _EVENT_NAMES.get(dp_type, dp_type)
+        translation_key = _EVENT_TRANSLATION_KEYS.get(dp_type)
+        if translation_key:
+            self._attr_translation_key = translation_key
+        else:
+            self._attr_name = dp_type
         self._attr_unique_id = stable_unique_id(device, datapoint, "event")
         self._attr_icon = "mdi:gesture-tap-button"
         # Availability is inherited from CoordinatorEntity (tracks the gateway

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b6"
+  "version": "1.2.0b7"
 }

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -47,5 +47,15 @@
       "reauth_successful": "Re-authentication was successful.",
       "reconfigure_successful": "The gateway address was updated."
     }
+  },
+  "entity": {
+    "event": {
+      "up": { "name": "Up" },
+      "down": { "name": "Down" },
+      "press": { "name": "Press" }
+    },
+    "switch": {
+      "status_led": { "name": "Status LED" }
+    }
   }
 }

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -149,9 +149,10 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
     """Representation of a Jung Home status LED as a switch entity."""
 
     # Secondary entity on the rocker device; HA prepends the device name, so the
-    # entity_id becomes `switch.<device>_status_led`.
+    # entity_id becomes `switch.<device>_status_led`. The name comes from the
+    # entity.switch.status_led translation.
     _attr_has_entity_name = True
-    _attr_name = "Status LED"
+    _attr_translation_key = "status_led"
 
     def __init__(self, coordinator, device, datapoint):
         super().__init__(coordinator)
@@ -183,16 +184,16 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
         return self._attr_is_on
 
     async def async_turn_on(self, **kwargs):
-        _LOGGER.debug("Turning on switch %s", self._attr_name)
+        _LOGGER.debug("Turning on switch %s", self._attr_unique_id)
         await self.coordinator.set_status_led(self._datapoint["id"], True)
 
     async def async_turn_off(self, **kwargs):
-        _LOGGER.debug("Turning off switch %s", self._attr_name)
+        _LOGGER.debug("Turning off switch %s", self._attr_unique_id)
         await self.coordinator.set_status_led(self._datapoint["id"], False)
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        _LOGGER.debug("Updating switch for %s", self._attr_name)
+        _LOGGER.debug("Updating switch for %s", self._attr_unique_id)
         device = next(
             (d for d in self.coordinator.data if d["id"] == self._device["id"]), None
         )

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -47,5 +47,15 @@
       "reauth_successful": "Re-authentication was successful.",
       "reconfigure_successful": "The gateway address was updated."
     }
+  },
+  "entity": {
+    "event": {
+      "up": { "name": "Up" },
+      "down": { "name": "Down" },
+      "press": { "name": "Press" }
+    },
+    "switch": {
+      "status_led": { "name": "Status LED" }
+    }
   }
 }


### PR DESCRIPTION
Quality-scale `entity-translations`: fixed-name entities (event up/down/press, status LED) now use translation keys + an `entity:` strings section instead of hardcoded names. Rendered names are identical, so entity_ids/friendly names don't change. Sensor quantity names stay dynamic. Local: ruff clean, hassfest validates the keys, 7 tests pass. `1.2.0b7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)