### PR TITLE
Config-flow + coordinator tests; 1.2.0b14

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "requirements": [],
-  "version": "1.2.0b13",
+  "version": "1.2.0b14",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = tests
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest
+pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared fixtures for the Jung Home test suite."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading the junghome custom integration in every test."""
+    return

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,14 @@
-"""Tests for the config-flow host normalisation helper."""
+"""Tests for the Jung Home config flow."""
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome.config_flow import _normalize_host
+from custom_components.junghome.const import DOMAIN
 
 
 def test_normalize_host_strips_scheme_whitespace_and_slash():
@@ -14,3 +22,75 @@ def test_normalize_host_strips_scheme_whitespace_and_slash():
     }
     for raw, expected in cases.items():
         assert _normalize_host(raw) == expected
+
+
+async def test_user_flow_invalid_host(hass: HomeAssistant) -> None:
+    """A blank host is rejected with an error and re-shows the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "   "}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_host"}
+
+
+async def test_user_flow_already_configured(hass: HomeAssistant) -> None:
+    """A gateway already configured aborts the flow."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "1.2.3.4"}
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_discovery_starts_confirm(hass: HomeAssistant) -> None:
+    """A discovered gateway pre-fills the host and asks to confirm."""
+    info = ZeroconfServiceInfo(
+        ip_address="1.2.3.4",
+        ip_addresses=["1.2.3.4"],
+        port=443,
+        hostname="junghome.local.",
+        type="_junghome._tcp.local.",
+        name="junghome._junghome._tcp.local.",
+        properties={},
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "zeroconf"}, data=info
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+
+async def test_zeroconf_aborts_when_already_configured(hass: HomeAssistant) -> None:
+    """Re-discovering an already-configured gateway aborts."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="junghome.local",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    ).add_to_hass(hass)
+    info = ZeroconfServiceInfo(
+        ip_address="1.2.3.4",
+        ip_addresses=["1.2.3.4"],
+        port=443,
+        hostname="junghome.local.",
+        type="_junghome._tcp.local.",
+        name="junghome._junghome._tcp.local.",
+        properties={},
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "zeroconf"}, data=info
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,61 @@
+"""Tests for the Jung Home data update coordinator."""
+
+from unittest.mock import Mock, patch
+
+import aiohttp
+import pytest
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.junghome.const import DOMAIN
+from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
+
+
+def _coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
+    entry.add_to_hass(hass)
+    return JungHomeDataUpdateCoordinator(hass, {"host": "h", "token": "t"}, entry)
+
+
+async def test_update_raises_auth_failed_on_401(hass: HomeAssistant) -> None:
+    coordinator = _coordinator(hass)
+    err = aiohttp.ClientResponseError(Mock(), (), status=401)
+    with (
+        patch.object(coordinator, "_fetch_devices_from_api", side_effect=err),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+async def test_update_raises_update_failed_on_client_error(hass: HomeAssistant) -> None:
+    coordinator = _coordinator(hass)
+    with (
+        patch.object(
+            coordinator,
+            "_fetch_devices_from_api",
+            side_effect=aiohttp.ClientError("boom"),
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+async def test_reload_scheduled_when_device_ids_change(hass: HomeAssistant) -> None:
+    coordinator = _coordinator(hass)
+    coordinator._device_ids = {"katilas": "idOLD"}
+    with patch.object(hass.config_entries, "async_schedule_reload") as reload:
+        coordinator._reload_if_device_ids_changed([{"id": "idNEW", "label": "Katilas"}])
+    reload.assert_called_once()
+
+
+async def test_no_reload_when_device_ids_stable(hass: HomeAssistant) -> None:
+    coordinator = _coordinator(hass)
+    coordinator._device_ids = {"katilas": "idSAME"}
+    with patch.object(hass.config_entries, "async_schedule_reload") as reload:
+        coordinator._reload_if_device_ids_changed(
+            [{"id": "idSAME", "label": "Katilas"}]
+        )
+    reload.assert_not_called()


### PR DESCRIPTION
Adds `pytest-homeassistant-custom-component` and real tests: config flow (invalid host, already-configured abort, zeroconf discovery + dedupe) and coordinator (401 → ConfigEntryAuthFailed, client error → UpdateFailed, firmware device-id change → schedule reload). 15 tests, all pass locally in 0.2s. `1.2.0b14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)