### PR TITLE
Model gateway payloads with TypedDicts (load-bearing strict typing)

### DIFF
--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -1,8 +1,8 @@
 """Constants and firmware-stable identity helpers for Jung Home."""
 
-from typing import Any
-
 from homeassistant.util import slugify
+
+from .models import Datapoint, Device
 
 DOMAIN = "junghome"
 
@@ -17,7 +17,7 @@ def datapoint_suffix(datapoint_id: str) -> str:
     return str(datapoint_id).rsplit("-", 1)[-1]
 
 
-def device_slug(device: dict[str, Any]) -> str:
+def device_slug(device: Device) -> str:
     """Return a firmware-stable slug for a device, based on its label.
 
     The gateway exposes no hardware identifier (serial/MAC/address); the user
@@ -56,7 +56,7 @@ def device_slug(device: dict[str, Any]) -> str:
 
 
 def stable_unique_id(
-    device: dict[str, Any], datapoint: dict[str, Any], qualifier: str | None = None
+    device: Device, datapoint: Datapoint, qualifier: str | None = None
 ) -> str:
     """Build a firmware-stable unique id from a device label and datapoint suffix."""
     parts = [device_slug(device), datapoint_suffix(datapoint["id"])]

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -15,6 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, device_slug
+from .models import Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ MAX_RECONNECT_DELAY = 60
 type JungHomeConfigEntry = ConfigEntry[JungHomeDataUpdateCoordinator]
 
 
-class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
+class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     """Class to manage fetching data from the Jung Home API."""
 
     def __init__(
@@ -57,7 +58,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]])
             update_interval=timedelta(minutes=1),
         )
 
-    async def _async_update_data(self) -> list[dict[str, Any]]:
+    async def _async_update_data(self) -> list[Device]:
         """Fetch data from the API."""
         _LOGGER.debug("Fetching new device data from Jung Home API")
         try:
@@ -96,7 +97,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]])
         # `async_set_updated_data` is automatically called with this.
         return response
 
-    def _reload_if_device_ids_changed(self, devices: list[dict[str, Any]]) -> None:
+    def _reload_if_device_ids_changed(self, devices: list[Device]) -> None:
         """Reload the entry if the gateway regenerated its device ids.
 
         The gateway assigns new volatile device/datapoint ids on a firmware
@@ -117,9 +118,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]])
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
-    async def _fetch_devices_from_api(
-        self, host: str, token: str
-    ) -> list[dict[str, Any]]:
+    async def _fetch_devices_from_api(self, host: str, token: str) -> list[Device]:
         """Fetch devices from the Jung Home API."""
         # Shared HA session; verify_ssl=False tolerates the gateway's self-signed
         # cert without building an SSL context on the event loop.
@@ -141,8 +140,10 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]])
             )
         # Keep the full device payload so any firmware-stable identifier
         # (serial / address / etc.) is available for building unique IDs,
-        # and is visible in the debug log above for inspection.
-        return [device for device in data if isinstance(device, dict)]
+        # and is visible in the debug log above for inspection. This is the
+        # trust boundary: untyped gateway JSON becomes the typed `Device` model.
+        # Downstream code keeps defensive `.get(...)` access for malformed items.
+        return cast("list[Device]", [d for d in data if isinstance(d, dict)])
 
     async def _websocket_loop(self) -> None:
         """Keep a WebSocket connection alive, reconnecting with backoff on drop.
@@ -263,10 +264,13 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]])
             for device in self.data or []:
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("id") == datapoint_id:
-                        # Update all keys in the datapoint with the new data
+                        # Merge the pushed keys into the stored datapoint. The push
+                        # carries arbitrary keys (typically `values`), so mutate via
+                        # a dict view rather than the TypedDict.
+                        dp_dict = cast("dict[str, Any]", datapoint)
                         for key, value in data.items():
                             if key != "id":
-                                datapoint[key] = value
+                                dp_dict[key] = value
                         _LOGGER.debug(
                             "Updated datapoint for device %s: %s",
                             device.get("id"),

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -1,7 +1,6 @@
 """Event platform for Jung Home rocker buttons."""
 
 import logging
-from typing import Any
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
@@ -11,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,8 +78,8 @@ class JungHomeEventEntity(
     def __init__(
         self,
         coordinator: JungHomeDataUpdateCoordinator,
-        device: dict[str, Any],
-        datapoint: dict[str, Any],
+        device: Device,
+        datapoint: Datapoint,
     ) -> None:
         """Initialize the event entity."""
         super().__init__(coordinator)
@@ -145,7 +145,7 @@ class JungHomeEventEntity(
             datapoint = next(
                 (
                     dp
-                    for dp in (device or {}).get("datapoints", [])
+                    for dp in (device["datapoints"] if device else [])
                     if dp.get("id") == self._datapoint["id"]
                 ),
                 None,
@@ -160,7 +160,7 @@ class JungHomeEventEntity(
                 self._trigger_event(event_type)
         self.async_write_ha_state()
 
-    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         """Extract state from datapoint values. Returns True if pressed.
 
         Scoped to this datapoint's own type so bundled request keys don't merge.

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,8 +66,8 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
     def __init__(
         self,
         coordinator: JungHomeDataUpdateCoordinator,
-        device: dict[str, Any],
-        datapoint: dict[str, Any],
+        device: Device,
+        datapoint: Datapoint,
     ) -> None:
         """Initialize the light."""
         super().__init__(coordinator)
@@ -249,14 +250,14 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         """
         return self.coordinator.ws_connected or self.coordinator.last_update_success
 
-    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         """Extract the state of the light from its datapoint."""
         for value in datapoint.get("values", []):
             if value["key"] == "switch":
-                return str(value["value"]) == "1"
+                return value["value"] == "1"
         return False
 
-    def _get_brightness_from_datapoint(self, datapoint: dict[str, Any] | None) -> int:
+    def _get_brightness_from_datapoint(self, datapoint: Datapoint | None) -> int:
         """Extract the brightness of the light from its datapoint."""
         if not datapoint:
             return 0
@@ -272,11 +273,12 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
 
     def _ha_to_raw_brightness(self, ha_brightness: int) -> int:
         """Convert Home Assistant 0-255 brightness to device raw scale (0-100)."""
-        return round(int(ha_brightness) * 100 / 255)
+        raw = round(ha_brightness * 100 / 255)
+        # A non-zero HA brightness (1-2) rounds to 0 on the 0-100 device scale,
+        # which the device reads as off; floor it at 1 so "very dim" stays on.
+        return max(1, raw) if ha_brightness > 0 else 0
 
-    def _get_color_temp_from_datapoint(
-        self, datapoint: dict[str, Any] | None
-    ) -> int | None:
+    def _get_color_temp_from_datapoint(self, datapoint: Datapoint | None) -> int | None:
         """Extract the color temperature of the light from its datapoint."""
         if not datapoint:
             return None

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b15",
+  "version": "1.2.0b16",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/models.py
+++ b/custom_components/junghome/models.py
@@ -1,0 +1,36 @@
+"""Typed models for the JUNG HOME gateway REST/WebSocket payloads.
+
+These ``TypedDict``s describe the shape of the device data the gateway returns
+from ``GET /functions`` (and re-broadcasts over the WebSocket). They are a
+*static* contract: the data still arrives as untrusted JSON, so call sites keep
+their defensive ``.get(...)`` access for malformed payloads — but typing the
+stored device list as ``list[Device]`` makes key typos and wrong-key access
+``mypy`` errors instead of silent ``Any``.
+"""
+
+from typing import NotRequired, TypedDict
+
+
+class DatapointValue(TypedDict):
+    """A single ``key``/``value`` pair inside a datapoint (values are strings)."""
+
+    key: str
+    value: str
+
+
+class Datapoint(TypedDict):
+    """A device datapoint (e.g. ``switch``, ``brightness``, ``up_request``)."""
+
+    id: str
+    type: str
+    values: list[DatapointValue]
+
+
+class Device(TypedDict):
+    """A gateway device (``OnOff``, ``ColorLight``, ``Socket``, ``RockerSwitch``)."""
+
+    id: str
+    type: str
+    label: str
+    datapoints: list[Datapoint]
+    sw_version: NotRequired[str]

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -1,7 +1,6 @@
 """Sensor platform for Jung Home (socket energy quantities)."""
 
 import logging
-from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -23,6 +22,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Jung Home sensors from a config entry."""
     coordinator = entry.runtime_data
-    known: set[str | None] = set()
+    known: set[str] = set()
 
     @callback
     def _discover_sensors() -> None:
@@ -85,12 +85,16 @@ async def async_setup_entry(
                             None,
                         )
                         if label and unit:
-                            entity = JungHomeQuantity(
-                                coordinator, device, datapoint, label, unit
+                            uid = stable_unique_id(
+                                device, datapoint, label.replace(" ", "_").lower()
                             )
-                            if entity.unique_id not in known:
-                                known.add(entity.unique_id)
-                                new_entities.append(entity)
+                            if uid not in known:
+                                known.add(uid)
+                                new_entities.append(
+                                    JungHomeQuantity(
+                                        coordinator, device, datapoint, label, unit
+                                    )
+                                )
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
@@ -109,8 +113,8 @@ class JungHomeQuantity(CoordinatorEntity[JungHomeDataUpdateCoordinator], SensorE
     def __init__(
         self,
         coordinator: JungHomeDataUpdateCoordinator,
-        device: dict[str, Any],
-        datapoint: dict[str, Any],
+        device: Device,
+        datapoint: Datapoint,
         label: str,
         unit: str,
     ) -> None:
@@ -212,7 +216,7 @@ class JungHomeQuantity(CoordinatorEntity[JungHomeDataUpdateCoordinator], SensorE
                 )
                 self.async_write_ha_state()
 
-    def _get_value_from_datapoint(self, datapoint: dict[str, Any]) -> str | None:
+    def _get_value_from_datapoint(self, datapoint: Datapoint) -> str | None:
         """Extract the value of the quantity from its datapoint."""
         for value in datapoint.get("values", []):
             if value["key"] == "quantity":

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, device_slug, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Jung Home switches from a config entry."""
     coordinator = entry.runtime_data
-    known: set[str | None] = set()
+    known: set[str] = set()
 
     @callback
     def _discover_switches() -> None:
@@ -35,17 +36,21 @@ async def async_setup_entry(
             if device.get("type") == "Socket":
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "switch":
-                        socket = JungHomeSocket(coordinator, device, datapoint)
-                        if socket.unique_id not in known:
-                            known.add(socket.unique_id)
-                            new_entities.append(socket)
+                        uid = stable_unique_id(device, datapoint)
+                        if uid not in known:
+                            known.add(uid)
+                            new_entities.append(
+                                JungHomeSocket(coordinator, device, datapoint)
+                            )
             elif device.get("type") == "RockerSwitch":
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "status_led":
-                        led = JungHomeSwitch(coordinator, device, datapoint)
-                        if led.unique_id not in known:
-                            known.add(led.unique_id)
-                            new_entities.append(led)
+                        uid = stable_unique_id(device, datapoint, "switch")
+                        if uid not in known:
+                            known.add(uid)
+                            new_entities.append(
+                                JungHomeSwitch(coordinator, device, datapoint)
+                            )
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
@@ -65,8 +70,8 @@ class JungHomeSocket(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
     def __init__(
         self,
         coordinator: JungHomeDataUpdateCoordinator,
-        device: dict[str, Any],
-        datapoint: dict[str, Any],
+        device: Device,
+        datapoint: Datapoint,
     ) -> None:
         """Initialize the socket."""
         super().__init__(coordinator)
@@ -157,11 +162,11 @@ class JungHomeSocket(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
         """
         return self.coordinator.ws_connected or self.coordinator.last_update_success
 
-    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         """Extract the state of the socket from its datapoint."""
         for value in datapoint.get("values", []):
             if value["key"] == "switch":
-                return str(value["value"]) == "1"
+                return value["value"] == "1"
         return False
 
 
@@ -177,8 +182,8 @@ class JungHomeSwitch(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
     def __init__(
         self,
         coordinator: JungHomeDataUpdateCoordinator,
-        device: dict[str, Any],
-        datapoint: dict[str, Any],
+        device: Device,
+        datapoint: Datapoint,
     ) -> None:
         """Initialize the status LED switch."""
         super().__init__(coordinator)
@@ -200,10 +205,10 @@ class JungHomeSwitch(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
             or "Unknown Version",
         }
 
-    def _get_state_from_datapoint(self, datapoint: dict[str, Any]) -> bool:
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         for value in datapoint.get("values", []):
             if value["key"] == "status_led":
-                return str(value["value"]) == "1"
+                return value["value"] == "1"
         return False
 
     @property
@@ -253,7 +258,7 @@ class JungHomeSwitch(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
         datapoint = next(
             (
                 dp
-                for dp in (device or {}).get("datapoints", [])
+                for dp in (device["datapoints"] if device else [])
                 if dp.get("id") == self._datapoint["id"]
             ),
             None,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -779,6 +779,15 @@ async def test_light_set_without_datapoints_warns_and_noops(
     sc.assert_not_called()
 
 
+async def test_brightness_floor_keeps_dim_on(hass: HomeAssistant) -> None:
+    """A non-zero HA brightness never rounds to device raw 0 (which reads as off)."""
+    light = _color_light(_bare_coordinator(hass))
+    assert light._ha_to_raw_brightness(0) == 0
+    # round(1 * 100 / 255) == 0 without the floor; the floor keeps it on at 1.
+    assert light._ha_to_raw_brightness(1) == 1
+    assert light._ha_to_raw_brightness(255) == 100
+
+
 async def test_sensor_value_extractor_defensive(hass: HomeAssistant) -> None:
     """Sensor helpers return None for a missing value / None state."""
     coordinator = _bare_coordinator(hass)


### PR DESCRIPTION
A deeper "maximum quality / no doubts" pass on the platinum integration. The one
substantive gap found: although `mypy --strict` already passes, **every gateway
payload was `dict[str, Any]`** — so the typing was strict-*legal* but not
load-bearing. A `device["datpoints"]` typo, a missing key, or `value["valeu"]`
all type-checked clean.

## Type safety
- New `custom_components/junghome/models.py` with `Device` / `Datapoint` /
  `DatapointValue` TypedDicts modelling the REST/WebSocket payload shape.
- Coordinator generic is now `DataUpdateCoordinator[list[Device]]`; `const.py`
  identity helpers and all four platforms take `Device` / `Datapoint`.
- One documented `cast` at the REST fetch boundary (after the existing
  `isinstance(data, list)` guard) is the single trust boundary where untyped
  gateway JSON becomes the typed model. Defensive `.get(...)` access is retained
  for malformed runtime payloads — the TypedDicts are a static contract, not a
  runtime validator.
- Because values are now statically `str`, the `str(value["value"])` wraps added
  earlier for `no-any-return` are removed.

Result: explicit-`Any` drops **38 → 21** under `--disallow-any-explicit`; the 21
that remain are all genuine boundaries (HA-mandated `**kwargs: Any` /
`user_input: dict[str, Any]`, the raw untrusted WS message, diagnostics output,
and the one documented mutation cast). Key typos / wrong-key access are now
`mypy` errors.

## Polish
- Floor a non-zero HA brightness so 1-2 no longer rounds to device raw `0`
  (which the device reads as off) — "very dim" stays on.
- Unify `switch`/`sensor` discovery on `known: set[str]` (compute the stable uid
  first, matching `light.py`) instead of `set[str | None]`.

## Considered, no change
- **Per-device colour-temp range**: the gateway exposes `color_temperature_range`
  only as a group capability flag, never as a datapoint with min/max bounds
  (verified against `disk_dump/`); the fixed 2000–6500 K (floor confirmed) stands.
- **`--warn-unreachable`** flags 3 sites: one is a false positive (a `break` on a
  flag mutated concurrently by `stop()`), the other two are intentional
  defense-in-depth guards against malformed gateway JSON. Kept deliberately;
  not a CI check.

`mypy --strict` clean (10 files), `ruff check` + `ruff format --check` clean,
80 tests pass, coverage 98%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)