### PR TITLE
Stale-devices pruning + Gold docs; 1.2.0b13

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ Import the blueprint by URL (Settings → Automations & scenes → Blueprints �
 Import), select **all** of the button's event entities (JUNG alternates between
 the up/down events), and assign actions for single / double / hold.
 
+# How updates work
+
+The integration is **local push**: it holds a WebSocket to the gateway and
+applies state changes the moment the gateway broadcasts them, so device states
+update in real time. It also re-fetches the full device list over REST once a
+minute as a backstop, and on every WebSocket reconnect. If the WebSocket drops it
+reconnects automatically with backoff. No cloud and no account are involved.
+
+# Known limitations
+
+- **Scenes and groups** defined in the JUNG app aren't exposed; use Home
+  Assistant scenes/areas instead.
+- **Button gestures** (single/double/hold) aren't native — derive them with the
+  [blueprint](#button-automations-rocker-switches).
+- The rocker **status-LED colour** can't be set from here (on/off only); colour
+  is configured in the JUNG app or over BT-Mesh.
+- Curtains/covers, thermostats and the puck aren't supported yet.
+- The gateway uses a **self-signed certificate**, so TLS verification is disabled
+  for the local connection (expected for a LAN device).
+
+# Removing the integration
+
+Settings → Devices & Services → **Jung Home** → ⋮ → **Delete**. This removes all
+of its devices and entities. The access token is dropped with the config entry;
+to also revoke it on the gateway, remove "Home Assistant" under **Settings →
+Gateway → Access Permissions** in the JUNG app.
+
 # Gateway internals (for contributors)
 
 The local gateway API (REST + WebSocket), its registration flow, and the

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
@@ -51,6 +51,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
 
     # Forward the setup to the appropriate platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Prune HA devices the gateway no longer reports (quality-scale stale-devices).
+    @callback
+    def _prune_stale_devices() -> None:
+        if not coordinator.data:
+            return  # don't prune on an empty/failed poll
+        current = {device_slug(d) for d in coordinator.data}
+        dev_reg = dr.async_get(hass)
+        for device_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+            slugs = {
+                identifier
+                for domain, identifier in device_entry.identifiers
+                if domain == DOMAIN
+            }
+            if slugs and not (slugs & current):
+                dev_reg.async_update_device(
+                    device_entry.id, remove_config_entry_id=entry.entry_id
+                )
+
+    _prune_stale_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_prune_stale_devices))
 
     return True
 

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b12",
+  "version": "1.2.0b13",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
Two more Gold rules: **stale-devices** (prune HA devices the gateway no longer reports, on setup + each update, guarded against empty polls) and the **docs** rules (README gains How updates work / Known limitations / Removing the integration). Local: ruff clean, 7 tests pass. `1.2.0b13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)