### PR TITLE
Strict typing (Platinum) + capture gateway version; 1.2.0b11

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -16,7 +16,6 @@ ignore = [
 
     # Families this (largely pre-existing) codebase does not follow; relaxed so
     # CI lint is green without rewriting working code.
-    "ANN", # type annotations not used throughout
     "ARG", # unused arguments are common in Home Assistant callback signatures
     "FBT", # boolean positional args are common in HA APIs
     "EM", # exception messages as string literals
@@ -37,10 +36,10 @@ ignore = [
 [lint.per-file-ignores]
 # Reference prototypes: CLI-style scripts, intentional prints / passthroughs;
 # not held to the integration's docstring convention.
-"tools/**" = ["T201", "SLF001", "EXE001", "INP001", "D"]
+"tools/**" = ["T201", "SLF001", "EXE001", "INP001", "D", "ANN"]
 # Tests: asserts are the point; private-member access is fine; descriptive test
 # names stand in for docstrings.
-"tests/**" = ["S101", "S105", "S106", "SLF001", "INP001", "D"]
+"tests/**" = ["S101", "S105", "S106", "SLF001", "INP001", "D", "ANN"]
 "conftest.py" = ["INP001"]
 
 [lint.isort]

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -56,7 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
 
 
 def _migrate_to_stable_ids(
-    hass: HomeAssistant, entry: JungHomeConfigEntry, coordinator
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    coordinator: JungHomeDataUpdateCoordinator,
 ) -> None:
     """Re-point existing id-based registry entries to label-based stable ids.
 

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -2,10 +2,13 @@
 
 import asyncio
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -46,11 +49,13 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._host: str | None = None
         self._token: str | None = None
         self._error: str = "register_failed"
-        self._register_task: asyncio.Task | None = None
+        self._register_task: asyncio.Task[str] | None = None
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Collect the gateway host, then start registration."""
-        errors = {}
+        errors: dict[str, str] = {}
         if user_input is not None:
             self._host = _normalize_host(user_input[CONF_HOST])
             if not self._host:
@@ -64,7 +69,9 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
-    async def async_step_register(self, user_input=None):
+    async def async_step_register(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Wait for the user to approve the access request in the Jung Home app."""
         if self._register_task is None:
             self._register_task = self.hass.async_create_task(self._async_register())
@@ -85,14 +92,18 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._register_task = None
         return self.async_show_progress_done(next_step_id="finish")
 
-    async def async_step_finish(self, user_input=None):
+    async def async_step_finish(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Create the config entry once a token has been obtained."""
         return self.async_create_entry(
             title="Jung Home",
             data={CONF_HOST: self._host, CONF_TOKEN: self._token},
         )
 
-    async def async_step_register_failed(self, user_input=None):
+    async def async_step_register_failed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Show the failure reason and allow the user to retry."""
         if user_input is not None:
             return await self.async_step_register()
@@ -102,12 +113,16 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={"base": self._error},
         )
 
-    async def async_step_reauth(self, entry_data):
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
         """Start reauth when the gateway rejects the stored token."""
         self._host = entry_data[CONF_HOST]
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None):
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Re-register with the gateway to obtain a fresh token."""
         if self._register_task is None:
             self._register_task = self.hass.async_create_task(self._async_register())
@@ -128,14 +143,18 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._register_task = None
         return self.async_show_progress_done(next_step_id="reauth_finish")
 
-    async def async_step_reauth_finish(self, user_input=None):
+    async def async_step_reauth_finish(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Store the fresh token on the existing entry and reload it."""
         return self.async_update_reload_and_abort(
             self._get_reauth_entry(),
             data_updates={CONF_TOKEN: self._token},
         )
 
-    async def async_step_reauth_failed(self, user_input=None):
+    async def async_step_reauth_failed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Show the failure reason and allow retrying the reauth."""
         if user_input is not None:
             return await self.async_step_reauth_confirm()
@@ -145,14 +164,16 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={"base": self._error},
         )
 
-    async def async_step_reconfigure(self, user_input=None):
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Let the user update the gateway address (e.g. after an IP change).
 
         The existing token still works for the same gateway at a new address; if
         it points at a different gateway, the next refresh triggers reauth.
         """
         entry = self._get_reconfigure_entry()
-        errors = {}
+        errors: dict[str, str] = {}
         if user_input is not None:
             host = _normalize_host(user_input[CONF_HOST])
             if not host:
@@ -176,7 +197,9 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo):
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
         """Handle a gateway discovered via mDNS (_junghome._tcp)."""
         self._host = discovery_info.host
         hostname = (discovery_info.hostname or "").rstrip(".") or self._host
@@ -192,7 +215,9 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"host": hostname}
         return await self.async_step_zeroconf_confirm()
 
-    async def async_step_zeroconf_confirm(self, user_input=None):
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Confirm setup of a discovered gateway, then register."""
         if user_input is None:
             return self.async_show_form(

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -5,7 +5,7 @@ from homeassistant.util import slugify
 DOMAIN = "junghome"
 
 
-def datapoint_suffix(datapoint_id) -> str:
+def datapoint_suffix(datapoint_id: str) -> str:
     """Return the stable element index of a datapoint id.
 
     Datapoint ids look like ``id5f09764942a70ce-001``. The ``id...`` prefix is

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from datetime import timedelta
+from typing import Any
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -24,15 +25,19 @@ MAX_RECONNECT_DELAY = 60
 type JungHomeConfigEntry = ConfigEntry[JungHomeDataUpdateCoordinator]
 
 
-class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
+class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     """Class to manage fetching data from the Jung Home API."""
 
-    def __init__(self, hass: HomeAssistant, config: dict, config_entry: ConfigEntry):
+    def __init__(
+        self, hass: HomeAssistant, config: dict[str, Any], config_entry: ConfigEntry
+    ) -> None:
         """Initialize the coordinator."""
         self.hass = hass
         self.config = config
-        self.websocket = None
-        self._ws_task = None
+        self.websocket: aiohttp.ClientWebSocketResponse | None = None
+        # Gateway firmware version, reported by the WebSocket "version" frame.
+        self.gateway_version: str | None = None
+        self._ws_task: asyncio.Task[None] | None = None
         self._closing = False
         self._reconnect_delay = INITIAL_RECONNECT_DELAY
         super().__init__(
@@ -43,7 +48,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(minutes=1),
         )
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> list[dict[str, Any]]:
         """Fetch data from the API."""
         _LOGGER.debug("Fetching new device data from Jung Home API")
         try:
@@ -75,7 +80,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         # `async_set_updated_data` is automatically called with this.
         return response
 
-    async def _fetch_devices_from_api(self, host, token):
+    async def _fetch_devices_from_api(
+        self, host: str, token: str
+    ) -> list[dict[str, Any]]:
         """Fetch devices from the Jung Home API."""
         # Shared HA session; verify_ssl=False tolerates the gateway's self-signed
         # cert without building an SSL context on the event loop.
@@ -92,7 +99,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         # and is visible in the debug log above for inspection.
         return list(data)
 
-    async def _websocket_loop(self):
+    async def _websocket_loop(self) -> None:
         """Keep a WebSocket connection alive, reconnecting with backoff on drop.
 
         The gateway pushes state via WebSocket; without this loop a single
@@ -114,7 +121,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             await asyncio.sleep(self._reconnect_delay)
             self._reconnect_delay = min(self._reconnect_delay * 2, MAX_RECONNECT_DELAY)
 
-    async def _run_websocket(self):
+    async def _run_websocket(self) -> None:
         """Open one WebSocket session and pump messages until it closes."""
         session = async_get_clientsession(self.hass, verify_ssl=False)
         url = f"wss://{self.config['host']}/ws"
@@ -139,7 +146,14 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
                                     "Received WebSocket message is a list: %s", data
                                 )
                                 continue
-                            if data.get("type") in ["message", "version"]:
+                            if data.get("type") == "version":
+                                self.gateway_version = data.get("data")
+                                _LOGGER.info(
+                                    "Jung Home gateway firmware version: %s",
+                                    self.gateway_version,
+                                )
+                                continue
+                            if data.get("type") == "message":
                                 _LOGGER.debug("Received initial message: %s", data)
                                 continue
                             self._handle_websocket_message(data)
@@ -155,7 +169,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             finally:
                 self.websocket = None
 
-    def _handle_websocket_message(self, message):
+    def _handle_websocket_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages."""
         if not isinstance(message, dict):
             _LOGGER.error("Received WebSocket message is not a dictionary: %s", message)
@@ -199,7 +213,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
                 "Received WebSocket message with unknown data type: %s", message
             )
 
-    async def start(self):
+    async def start(self) -> None:
         """Connect to the WebSocket.
 
         Initial device data is fetched separately during setup via
@@ -210,7 +224,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self._closing = False
         self._ws_task = self.hass.loop.create_task(self._websocket_loop())
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop the coordinator and close the WebSocket connection."""
         _LOGGER.debug("Stopping coordinator and closing WebSocket")
         self._closing = True
@@ -225,7 +239,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
             await self.websocket.close()
         self.websocket = None
 
-    async def send_websocket_message(self, message):
+    async def send_websocket_message(self, message: dict[str, Any]) -> None:
         """Send a message via WebSocket."""
         _LOGGER.debug("Sending WebSocket message: %s", message)
         if self.websocket and not self.websocket.closed:
@@ -241,7 +255,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
                 "WebSocket is not connected; command dropped (reconnect in progress)"
             )
 
-    async def turn_on_switch(self, datapoint_id):
+    async def turn_on_switch(self, datapoint_id: str) -> None:
         """Turn on the switch."""
         _LOGGER.debug("Turning on switch with datapoint_id: %s", datapoint_id)
         message = {
@@ -254,7 +268,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         }
         await self.send_websocket_message(message)
 
-    async def turn_off_switch(self, datapoint_id):
+    async def turn_off_switch(self, datapoint_id: str) -> None:
         """Turn off the switch."""
         _LOGGER.debug("Turning off switch with datapoint_id: %s", datapoint_id)
         message = {
@@ -267,7 +281,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         }
         await self.send_websocket_message(message)
 
-    async def turn_on_light(self, datapoint_id):
+    async def turn_on_light(self, datapoint_id: str) -> None:
         """Turn on the light."""
         _LOGGER.debug("Turning on light with datapoint_id: %s", datapoint_id)
         message = {
@@ -280,7 +294,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         }
         await self.send_websocket_message(message)
 
-    async def turn_off_light(self, datapoint_id):
+    async def turn_off_light(self, datapoint_id: str) -> None:
         """Turn off the light."""
         _LOGGER.debug("Turning off light with datapoint_id: %s", datapoint_id)
         message = {
@@ -293,7 +307,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         }
         await self.send_websocket_message(message)
 
-    async def set_brightness(self, datapoint_id, brightness):
+    async def set_brightness(self, datapoint_id: str, brightness: int) -> None:
         """Set the brightness of the light."""
         message = {
             "type": "datapoint",
@@ -305,7 +319,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         }
         await self.send_websocket_message(message)
 
-    async def set_color_temp(self, datapoint_id, color_temp):
+    async def set_color_temp(self, datapoint_id: str, color_temp: int) -> None:
         """Set the color temperature of the light."""
         message = {
             "type": "datapoint",
@@ -317,7 +331,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator):
         }
         await self.send_websocket_message(message)
 
-    async def set_status_led(self, datapoint_id, state):
+    async def set_status_led(self, datapoint_id: str, state: bool) -> None:
         """Set the status LED on (True) or off (False)."""
         value = "1" if state else "0"
         message = {

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -27,6 +27,7 @@ async def async_get_config_entry_diagnostics(
             "data": async_redact_data(entry.data, TO_REDACT),
             "title": entry.title,
         },
+        "gateway_version": coordinator.gateway_version,
         "device_count": len(coordinator.data or []),
         "devices": coordinator.data or [],
     }

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -2,14 +2,18 @@
 
 import logging
 import time
+from datetime import datetime
+from typing import Any
 
 from homeassistant.components.event import EventEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, device_slug, stable_unique_id
-from .coordinator import JungHomeConfigEntry
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,14 +32,16 @@ _EVENT_TRANSLATION_KEYS = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: JungHomeConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Jung Home event entities from a config entry."""
     coordinator = entry.runtime_data
     known: set[str] = set()
 
     @callback
-    def _discover_events():
+    def _discover_events() -> None:
         """Add entities for any events not yet created (handles devices added later)."""
         new_entities = []
         for device in coordinator.data or []:
@@ -69,7 +75,12 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
     _attr_event_types = ["pressed", "depressed"]
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, device, datapoint):
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: dict[str, Any],
+        datapoint: dict[str, Any],
+    ) -> None:
         """Initialize the event entity."""
         super().__init__(coordinator)
         self._device = device
@@ -89,7 +100,7 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
         self._last_value = self._get_state_from_datapoint(datapoint)
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device information for this event entity."""
         return {
             "identifiers": {(DOMAIN, device_slug(self._device))},
@@ -138,11 +149,11 @@ class JungHomeEventEntity(CoordinatorEntity, EventEntity):
             self._last_value = new_state
 
     @property
-    def state(self):
+    def state(self) -> datetime | None:
         """Return the timestamp of the last button event."""
         return getattr(self, "_attr_event_timestamp", None)
 
-    def _get_state_from_datapoint(self, datapoint):
+    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
         """Extract state from datapoint values. Returns True if pressed."""
         for value in datapoint.get("values", []):
             if value["key"] in {"up_request", "down_request", "trigger_request"}:

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -2,13 +2,16 @@
 
 import logging
 import time
+from typing import Any
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
-from .coordinator import JungHomeConfigEntry
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,16 +23,18 @@ DEFAULT_MAX_KELVIN = 6500
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: JungHomeConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    config_entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Jung Home lights from a config entry."""
     coordinator = config_entry.runtime_data
     known: set[str] = set()
 
     @callback
-    def _discover_lights():
+    def _discover_lights() -> None:
         """Add entities for any lights not yet created (handles devices added later)."""
-        new_entities = []
+        new_entities: list[JungHomeLight] = []
         for device in coordinator.data or []:
             if device.get("type") in ("OnOff", "ColorLight"):
                 for datapoint in device.get("datapoints", []):
@@ -57,7 +62,12 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(self, coordinator, device, datapoint):
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: dict[str, Any],
+        datapoint: dict[str, Any],
+    ) -> None:
         """Initialize the light."""
         super().__init__(coordinator)
         self._device = device
@@ -87,10 +97,10 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         )
         # Device brightness scale is 0-100 (device) — Home Assistant uses 0-255
         # Track last local write to debounce weird rapid WS echoes
-        self._last_written_brightness_raw = None
+        self._last_written_brightness_raw: int | None = None
         self._last_written_brightness_ts = 0.0
         # Track last local write for color temperature (Kelvin)
-        self._last_written_color_temp_raw = None
+        self._last_written_color_temp_raw: int | None = None
         self._last_written_color_temp_ts = 0.0
         self._name = device.get("label", "Jung Light")
         # Firmware-stable id derived from the label, not the volatile device id.
@@ -99,10 +109,10 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
 
         if device["type"] == "ColorLight":
             # Read brightness and color_temp from their specific datapoints (if present)
-            self._brightness = self._get_brightness_from_datapoint(
+            self._brightness: int | None = self._get_brightness_from_datapoint(
                 self._brightness_datapoint
             )
-            self._color_temp = self._get_color_temp_from_datapoint(
+            self._color_temp: int | None = self._get_color_temp_from_datapoint(
                 self._color_temp_datapoint
             )
             self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
@@ -126,27 +136,27 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
             self._attr_color_mode = ColorMode.ONOFF
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str | None:
         """Return a unique ID for the light."""
         return self._unique_id
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return the state of the light."""
         return self._is_on
 
     @property
-    def brightness(self):
+    def brightness(self) -> int | None:
         """Return the brightness of the light."""
         return self._brightness
 
     @property
-    def color_temp_kelvin(self):
+    def color_temp_kelvin(self) -> int | None:
         """Return the color temperature in Kelvin (device-native)."""
         return self._color_temp
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device information about this light."""
         return {
             "identifiers": {(DOMAIN, device_slug(self._device))},  # Link to the device
@@ -267,7 +277,7 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
                 _LOGGER.debug("Updated state for light %s: %s", self._name, self._is_on)
                 self.async_write_ha_state()
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         _LOGGER.debug("Turning on light %s", self._name)
         # Turn on first, then apply brightness/color temperature to avoid
@@ -282,7 +292,7 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
                 await self._set_color_temp(kwargs["color_temp_kelvin"])
         self.async_write_ha_state()
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         _LOGGER.debug("Turning off light %s", self._name)
         await self.coordinator.turn_off_light(self._datapoint["id"])
@@ -290,23 +300,23 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         self.async_write_ha_state()
 
     @property
-    def should_poll(self):
+    def should_poll(self) -> bool:
         """No polling needed for this entity."""
         return False
 
     @property
-    def available(self):
+    def available(self) -> bool:
         """Return if the device is available."""
         return self.coordinator.last_update_success
 
-    def _get_state_from_datapoint(self, datapoint):
+    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
         """Extract the state of the light from its datapoint."""
         for value in datapoint.get("values", []):
             if value["key"] == "switch":
                 return value["value"] == "1"
         return False
 
-    def _get_brightness_from_datapoint(self, datapoint):
+    def _get_brightness_from_datapoint(self, datapoint: dict[str, Any] | None) -> int:
         """Extract the brightness of the light from its datapoint."""
         if not datapoint:
             return 0
@@ -327,7 +337,7 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         except Exception:
             return round(int(ha_brightness) * 100 / 255)
 
-    def _get_color_temp_from_datapoint(self, datapoint):
+    def _get_color_temp_from_datapoint(self, datapoint: dict[str, Any] | None) -> int:
         """Extract the color temperature of the light from its datapoint."""
         if not datapoint:
             return 3000
@@ -340,7 +350,7 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
                     return 3000
         return 3000
 
-    async def _set_brightness(self, brightness):
+    async def _set_brightness(self, brightness: int) -> None:
         """Set the brightness of the light."""
         _LOGGER.debug("Setting brightness for light %s to %s", self._name, brightness)
         if not self._brightness_datapoint_id:
@@ -365,7 +375,7 @@ class JungHomeLight(CoordinatorEntity, LightEntity):
         self._brightness = brightness
         self.async_write_ha_state()
 
-    async def _set_color_temp(self, kelvin):
+    async def _set_color_temp(self, kelvin: int) -> None:
         """Set the color temperature of the light (Kelvin, device-native)."""
         if not self._color_temp_datapoint_id:
             _LOGGER.warning(

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b10",
+  "version": "1.2.0b11",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -1,6 +1,7 @@
 """Sensor platform for Jung Home (socket energy quantities)."""
 
 import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -16,10 +17,12 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
-from .coordinator import JungHomeConfigEntry
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +36,7 @@ _TOTAL = SensorStateClass.TOTAL_INCREASING
 # (device_class, state_class, Home Assistant unit). Energy is TOTAL_INCREASING so
 # it feeds the energy dashboard; the rest are MEASUREMENT. Unknown units fall
 # back to a plain string sensor with no class.
-_UNIT_MAP = {
+_UNIT_MAP: dict[str, tuple[SensorDeviceClass, SensorStateClass, str]] = {
     "w": (SensorDeviceClass.POWER, _MEAS, UnitOfPower.WATT),
     "kw": (SensorDeviceClass.POWER, _MEAS, UnitOfPower.KILO_WATT),
     "wh": (SensorDeviceClass.ENERGY, _TOTAL, UnitOfEnergy.WATT_HOUR),
@@ -46,16 +49,18 @@ _UNIT_MAP = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: JungHomeConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Jung Home sensors from a config entry."""
     coordinator = entry.runtime_data
     known: set[str] = set()
 
     @callback
-    def _discover_sensors():
+    def _discover_sensors() -> None:
         """Add entities for any sensors not yet created (handles devices added later)."""
-        new_entities = []
+        new_entities: list[JungHomeQuantity] = []
         for device in coordinator.data or []:
             if device.get("type") == "Socket":
                 for datapoint in device.get("datapoints", []):
@@ -98,7 +103,14 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
     # baked into the entity name).
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, device, datapoint, label, unit):
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: dict[str, Any],
+        datapoint: dict[str, Any],
+        label: str,
+        unit: str,
+    ) -> None:
         """Initialize the quantity."""
         super().__init__(coordinator)
         self._device = device
@@ -118,17 +130,17 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
         self._value = self._get_value_from_datapoint(datapoint)
 
     @property
-    def name(self):
+    def name(self) -> str | None:
         """Return the entity name (the measured quantity; HA adds the device)."""
         return self._attr_name
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str | None:
         """Return a unique ID for the quantity."""
         return self._unique_id
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | str | None:
         """Return the measured value (numeric when the unit has a state class)."""
         if self._value is None:
             return None
@@ -140,7 +152,7 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
         return self._value
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device information about this quantity."""
         return {
             "identifiers": {(DOMAIN, device_slug(self._device))},  # Link to the device
@@ -173,7 +185,7 @@ class JungHomeQuantity(CoordinatorEntity, SensorEntity):
                 )
                 self.async_write_ha_state()
 
-    def _get_value_from_datapoint(self, datapoint):
+    def _get_value_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
         """Extract the value of the quantity from its datapoint."""
         for value in datapoint.get("values", []):
             if value["key"] == "quantity":

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -1,13 +1,16 @@
 """Switch platform for Jung Home (sockets and rocker status LEDs)."""
 
 import logging
+from typing import Any
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
-from .coordinator import JungHomeConfigEntry
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,31 +19,33 @@ PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: JungHomeConfigEntry, async_add_entities
-):
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
     """Set up Jung Home switches from a config entry."""
     coordinator = entry.runtime_data
     known: set[str] = set()
 
     @callback
-    def _discover_switches():
+    def _discover_switches() -> None:
         """Add entities for any switches not yet created (handles devices added later)."""
-        new_entities = []
+        new_entities: list[JungHomeSocket | JungHomeSwitch] = []
         for device in coordinator.data or []:
             if device.get("type") == "Socket":
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "switch":
-                        entity = JungHomeSocket(coordinator, device, datapoint)
-                        if entity.unique_id not in known:
-                            known.add(entity.unique_id)
-                            new_entities.append(entity)
+                        socket = JungHomeSocket(coordinator, device, datapoint)
+                        if socket.unique_id not in known:
+                            known.add(socket.unique_id)
+                            new_entities.append(socket)
             elif device.get("type") == "RockerSwitch":
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "status_led":
-                        entity = JungHomeSwitch(coordinator, device, datapoint)
-                        if entity.unique_id not in known:
-                            known.add(entity.unique_id)
-                            new_entities.append(entity)
+                        led = JungHomeSwitch(coordinator, device, datapoint)
+                        if led.unique_id not in known:
+                            known.add(led.unique_id)
+                            new_entities.append(led)
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
@@ -55,8 +60,14 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
     # (entity_id `switch.<device>`, not the old `switch.<device>_<device>`).
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_device_class = SwitchDeviceClass.OUTLET
 
-    def __init__(self, coordinator, device, datapoint):
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: dict[str, Any],
+        datapoint: dict[str, Any],
+    ) -> None:
         """Initialize the socket."""
         super().__init__(coordinator)
         self._device = device
@@ -67,22 +78,17 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
         self._is_on = self._get_state_from_datapoint(datapoint)
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str | None:
         """Return a unique ID for the socket."""
         return self._unique_id
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return the state of the socket."""
         return self._is_on
 
     @property
-    def device_class(self):
-        """Return the device class of the socket."""
-        return "outlet"
-
-    @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device information about this socket."""
         return {
             "identifiers": {(DOMAIN, device_slug(self._device))},  # Link to the device
@@ -115,14 +121,14 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
                 )
                 self.async_write_ha_state()
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the socket on."""
         _LOGGER.debug("Turning on socket %s", self._name)
         await self.coordinator.turn_on_switch(self._datapoint["id"])
         self._is_on = True
         self.async_write_ha_state()
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the socket off."""
         _LOGGER.debug("Turning off socket %s", self._name)
         await self.coordinator.turn_off_switch(self._datapoint["id"])
@@ -130,16 +136,16 @@ class JungHomeSocket(CoordinatorEntity, SwitchEntity):
         self.async_write_ha_state()
 
     @property
-    def should_poll(self):
+    def should_poll(self) -> bool:
         """No polling needed for this entity."""
         return False
 
     @property
-    def available(self):
+    def available(self) -> bool:
         """Return if the device is available."""
         return self.coordinator.last_update_success
 
-    def _get_state_from_datapoint(self, datapoint):
+    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
         """Extract the state of the socket from its datapoint."""
         for value in datapoint.get("values", []):
             if value["key"] == "switch":
@@ -156,7 +162,12 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "status_led"
 
-    def __init__(self, coordinator, device, datapoint):
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: dict[str, Any],
+        datapoint: dict[str, Any],
+    ) -> None:
         """Initialize the status LED switch."""
         super().__init__(coordinator)
         self._device = device
@@ -167,7 +178,7 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_is_on = self._get_state_from_datapoint(datapoint)
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device information for the rocker this LED belongs to."""
         return {
             "identifiers": {(DOMAIN, device_slug(self._device))},
@@ -177,23 +188,23 @@ class JungHomeSwitch(CoordinatorEntity, SwitchEntity):
             "sw_version": self._device.get("sw_version", "Unknown Version"),
         }
 
-    def _get_state_from_datapoint(self, datapoint):
+    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
         for value in datapoint.get("values", []):
             if value["key"] == "status_led":
                 return value["value"] == "1"
         return False
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return whether the status LED is on."""
         return self._attr_is_on
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the status LED on."""
         _LOGGER.debug("Turning on switch %s", self._attr_unique_id)
         await self.coordinator.set_status_led(self._datapoint["id"], True)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the status LED off."""
         _LOGGER.debug("Turning off switch %s", self._attr_unique_id)
         await self.coordinator.set_status_led(self._datapoint["id"], False)


### PR DESCRIPTION
Full type annotations across the integration (ruff `ANN` enforced, `ANN401` kept for the `dict[str, Any]` device payloads); typed `JungHomeConfigEntry`, parameterised coordinator, typed platform/config-flow signatures. tools/ + tests stay ANN-exempt. Also captures the gateway firmware version from the WS `version` frame (`coordinator.gateway_version`), logs it at INFO, and adds it to diagnostics. Local: ruff clean, 7 tests pass, all modules import. `1.2.0b11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)