### PR TITLE
Enforce docstrings + lazy logging; 1.2.0b9

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -10,20 +10,18 @@ select = [
 ignore = [
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "D203", # no-blank-line-before-class (incompatible with formatter)
-    "D212", # multi-line-summary-first-line (incompatible with formatter)
+    "D213", # multi-line-summary-second-line (we summarise on the first line)
     "COM812", # incompatible with formatter
     "ISC001", # incompatible with formatter
 
     # Families this (largely pre-existing) codebase does not follow; relaxed so
     # CI lint is green without rewriting working code.
     "ANN", # type annotations not used throughout
-    "D", # docstrings not present throughout
     "ARG", # unused arguments are common in Home Assistant callback signatures
     "FBT", # boolean positional args are common in HA APIs
     "EM", # exception messages as string literals
     "TRY", # tryceratops opinions (TRY003/TRY300/TRY400)
     "BLE001", # blind "except Exception" is intentional in places
-    "G004", # f-strings in logging calls
     "E501", # line length (formatter handles wrapping; long URLs/strings remain)
     "SIM102", # nested if (clearer as-is in places)
     "SIM105", # contextlib.suppress
@@ -37,10 +35,12 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-# Reference prototypes: CLI-style scripts, intentional prints / passthroughs.
-"tools/**" = ["T201", "SLF001", "EXE001", "INP001"]
-# Tests: asserts are the point; private-member access is fine.
-"tests/**" = ["S101", "S105", "S106", "SLF001", "INP001"]
+# Reference prototypes: CLI-style scripts, intentional prints / passthroughs;
+# not held to the integration's docstring convention.
+"tools/**" = ["T201", "SLF001", "EXE001", "INP001", "D"]
+# Tests: asserts are the point; private-member access is fine; descriptive test
+# names stand in for docstrings.
+"tests/**" = ["S101", "S105", "S106", "SLF001", "INP001", "D"]
 "conftest.py" = ["INP001"]
 
 [lint.isort]

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -1,3 +1,5 @@
+"""The Jung Home integration."""
+
 import logging
 
 from homeassistant.core import HomeAssistant
@@ -56,8 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
 def _migrate_to_stable_ids(
     hass: HomeAssistant, entry: JungHomeConfigEntry, coordinator
 ) -> None:
-    """
-    Re-point existing id-based registry entries to label-based stable ids.
+    """Re-point existing id-based registry entries to label-based stable ids.
 
     The Jung HOME gateway exposes no hardware identifier, and it regenerates the
     random device id on firmware updates, which previously caused Home Assistant

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -1,3 +1,5 @@
+"""Config flow for the Jung Home integration."""
+
 import asyncio
 import logging
 
@@ -40,6 +42,7 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     def __init__(self) -> None:
+        """Initialize the config flow."""
         self._host: str | None = None
         self._token: str | None = None
         self._error: str = "register_failed"
@@ -199,8 +202,7 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_register()
 
     async def _async_register(self) -> str:
-        """
-        POST the registration request and return the issued token.
+        """POST the registration request and return the issued token.
 
         Blocks until the user approves the request in the app or the gateway
         times out (~180s).

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -1,11 +1,12 @@
+"""Constants and firmware-stable identity helpers for Jung Home."""
+
 from homeassistant.util import slugify
 
 DOMAIN = "junghome"
 
 
 def datapoint_suffix(datapoint_id) -> str:
-    """
-    Return the stable element index of a datapoint id.
+    """Return the stable element index of a datapoint id.
 
     Datapoint ids look like ``id5f09764942a70ce-001``. The ``id...`` prefix is
     the device id, which the gateway regenerates on firmware updates, but the
@@ -15,8 +16,7 @@ def datapoint_suffix(datapoint_id) -> str:
 
 
 def device_slug(device: dict) -> str:
-    """
-    Return a firmware-stable slug for a device, based on its label.
+    """Return a firmware-stable slug for a device, based on its label.
 
     The gateway exposes no hardware identifier (serial/MAC/address); the user
     facing label is the only attribute that survives firmware updates, so it is

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -1,3 +1,5 @@
+"""Data update coordinator for Jung Home (REST polling + WebSocket push)."""
+
 import asyncio
 import json
 import logging

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -1,3 +1,5 @@
+"""Event platform for Jung Home rocker buttons."""
+
 import logging
 import time
 
@@ -119,25 +121,25 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
         if new_state != self._last_value:
             now = time.time()
             if new_state is True:
-                _LOGGER.debug(f"Triggering event for {self._attr_name} at {now}")
+                _LOGGER.debug(
+                    "Triggering pressed event for %s at %s", self.entity_id, now
+                )
                 self._trigger_event("pressed")
                 self._attr_event_timestamp = dt_util.now()
                 self.async_write_ha_state()
-                _LOGGER.debug(f"EventEntity state after trigger: {self.state}")
                 self._last_press_time = now
             elif new_state is False:
                 _LOGGER.debug(
-                    f"Triggering depressed event for {self._attr_name} at {now}"
+                    "Triggering depressed event for %s at %s", self.entity_id, now
                 )
                 self._trigger_event("depressed")
                 self._attr_event_timestamp = dt_util.now()
                 self.async_write_ha_state()
-                _LOGGER.debug(f"EventEntity state after trigger: {self.state}")
             self._last_value = new_state
 
     @property
     def state(self):
-        # Show the last event timestamp as state if available
+        """Return the timestamp of the last button event."""
         return getattr(self, "_attr_event_timestamp", None)
 
     def _get_state_from_datapoint(self, datapoint):

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -1,3 +1,5 @@
+"""Light platform for Jung Home (on/off, dimmable, tunable white)."""
+
 import logging
 import time
 

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b8",
+  "version": "1.2.0b9",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -1,3 +1,5 @@
+"""Sensor platform for Jung Home (socket energy quantities)."""
+
 import logging
 
 from homeassistant.components.sensor import (

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -1,3 +1,5 @@
+"""Switch platform for Jung Home (sockets and rocker status LEDs)."""
+
 import logging
 
 from homeassistant.components.switch import SwitchEntity
@@ -155,6 +157,7 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
     _attr_translation_key = "status_led"
 
     def __init__(self, coordinator, device, datapoint):
+        """Initialize the status LED switch."""
         super().__init__(coordinator)
         self._device = device
         self._datapoint = datapoint
@@ -165,6 +168,7 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def device_info(self):
+        """Return device information for the rocker this LED belongs to."""
         return {
             "identifiers": {(DOMAIN, device_slug(self._device))},
             "name": self._device.get("label", "Jung Device"),
@@ -181,13 +185,16 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self):
+        """Return whether the status LED is on."""
         return self._attr_is_on
 
     async def async_turn_on(self, **kwargs):
+        """Turn the status LED on."""
         _LOGGER.debug("Turning on switch %s", self._attr_unique_id)
         await self.coordinator.set_status_led(self._datapoint["id"], True)
 
     async def async_turn_off(self, **kwargs):
+        """Turn the status LED off."""
         _LOGGER.debug("Turning off switch %s", self._attr_unique_id)
         await self.coordinator.set_status_led(self._datapoint["id"], False)
 


### PR DESCRIPTION
Un-ignores ruff `D` (docstrings) and `G` (lazy logging) and fixes the fallout (module/method docstrings across the integration, event-entity logs to %-format, docstring convention D212→D213). Exception-style rules (ANN/BLE001/TRY/EM) stay relaxed like HA core. Local: ruff clean, 7 tests pass. `1.2.0b9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)