### PR TITLE
Icon + exception translations (Gold); 1.2.0b10

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -12,6 +12,8 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 # WebSocket reconnect backoff bounds (seconds).
@@ -52,11 +54,19 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             if err.status in (401, 403):
                 # Token revoked/expired — trigger Home Assistant's reauth flow.
                 raise ConfigEntryAuthFailed(
-                    "Jung Home gateway rejected the token"
+                    translation_domain=DOMAIN, translation_key="auth_failed"
                 ) from err
-            raise UpdateFailed(f"Error fetching data from Jung Home: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except aiohttp.ClientError as err:
-            raise UpdateFailed(f"Error connecting to Jung Home: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         if response is None:
             _LOGGER.error("Received None response from API")

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -81,7 +81,7 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
         else:
             self._attr_name = dp_type
         self._attr_unique_id = stable_unique_id(device, datapoint, "event")
-        self._attr_icon = "mdi:gesture-tap-button"
+        # Icon comes from icons.json (icon-translations).
         # Availability is inherited from CoordinatorEntity (tracks the gateway
         # connection); don't pin it True or it stays "available" when the
         # gateway is down.

--- a/custom_components/junghome/icons.json
+++ b/custom_components/junghome/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "event": {
+      "up": { "default": "mdi:gesture-tap-button" },
+      "down": { "default": "mdi:gesture-tap-button" },
+      "press": { "default": "mdi:gesture-tap-button" }
+    }
+  }
+}

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b9",
+  "version": "1.2.0b10",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -62,5 +62,13 @@
     "switch": {
       "status_led": { "name": "Status LED" }
     }
+  },
+  "exceptions": {
+    "auth_failed": {
+      "message": "The Jung Home gateway rejected the access token."
+    },
+    "cannot_connect": {
+      "message": "Error communicating with the Jung Home gateway: {error}"
+    }
   }
 }

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -62,5 +62,13 @@
     "switch": {
       "status_led": { "name": "Status LED" }
     }
+  },
+  "exceptions": {
+    "auth_failed": {
+      "message": "The Jung Home gateway rejected the access token."
+    },
+    "cannot_connect": {
+      "message": "Error communicating with the Jung Home gateway: {error}"
+    }
   }
 }


### PR DESCRIPTION
Two Gold rules: `icon-translations` (rocker-button icon moved to `icons.json`) and `exception-translations` (`ConfigEntryAuthFailed`/`UpdateFailed` now use `translation_key` + an `exceptions` strings section). Local: ruff clean, 7 tests pass, JSON valid. `1.2.0b10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)