### PR TITLE
Add cover, climate, scene platforms; fix DimmerLight + Measurement (b17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,21 @@ JUNG HOME Gateway over its REST API and WebSocket.
     app-approval registration.
   - `const.py` — `DOMAIN` and the stable-ID helpers (`device_slug`,
     `datapoint_suffix`, `stable_unique_id`).
-  - `light.py`, `switch.py`, `sensor.py`, `event.py` — platforms (each does live
-    discovery of devices added at runtime). `event.py` exposes RockerSwitch
-    buttons; the gateway only reports raw `pressed` / `depressed` edges (no
-    native single/double/hold) and alternates a button between its `up_request`
-    and `down_request` events on consecutive presses.
+  - `light.py`, `switch.py`, `sensor.py`, `event.py`, `cover.py`, `climate.py`,
+    `scene.py` — platforms (each does live discovery of devices added at
+    runtime). `event.py` exposes RockerSwitch buttons; the gateway only reports
+    raw `pressed` / `depressed` edges (no native single/double/hold) and
+    alternates a button between its `up_request` and `down_request` events on
+    consecutive presses. Function-type → platform map:
+    `OnOff`/`DimmerLight`/`ColorLight` → light (capabilities follow the
+    datapoints present, not the type name); `Socket` → switch + sensor;
+    `Measurement` → sensor; `Position`/`PositionAndAngle` → cover;
+    `Thermostat` → climate; `RockerSwitch` → event + switch (status LED).
+    Scenes come from the WebSocket `scenes` broadcast and recall over REST
+    (`POST /scenes/{id}`; the WebSocket `scene` command is unimplemented).
+    **Cover position convention is an unverified assumption** — the gateway
+    `level` is treated as percent-*closed* (HA position = `100 - level`); the
+    single inversion point is `_to_ha`/`_to_device` in `cover.py`.
 - `blueprints/automation/junghome/button_gestures.yaml` — shipped HA blueprint
   deriving single/double/hold from those raw edges. Users import it by URL; it is
   **not** distributed by HACS (HACS only installs `custom_components/`).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ Currently functional things:
 - BT S1 B2 U switch actuators.
 - Dimmers (DALI, etc.) - color and brightness as well as On/Off.
 - Sockets - On/Off, energy statistics, etc.
+- Blinds / shutters (covers) - open/close/stop, position, and slat tilt.
+- Thermostats (room temperature regulators) - target temperature and presets.
+- Scenes - recall any Jung Home scene from Home Assistant.
+- Measurement sensors (e.g. ambient brightness on presence detectors).
 - IoT integration for Rocker Switches - allows triggering any script or automation in HomeAssistant via button presses.
 - Button LED On/Off (unfortunately, color can only be configured via app or BT Mesh/NRF).
+
+> Note: covers, thermostats, scenes and measurement sensors are implemented from
+> the gateway protocol but have **not yet been verified against real hardware**.
+> If you have such a device, feedback is very welcome — in particular whether a
+> blind's open/closed position reads the right way round (the direction is an
+> assumption; see `docs/gateway-websocket.md`).
 
 All communication is via WebSockets. I've managed to reliably automate:
 - Single click

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -18,6 +18,9 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SENSOR,
     Platform.EVENT,
+    Platform.COVER,
+    Platform.CLIMATE,
+    Platform.SCENE,
 ]
 
 

--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -15,11 +15,11 @@ sensor entity).
 import logging
 from typing import Any
 
-from homeassistant.components.climate import (
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
     PRESET_COMFORT,
     PRESET_ECO,
     PRESET_NONE,
-    ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
 )

--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -1,0 +1,260 @@
+"""Climate platform for Jung Home (Thermostat / room temperature regulator).
+
+A ``Thermostat`` function exposes a ``temperature_ctrl`` datapoint with two
+keys (see ``cdb_types_datapoints.json``):
+
+- ``temperature_ctrl`` — the target temperature in °C (range 5..30).
+- ``temperature_ctrl_preset`` — ``none`` / ``frost`` / ``eco`` / ``comfort``.
+
+The function carries no ambient reading, so ``current_temperature`` is only
+populated if the device also exposes a temperature ``quantity`` datapoint;
+otherwise it stays ``None`` (the measured value, if any, shows up as a separate
+sensor entity).
+"""
+
+import logging
+from typing import Any
+
+from homeassistant.components.climate import (
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_NONE,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, device_slug, stable_unique_id
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
+
+_LOGGER = logging.getLogger(__name__)
+
+# Commands are cheap async WebSocket sends; don't serialise them.
+PARALLEL_UPDATES = 0
+
+DEFAULT_MIN_TEMP = 5.0
+DEFAULT_MAX_TEMP = 30.0
+
+# "frost" (frost protection) has no standard HA preset constant; expose it under
+# its gateway name. The others map onto HA's well-known presets.
+PRESET_FROST = "frost"
+# HA preset <-> gateway preset value (they coincide, but keep the map explicit
+# so a future HA constant rename doesn't silently desync the wire value).
+_HA_TO_DEVICE_PRESET = {
+    PRESET_NONE: "none",
+    PRESET_FROST: "frost",
+    PRESET_ECO: "eco",
+    PRESET_COMFORT: "comfort",
+}
+_DEVICE_TO_HA_PRESET = {v: k for k, v in _HA_TO_DEVICE_PRESET.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Jung Home thermostats from a config entry."""
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _discover_climates() -> None:
+        """Add entities for any thermostats not yet created."""
+        new_entities: list[JungHomeClimate] = []
+        for device in coordinator.data or []:
+            if device.get("type") != "Thermostat":
+                continue
+            ctrl_dp = next(
+                (
+                    dp
+                    for dp in device.get("datapoints", [])
+                    if dp.get("type") == "temperature_ctrl"
+                ),
+                None,
+            )
+            if ctrl_dp is None:
+                continue
+            uid = stable_unique_id(device, ctrl_dp)
+            if uid in known:
+                continue
+            known.add(uid)
+            new_entities.append(JungHomeClimate(coordinator, device, ctrl_dp))
+        if new_entities:
+            async_add_entities(new_entities, update_before_add=True)
+
+    _discover_climates()
+    entry.async_on_unload(coordinator.async_add_listener(_discover_climates))
+
+
+class JungHomeClimate(CoordinatorEntity[JungHomeDataUpdateCoordinator], ClimateEntity):
+    """Representation of a Jung Home thermostat."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 0.5
+    _attr_min_temp = DEFAULT_MIN_TEMP
+    _attr_max_temp = DEFAULT_MAX_TEMP
+    # The RTR regulates heating; there is no gateway "off" for the function, so a
+    # single HEAT mode is exposed (HA requires a non-empty hvac_modes list).
+    _attr_hvac_modes = [HVACMode.HEAT]
+    _attr_hvac_mode = HVACMode.HEAT
+    _attr_preset_modes = [PRESET_NONE, PRESET_FROST, PRESET_ECO, PRESET_COMFORT]
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+    )
+
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: Device,
+        ctrl_datapoint: Datapoint,
+    ) -> None:
+        """Initialize the thermostat."""
+        super().__init__(coordinator)
+        self._device = device
+        self._datapoint = ctrl_datapoint
+        self._ctrl_datapoint_id = ctrl_datapoint["id"]
+        self._name = device.get("label", "Jung Thermostat")
+        self._unique_id = stable_unique_id(device, ctrl_datapoint)
+        self._target_temperature = self._get_target_from_datapoint(ctrl_datapoint)
+        self._preset_mode = self._get_preset_from_datapoint(ctrl_datapoint)
+        self._current_temperature = self._get_current_temperature(device)
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID for the thermostat."""
+        return self._unique_id
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target temperature."""
+        return self._target_temperature
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current ambient temperature, if the device reports one."""
+        return self._current_temperature
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the active preset."""
+        return self._preset_mode
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this thermostat."""
+        return {
+            "identifiers": {(DOMAIN, device_slug(self._device))},
+            "name": self._device.get("label", "Jung Device"),
+            "manufacturer": "Jung",
+            "model": self._device.get("type", "Unknown Model"),
+            "sw_version": self._device.get("sw_version")
+            or self.coordinator.gateway_version
+            or "Unknown Version",
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if the device is available."""
+        return self.coordinator.ws_connected or self.coordinator.last_update_success
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set a new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        await self.coordinator.set_temperature(self._ctrl_datapoint_id, temperature)
+        self._target_temperature = temperature
+        self.async_write_ha_state()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set a new preset."""
+        device_preset = _HA_TO_DEVICE_PRESET.get(preset_mode)
+        if device_preset is None:
+            _LOGGER.warning("Unknown thermostat preset %r", preset_mode)
+            return
+        await self.coordinator.set_temperature_preset(
+            self._ctrl_datapoint_id, device_preset
+        )
+        self._preset_mode = preset_mode
+        self.async_write_ha_state()
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Accept the single supported HVAC mode (no-op)."""
+        # Only HEAT is exposed; nothing to send to the gateway.
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        device = next(
+            (
+                d
+                for d in self.coordinator.data or []
+                if d.get("id") == self._device["id"]
+            ),
+            None,
+        )
+        if device:
+            ctrl_dp = next(
+                (
+                    dp
+                    for dp in device.get("datapoints", [])
+                    if dp.get("id") == self._ctrl_datapoint_id
+                ),
+                None,
+            )
+            if ctrl_dp:
+                self._target_temperature = self._get_target_from_datapoint(ctrl_dp)
+                self._preset_mode = self._get_preset_from_datapoint(ctrl_dp)
+            self._current_temperature = self._get_current_temperature(device)
+        self.async_write_ha_state()
+
+    def _get_target_from_datapoint(self, datapoint: Datapoint | None) -> float | None:
+        if not datapoint:
+            return None
+        for value in datapoint.get("values", []):
+            if value["key"] == "temperature_ctrl":
+                try:
+                    return float(value["value"])
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    def _get_preset_from_datapoint(self, datapoint: Datapoint | None) -> str | None:
+        if not datapoint:
+            return None
+        for value in datapoint.get("values", []):
+            if value["key"] == "temperature_ctrl_preset":
+                return _DEVICE_TO_HA_PRESET.get(value["value"])
+        return None
+
+    def _get_current_temperature(self, device: Device) -> float | None:
+        """Read an ambient temperature from a sibling °C quantity datapoint, if any."""
+        for dp in device.get("datapoints", []):
+            if dp.get("type") != "quantity":
+                continue
+            unit = next(
+                (
+                    (v.get("value") or "").strip().lower()
+                    for v in dp.get("values", [])
+                    if v.get("key") == "quantity_unit"
+                ),
+                None,
+            )
+            if unit not in ("°c", "c"):
+                continue
+            for v in dp.get("values", []):
+                if v.get("key") == "quantity":
+                    try:
+                        return float(v["value"])
+                    except (TypeError, ValueError):
+                        return None
+        return None

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, device_slug
-from .models import Device
+from .models import Device, Scene
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +45,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         self.pushed_datapoint_id: str | None = None
         # Gateway firmware version, reported by the WebSocket "version" frame.
         self.gateway_version: str | None = None
+        # Scene list, populated from the WebSocket `scenes` broadcasts (full list
+        # on connect, `scenes-new` / `scenes-deleted` deltas on change). The scene
+        # platform discovers from this; recall goes over REST because the
+        # WebSocket `scene` command is unimplemented on the gateway.
+        self.scenes: list[Scene] = []
         # Stable-slug -> volatile device id, to detect firmware-update id changes.
         self._device_ids: dict[str, str] = {}
         self._ws_task: asyncio.Task[None] | None = None
@@ -144,6 +149,23 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # trust boundary: untyped gateway JSON becomes the typed `Device` model.
         # Downstream code keeps defensive `.get(...)` access for malformed items.
         return cast("list[Device]", [d for d in data if isinstance(d, dict)])
+
+    async def activate_scene(self, scene_id: str) -> None:
+        """Activate a scene via REST (the WebSocket scene command is unimplemented)."""
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        url = f"https://{self.config['host']}/api/junghome/scenes/{scene_id}"
+        headers = {
+            "token": f"{self.config['token']}",
+            "Content-Type": "application/json",
+        }
+        try:
+            async with asyncio.timeout(30):
+                async with session.post(url, headers=headers) as response:
+                    response.raise_for_status()
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_send"
+            ) from err
 
     async def _websocket_loop(self) -> None:
         """Keep a WebSocket connection alive, reconnecting with backoff on drop.
@@ -294,12 +316,38 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             else:
                 _LOGGER.warning("No matching datapoint found for id %s", datapoint_id)
         elif isinstance(data, list):
-            # groups / scenes broadcasts — not consumed by any entity; ignore.
-            _LOGGER.debug("Received %s broadcast (%d items)", msg_type, len(data))
+            if msg_type in ("scenes", "scenes-new", "scenes-deleted"):
+                self._handle_scenes_broadcast(msg_type, data)
+            else:
+                # groups broadcasts — not consumed by any entity; ignore.
+                _LOGGER.debug("Received %s broadcast (%d items)", msg_type, len(data))
         else:
             _LOGGER.warning(
                 "Received WebSocket message with unknown data type: %s", message
             )
+
+    def _handle_scenes_broadcast(self, msg_type: str, data: list[Any]) -> None:
+        """Update the cached scene list from a WebSocket scenes broadcast.
+
+        The gateway pushes the full ``scenes`` list on connect and on change, and
+        ``scenes-new`` / ``scenes-deleted`` deltas when scenes are added/removed
+        in the app. The scene platform discovers from ``self.scenes`` and is
+        notified via ``async_update_listeners`` so new scenes appear without a
+        reload. (The WebSocket ``scene`` *command* is unimplemented on the
+        gateway, so recall still goes over REST — see ``activate_scene``.)
+        """
+        items = cast("list[Scene]", [s for s in data if isinstance(s, dict)])
+        if msg_type == "scenes":
+            self.scenes = items
+        elif msg_type == "scenes-new":
+            by_id = {s.get("id"): s for s in self.scenes}
+            for scene in items:
+                by_id[scene.get("id")] = scene
+            self.scenes = list(by_id.values())
+        else:  # scenes-deleted
+            removed = {s.get("id") for s in items}
+            self.scenes = [s for s in self.scenes if s.get("id") not in removed]
+        self.async_update_listeners()
 
     def _apply_gateway_version(self) -> None:
         """Push the gateway firmware version onto our devices in the registry.
@@ -454,6 +502,71 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 "id": datapoint_id,
                 "type": "status_led",
                 "values": [{"key": "status_led", "value": value}],
+            },
+        }
+        await self.send_websocket_message(message)
+
+    async def set_level(self, datapoint_id: str, level: int) -> None:
+        """Set a cover's position level (device scale 0-100)."""
+        message = {
+            "type": "datapoint",
+            "data": {
+                "id": datapoint_id,
+                "type": "level",
+                "values": [{"key": "level", "value": str(level)}],
+            },
+        }
+        await self.send_websocket_message(message)
+
+    async def move_level(self, datapoint_id: str, direction: int) -> None:
+        """Move/stop a cover via the ``level_move`` key.
+
+        ``direction`` is the gateway's tri-state: ``1`` / ``-1`` to start moving,
+        ``0`` to stop. (See ``cdb_types_datapoints.json``: ``level_move`` range
+        ``["-1","0","1"]``.)
+        """
+        message = {
+            "type": "datapoint",
+            "data": {
+                "id": datapoint_id,
+                "type": "level",
+                "values": [{"key": "level_move", "value": str(direction)}],
+            },
+        }
+        await self.send_websocket_message(message)
+
+    async def set_angle(self, datapoint_id: str, angle: int) -> None:
+        """Set a cover's slat angle (device scale 0-100)."""
+        message = {
+            "type": "datapoint",
+            "data": {
+                "id": datapoint_id,
+                "type": "angle",
+                "values": [{"key": "angle", "value": str(angle)}],
+            },
+        }
+        await self.send_websocket_message(message)
+
+    async def set_temperature(self, datapoint_id: str, temperature: float) -> None:
+        """Set a thermostat's target temperature (°C)."""
+        message = {
+            "type": "datapoint",
+            "data": {
+                "id": datapoint_id,
+                "type": "temperature_ctrl",
+                "values": [{"key": "temperature_ctrl", "value": str(temperature)}],
+            },
+        }
+        await self.send_websocket_message(message)
+
+    async def set_temperature_preset(self, datapoint_id: str, preset: str) -> None:
+        """Set a thermostat preset (``none`` / ``frost`` / ``eco`` / ``comfort``)."""
+        message = {
+            "type": "datapoint",
+            "data": {
+                "id": datapoint_id,
+                "type": "temperature_ctrl",
+                "values": [{"key": "temperature_ctrl_preset", "value": preset}],
             },
         }
         await self.send_websocket_message(message)

--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -1,0 +1,293 @@
+"""Cover platform for Jung Home (blinds / shutters).
+
+Two function types map here:
+
+- ``Position`` — a ``level`` datapoint (position only).
+- ``PositionAndAngle`` — a ``level`` datapoint plus an ``angle`` datapoint
+  (slat tilt).
+
+## Position convention (hardware-verifiable assumption)
+
+The gateway's ``level`` datapoint is a 0-100 ``%`` value (Generic Level model).
+The dump used to build this integration was factory-reset, so it carries no live
+cover to confirm direction, and the gateway docs don't state it. This platform
+follows the common JUNG/European blind convention where ``level`` is **percent
+closed**, so it inverts to Home Assistant's "percent open" position:
+
+    ha_position = 100 - device_level
+
+If a real device turns out to report percent-open instead, flip ``_to_ha`` /
+``_to_device`` below (they are the single inversion point) — nothing else needs
+to change. The slat ``angle`` is mapped straight through (0-100%).
+"""
+
+import logging
+from typing import Any
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, device_slug, stable_unique_id
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
+
+_LOGGER = logging.getLogger(__name__)
+
+# Commands are cheap async WebSocket sends; don't serialise them.
+PARALLEL_UPDATES = 0
+
+# Gateway level_move tri-state (see cdb_types_datapoints.json).
+_MOVE_STOP = 0
+
+
+def _to_ha(device_level: int) -> int:
+    """Convert a device level (% closed) to a Home Assistant position (% open)."""
+    return 100 - device_level
+
+
+def _to_device(ha_position: int) -> int:
+    """Convert a Home Assistant position (% open) to a device level (% closed)."""
+    return 100 - ha_position
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Jung Home covers from a config entry."""
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _discover_covers() -> None:
+        """Add entities for any covers not yet created (handles devices added later)."""
+        new_entities: list[JungHomeCover] = []
+        for device in coordinator.data or []:
+            if device.get("type") not in ("Position", "PositionAndAngle"):
+                continue
+            level_dp = next(
+                (
+                    dp
+                    for dp in device.get("datapoints", [])
+                    if dp.get("type") == "level"
+                ),
+                None,
+            )
+            if level_dp is None:
+                continue
+            uid = stable_unique_id(device, level_dp)
+            if uid in known:
+                continue
+            known.add(uid)
+            new_entities.append(JungHomeCover(coordinator, device, level_dp))
+        if new_entities:
+            async_add_entities(new_entities, update_before_add=True)
+
+    _discover_covers()
+    entry.async_on_unload(coordinator.async_add_listener(_discover_covers))
+
+
+class JungHomeCover(CoordinatorEntity[JungHomeDataUpdateCoordinator], CoverEntity):
+    """Representation of a Jung Home cover (blind / shutter)."""
+
+    # The cover is the device's main feature, so it adopts the device name
+    # (entity_id `cover.<device>`).
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_device_class = CoverDeviceClass.BLIND
+
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: Device,
+        level_datapoint: Datapoint,
+    ) -> None:
+        """Initialize the cover."""
+        super().__init__(coordinator)
+        self._device = device
+        self._datapoint = level_datapoint
+        self._level_datapoint_id = level_datapoint["id"]
+        self._angle_datapoint = next(
+            (dp for dp in device.get("datapoints", []) if dp.get("type") == "angle"),
+            None,
+        )
+        self._angle_datapoint_id = (
+            self._angle_datapoint.get("id") if self._angle_datapoint else None
+        )
+        self._name = device.get("label", "Jung Cover")
+        self._unique_id = stable_unique_id(device, level_datapoint)
+
+        features = (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.STOP
+            | CoverEntityFeature.SET_POSITION
+        )
+        if self._angle_datapoint_id is not None:
+            features |= (
+                CoverEntityFeature.OPEN_TILT
+                | CoverEntityFeature.CLOSE_TILT
+                | CoverEntityFeature.SET_TILT_POSITION
+            )
+        self._attr_supported_features = features
+
+        self._position = self._get_position_from_datapoint(level_datapoint)
+        self._tilt = self._get_tilt_from_datapoint(self._angle_datapoint)
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID for the cover."""
+        return self._unique_id
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the cover position (0 closed .. 100 open)."""
+        return self._position
+
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Return the slat tilt position (0 .. 100), if supported."""
+        return self._tilt
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return True if the cover is fully closed."""
+        if self._position is None:
+            return None
+        return self._position == 0
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this cover."""
+        return {
+            "identifiers": {(DOMAIN, device_slug(self._device))},
+            "name": self._device.get("label", "Jung Device"),
+            "manufacturer": "Jung",
+            "model": self._device.get("type", "Unknown Model"),
+            "sw_version": self._device.get("sw_version")
+            or self.coordinator.gateway_version
+            or "Unknown Version",
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if the device is available.
+
+        Matches the other platforms: a live WebSocket link is the primary
+        availability signal, falling back to the last REST poll.
+        """
+        return self.coordinator.ws_connected or self.coordinator.last_update_success
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover fully."""
+        await self.coordinator.set_level(self._level_datapoint_id, _to_device(100))
+        self._position = 100
+        self.async_write_ha_state()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover fully."""
+        await self.coordinator.set_level(self._level_datapoint_id, _to_device(0))
+        self._position = 0
+        self.async_write_ha_state()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position."""
+        ha_position = int(kwargs[ATTR_POSITION])
+        await self.coordinator.set_level(
+            self._level_datapoint_id, _to_device(ha_position)
+        )
+        self._position = ha_position
+        self.async_write_ha_state()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        await self.coordinator.move_level(self._level_datapoint_id, _MOVE_STOP)
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Tilt the slats fully open."""
+        await self._set_tilt(100)
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Tilt the slats fully closed."""
+        await self._set_tilt(0)
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Set the slat tilt to a specific position."""
+        await self._set_tilt(int(kwargs[ATTR_TILT_POSITION]))
+
+    async def _set_tilt(self, tilt: int) -> None:
+        if self._angle_datapoint_id is None:
+            return
+        # Angle is mapped straight through (no inversion) — see module docstring.
+        await self.coordinator.set_angle(self._angle_datapoint_id, tilt)
+        self._tilt = tilt
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        device = next(
+            (
+                d
+                for d in self.coordinator.data or []
+                if d.get("id") == self._device["id"]
+            ),
+            None,
+        )
+        if device:
+            level_dp = next(
+                (
+                    dp
+                    for dp in device.get("datapoints", [])
+                    if dp.get("id") == self._level_datapoint_id
+                ),
+                None,
+            )
+            if level_dp:
+                self._position = self._get_position_from_datapoint(level_dp)
+            if self._angle_datapoint_id is not None:
+                angle_dp = next(
+                    (
+                        dp
+                        for dp in device.get("datapoints", [])
+                        if dp.get("id") == self._angle_datapoint_id
+                    ),
+                    None,
+                )
+                if angle_dp:
+                    self._tilt = self._get_tilt_from_datapoint(angle_dp)
+        self.async_write_ha_state()
+
+    def _get_position_from_datapoint(self, datapoint: Datapoint | None) -> int | None:
+        """Extract the HA position (% open) from a level datapoint."""
+        if not datapoint:
+            return None
+        for value in datapoint.get("values", []):
+            if value["key"] == "level":
+                try:
+                    return _to_ha(round(float(value["value"])))
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    def _get_tilt_from_datapoint(self, datapoint: Datapoint | None) -> int | None:
+        """Extract the tilt position (0..100) from an angle datapoint."""
+        if not datapoint:
+            return None
+        for value in datapoint.get("values", []):
+            if value["key"] == "angle":
+                try:
+                    return round(float(value["value"]))
+                except (TypeError, ValueError):
+                    return None
+        return None

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
         """Add entities for any lights not yet created (handles devices added later)."""
         new_entities: list[JungHomeLight] = []
         for device in coordinator.data or []:
-            if device.get("type") in ("OnOff", "ColorLight"):
+            if device.get("type") in ("OnOff", "DimmerLight", "ColorLight"):
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "switch":
                         uid = stable_unique_id(device, datapoint)
@@ -96,13 +96,19 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         self._color_temp_datapoint_id = (
             self._color_temp_datapoint.get("id") if self._color_temp_datapoint else None
         )
+        # Capabilities follow the datapoints the device actually exposes, not the
+        # function type name: DimmerLight has brightness, ColorLight adds
+        # color_temperature, OnOff has neither. (Before, brightness was gated on
+        # type == "ColorLight", so DimmerLight produced no entity at all.)
+        self._has_brightness = self._brightness_datapoint_id is not None
+        self._has_color_temp = self._color_temp_datapoint_id is not None
         # Device brightness scale is 0-100 (device) — Home Assistant uses 0-255
         self._name = device.get("label", "Jung Light")
         # Firmware-stable id derived from the label, not the volatile device id.
         self._unique_id = stable_unique_id(device, datapoint)
         self._is_on = self._get_state_from_datapoint(datapoint)
 
-        if device["type"] == "ColorLight":
+        if self._has_brightness:
             # Read brightness and color_temp from their specific datapoints (if present)
             self._brightness: int | None = self._get_brightness_from_datapoint(
                 self._brightness_datapoint
@@ -120,10 +126,10 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         # the current value. Home Assistant requires supported_color_modes to be
         # a stable set, so decide it once here. COLOR_TEMP already implies
         # brightness support.
-        if self._color_temp_datapoint_id:
+        if self._has_color_temp:
             self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
             self._attr_color_mode = ColorMode.COLOR_TEMP
-        elif device["type"] == "ColorLight":
+        elif self._has_brightness:
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
             self._attr_color_mode = ColorMode.BRIGHTNESS
         else:
@@ -186,7 +192,7 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
             )
             if datapoint:
                 self._is_on = self._get_state_from_datapoint(datapoint)
-                if self._device["type"] == "ColorLight":
+                if self._has_brightness:
                     # Update brightness/color_temp from their respective datapoints (if available)
                     if self._brightness_datapoint_id:
                         brightness_dp = next(
@@ -220,12 +226,10 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         # device-side overrides (some devices reset brightness on power-on).
         await self.coordinator.turn_on_light(self._datapoint["id"])
         self._is_on = True
-        if self._device["type"] == "ColorLight":
-            if "brightness" in kwargs:
-                brightness = kwargs["brightness"]
-                await self._set_brightness(brightness)
-            if "color_temp_kelvin" in kwargs:
-                await self._set_color_temp(kwargs["color_temp_kelvin"])
+        if self._has_brightness and "brightness" in kwargs:
+            await self._set_brightness(kwargs["brightness"])
+        if self._has_color_temp and "color_temp_kelvin" in kwargs:
+            await self._set_color_temp(kwargs["color_temp_kelvin"])
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b16",
+  "version": "1.2.0b17",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/models.py
+++ b/custom_components/junghome/models.py
@@ -34,3 +34,17 @@ class Device(TypedDict):
     label: str
     datapoints: list[Datapoint]
     sw_version: NotRequired[str]
+
+
+class Scene(TypedDict):
+    """A gateway scene (``GET /scenes``).
+
+    ``id`` is volatile (regenerated on firmware updates, like a device id), so
+    the scene platform anchors identity on the stable ``label`` and re-resolves
+    ``id`` from the coordinator's scene list at activation time.
+    """
+
+    id: str
+    label: str
+    related_functions: NotRequired[list[str]]
+    value: NotRequired[str]

--- a/custom_components/junghome/scene.py
+++ b/custom_components/junghome/scene.py
@@ -1,0 +1,108 @@
+"""Scene platform for Jung Home.
+
+Scenes are recalled via REST (``POST /scenes/{id}``) — the WebSocket ``scene``
+command is not implemented on the gateway. The scene ``id`` is volatile (it is
+regenerated on firmware updates, like a device id), so identity is anchored on
+the stable ``label`` and the current ``id`` is re-resolved from the
+coordinator's scene list at activation time.
+"""
+
+import logging
+from typing import Any
+
+from homeassistant.components.scene import Scene as SceneEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Recalls are cheap async REST posts; don't serialise them.
+PARALLEL_UPDATES = 0
+
+
+def _scene_slug(label: str) -> str:
+    """Return a firmware-stable slug for a scene label."""
+    slug = slugify(label or "")
+    if slug and slug != "unknown":
+        return slug
+    return "scene"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Jung Home scenes from a config entry."""
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _discover_scenes() -> None:
+        """Add entities for any scenes not yet created."""
+        new_entities: list[JungHomeScene] = []
+        for scene in coordinator.scenes or []:
+            label = scene.get("label")
+            if not label:
+                continue
+            uid = f"{_scene_slug(label)}_scene"
+            if uid in known:
+                continue
+            known.add(uid)
+            new_entities.append(JungHomeScene(coordinator, label, uid))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _discover_scenes()
+    entry.async_on_unload(coordinator.async_add_listener(_discover_scenes))
+
+
+class JungHomeScene(CoordinatorEntity[JungHomeDataUpdateCoordinator], SceneEntity):
+    """Representation of a Jung Home scene."""
+
+    _attr_has_entity_name = False
+
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        label: str,
+        unique_id: str,
+    ) -> None:
+        """Initialize the scene."""
+        super().__init__(coordinator)
+        self._label = label
+        self._attr_unique_id = unique_id
+        self._attr_name = label
+
+    @property
+    def available(self) -> bool:
+        """Return if the gateway is reachable."""
+        return self.coordinator.ws_connected or self.coordinator.last_update_success
+
+    async def async_activate(self, **kwargs: Any) -> None:
+        """Activate the scene.
+
+        Re-resolve the volatile scene id from the label each time, so a firmware
+        update that regenerated ids doesn't leave us posting to a dead id.
+        """
+        scene_id = next(
+            (
+                s.get("id")
+                for s in self.coordinator.scenes or []
+                if s.get("label") == self._label and s.get("id")
+            ),
+            None,
+        )
+        if scene_id is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="scene_not_found",
+                translation_placeholders={"label": self._label},
+            )
+        await self.coordinator.activate_scene(scene_id)

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -8,6 +8,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    LIGHT_LUX,
+    PERCENTAGE,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -36,7 +38,7 @@ _TOTAL = SensorStateClass.TOTAL_INCREASING
 # (device_class, state_class, Home Assistant unit). Energy is TOTAL_INCREASING so
 # it feeds the energy dashboard; the rest are MEASUREMENT. Unknown units fall
 # back to a plain string sensor with no class.
-_UNIT_MAP: dict[str, tuple[SensorDeviceClass, SensorStateClass, str]] = {
+_UNIT_MAP: dict[str, tuple[SensorDeviceClass | None, SensorStateClass, str]] = {
     "w": (SensorDeviceClass.POWER, _MEAS, UnitOfPower.WATT),
     "kw": (SensorDeviceClass.POWER, _MEAS, UnitOfPower.KILO_WATT),
     "wh": (SensorDeviceClass.ENERGY, _TOTAL, UnitOfEnergy.WATT_HOUR),
@@ -45,6 +47,11 @@ _UNIT_MAP: dict[str, tuple[SensorDeviceClass, SensorStateClass, str]] = {
     "a": (SensorDeviceClass.CURRENT, _MEAS, UnitOfElectricCurrent.AMPERE),
     "hz": (SensorDeviceClass.FREQUENCY, _MEAS, UnitOfFrequency.HERTZ),
     "°c": (SensorDeviceClass.TEMPERATURE, _MEAS, UnitOfTemperature.CELSIUS),
+    "lux": (SensorDeviceClass.ILLUMINANCE, _MEAS, LIGHT_LUX),
+    "lx": (SensorDeviceClass.ILLUMINANCE, _MEAS, LIGHT_LUX),
+    # "%" is ambiguous (humidity, power factor, ...): keep the unit but assert no
+    # device class rather than risk mislabelling.
+    "%": (None, _MEAS, PERCENTAGE),
 }
 
 # Raw units we've already warned about, so each unmapped unit logs only once.
@@ -65,7 +72,10 @@ async def async_setup_entry(
         """Add entities for any sensors not yet created (handles devices added later)."""
         new_entities: list[JungHomeQuantity] = []
         for device in coordinator.data or []:
-            if device.get("type") == "Socket":
+            # Sockets expose energy quantities; Measurement functions (e.g. the
+            # ambient readings on a presence detector) expose their own quantity
+            # datapoints — both surface here as quantity sensors.
+            if device.get("type") in ("Socket", "Measurement"):
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "quantity":
                         label = next(

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -75,6 +75,9 @@
     },
     "invalid_response": {
       "message": "The Jung Home gateway returned an unexpected response."
+    },
+    "scene_not_found": {
+      "message": "The Jung Home scene {label} is no longer available on the gateway."
     }
   }
 }

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -75,6 +75,9 @@
     },
     "invalid_response": {
       "message": "The Jung Home gateway returned an unexpected response."
+    },
+    "scene_not_found": {
+      "message": "The Jung Home scene {label} is no longer available on the gateway."
     }
   }
 }

--- a/docs/gateway-system-analysis.md
+++ b/docs/gateway-system-analysis.md
@@ -1,0 +1,301 @@
+# JUNG HOME Gateway — System Analysis
+
+Analysis of the root partition microSD image (`disk_dump/jung/sdc2/`).
+
+**Platform:** Raspberry Pi Zero (armhf), Raspberry Pi OS Debian 13 Trixie
+**Firmware:** v2.1.3 Release (build 2840), built 2026-04-28 from GitLab CI (`lb-connect-gateway/lbc-gw-integration`)
+**Device serial:** `0000000084fb4b1b` · **MAC:** `00:22:d1:05:96:02`
+**mDNS hostname:** `junghome-0022d1059602.local`
+
+---
+
+## Software Stack Architecture
+
+The gateway is a multi-process Node.js stack orchestrated by a single C binary (`board_ctrl`). Nine GitLab CI projects assemble into this image:
+
+| CI Project | Version | What it is |
+|---|---|---|
+| `lbc-gw-integration` | 2.1.3 | Top-level build orchestrator |
+| `lbc-gw-middleware` | 2.1.3 | BT Mesh Node.js app |
+| `lbc-gw-api-server` | 2.1.1 | REST API + WebSocket + Web UI |
+| `lbc-gw-jungremote-client` | 2.1.0 | JUNG Cloud proxy (Socket.io) |
+| `lbc-gw-bt-tunnel` | 1.2.21.1 | UART↔NCP bridge (C binary) |
+| `lbc-gw-nginx` | 2.1.0 | nginx + WAF + SSL gen scripts |
+| `lbc-gw-node` | v22.22.0 | Node.js runtime (not from apt) |
+| `lbc-gw-system` | 2.1.0 | Board controller binary |
+| `lbc-gw-rootfs` | RASPIOS_13_PI32 | Base OS customization |
+
+---
+
+## /opt — Custom Application Directory
+
+### board_ctrl
+
+`/opt/board_ctrl/board_ctrl` — 192 KB stripped PIE ARM ELF. The *only* systemd service (`lbc-gw.service`). Runs as root with OOM score -999. This is the system orchestrator — it spawns and manages the Node.js processes. Restarts after 90 s on failure.
+
+### middleware
+
+`/opt/middleware/` — Node.js TypeScript app (`package: "bluetooth"` v1.0.0, author: Marius Biller). Handles all Bluetooth Mesh logic and talks to the Silicon Labs NCP co-processor via UART/bt_tunnel. State lives in `/data/middleware/res/`: `bt_mesh_project.json`, `cdb_*.json` (groups/scenes/functions), `btmesh_iv_index`, `btmesh_sequence_number`. Schema version 6 with migration framework and 6 numbered rollback backups.
+
+### api-server
+
+`/opt/api-server/` — Node.js TypeScript app (`package: "src"` v1.5.0). Express 5.2.1 + ws 8.19.0. Exposes the REST API on `:3000` and WebSocket on `:8080` (proxied by nginx). Has 14 controllers (devices, groups, scenes, functions, products, users, health, config, versions, remote, logs). Also serves a full Bootstrap-based Web UI with dashboards, device views, and settings pages.
+
+### jungremote-client
+
+`/opt/jungremote-client/` — Node.js TypeScript app (`package: "lbc-gw-jungremote-client"` v1.0.0). Socket.io-client 2.4.0 connecting to the JUNG Cloud. Acts as a transparent proxy, forwarding cloud commands to local subsystems. Bundles a JUNG CA certificate (`jung-ca-cer2034.crt`) for validating cloud TLS. Git origin: `https://git.jung.de/lb-connect-gateway/lbc-gw-jungremote-client.git`
+
+### bt_tunnel
+
+`/opt/bt_tunnel/lbc-gw-bt-tunnel_pi-zero` — 145 KB ARM ELF *with debug symbols* (not stripped). Bridges BT Mesh BGAPI frames between the Pi UART and the Silicon Labs co-processor. Built against Mesh SDK v4.4.6.0, cross-compiled with gcc-8.3.0. Version 1.2.21.1 (build was marked DIRTY — uncommitted changes at release time).
+
+### wireless_module
+
+`/opt/wireless_module/` — Silicon Labs `.gbl` firmware images for the BLE co-processor (full image, bootloader, secure element upgrade). Version 1.2.15.4 / Mesh SDK 4.4.6.0.
+
+### tools
+
+`/opt/tools/` — 7 bash scripts:
+
+| Script | Purpose |
+|---|---|
+| `gpio_init.sh` | Initialises LEDs on GPIO 4 (LAN/act), 17 (BT), 27 (Cloud) |
+| `led.sh` | LED state machine with `flock` serialisation |
+| `firewall.sh` | iptables rules (runtime only, no persisted rules file) |
+| `static_mac.sh` | Derives stable MAC from Pi serial to work around RTL8152 USB-Ethernet bug (LBGW-279); sets mDNS hostname |
+| `dns_test.sh` | DNS connectivity test with flock |
+| `serial.sh` | Reads Pi serial from `/proc/cpuinfo` |
+| `timezone_validator.sh` | Validates timezone against `/usr/share/zoneinfo` |
+
+### matter-interface
+
+`/opt/matter-interface/` — symlink `res → /data/matter-interface/res`. Currently empty — Matter integration placeholder, not yet populated.
+
+---
+
+## Systemd Services
+
+Only two custom services; everything else is stock Debian.
+
+### lbc-gw.service
+
+```ini
+[Unit]
+Description=System Service
+After=network.target
+RequiresMountsFor=/data
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/board_ctrl
+User=root
+OOMScoreAdjust=-999
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=lbc-gw.service
+KillMode=mixed
+KillSignal=SIGTERM
+SendSIGKILL=yes
+TimeoutStopSec=10
+ExecStart=/opt/board_ctrl/board_ctrl
+Restart=always
+RestartSec=90
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### nginx.service (customised)
+
+Pre-exec hooks run before nginx starts:
+
+1. `/etc/nginx/generate_ssl_key.sh` — generates a 2048-bit RSA self-signed cert (CN=`junghome.local`, O=Albrecht Jung GmbH & Co. KG, Schalksmuehle NRW DE) valid for 35 years, stored in `/data/etc/nginx/`. Also generates `dh2048.pem` and a fingerprint file.
+2. `/etc/nginx/generate_nginx_sites.sh` — reads `/tmp/ip` and `/tmp/mac` at runtime, generates the HTTPS server block dynamically and writes it to `/tmp/nginx/sites-available/https`.
+
+### Masked services (explicitly disabled)
+
+`dhcpcd`, `fake-hwclock`, `networking`, `nfs-*`, `systemd-timesyncd`, `systemd-tmpfiles-clean`, `raspi-config`, `rpi-display-backlight`, `rpi-eeprom-update`, `sshswitch`, `plymouth-*`
+
+### Enabled services
+
+`console-setup`, `cron`, `exim4`, `lbc-gw` (custom), `nfs-client.target`, `remote-fs.target`, `rng-tools-debian`, `rsyslog`, `wpa_supplicant`
+
+### Drop-in overrides
+
+| Override | Effect |
+|---|---|
+| `dhcpcd.service.d/wait.conf` | Runs dhcpcd with `-q -w` (quiet, wait for address) |
+| `getty@tty1.service.d/noclear.conf` | `TTYVTDisallocate=no` — keeps console output after logout |
+| `rc-local.service.d/ttyoutput.conf` | Redirects rc.local stdout to TTY |
+
+---
+
+## Nginx — Reverse Proxy & WAF
+
+### Proxy topology
+
+```
+Internet/LAN → :443 (nginx TLS) → :3000 (api-server HTTP)
+                                 → :8080 (api-server WebSocket, path /ws)
+              :80 → 307 redirect → :443
+```
+
+### TLS
+
+- Protocols: TLSv1.2 and TLSv1.3 only
+- Server ciphers preferred; RC4, SHA1, 3DES, NULL, CAMELLIA, RSA key exchange excluded
+- Session tickets disabled
+- DH parameters: `/data/etc/nginx/dh2048.pem`
+- Certificates: `/data/etc/nginx/svs.crt` / `svs.key`
+- HSTS: 1 year + `includeSubDomains`
+
+### Certificate details
+
+| Field | Value |
+|---|---|
+| CN | `junghome.local` |
+| O | Albrecht Jung GmbH & Co. KG |
+| OU | Software Engineering |
+| L | Schalksmuehle |
+| ST | NRW Germany |
+| C | DE |
+| Validity | 35 years (12,775 days) |
+
+### Security snippets (`/etc/nginx/snippets/`)
+
+| File | Purpose |
+|---|---|
+| `6G.conf` | WAF: SQLi, XSS, path traversal, bad UAs (nikto, sqlmap), blocks DELETE/PUT/TRACE/DEBUG/CONNECT |
+| `secrules.conf` | Blocks `.pl/.cgi/.py/.sh/.lua` execution, `base64_encode`, `display_errors` |
+| `header.conf` | HSTS (1 yr), X-Frame-Options: SAMEORIGIN, X-Content-Type-Options: nosniff, X-XSS-Protection |
+| `http-dns-rebind-protection.conf` | Default server returns 444 for unrecognised Host headers |
+| `rewrite_secure_cookies.conf` | Adds `Secure; HttpOnly; SameSite=strict` to all Set-Cookie headers |
+| `cors.conf` | CORS origin: device IP or `junghome-{MAC}.local` only |
+| `sse.conf` | Server-Sent Events support |
+| `error_page_503.conf` | Booting page (5 s auto-refresh) |
+| `error_page_505.conf` | Mode-switching page (9 s auto-refresh) |
+
+---
+
+## Network & Discovery
+
+| Setting | Value |
+|---|---|
+| Interface | eth0, DHCP by default |
+| Rescue static IP | `192.168.178.115/24`, gw `192.168.178.1` |
+| IPv6 | Disabled kernel-wide (`net.ipv6.conf.all.disable_ipv6=1`) |
+| mDNS | Avahi, eth0 + IPv4 only |
+| mDNS hostname | `junghome-0022d1059602.local` |
+| Advertised services | `_junghome._tcp:443` and `_workstation._tcp:443` with TXT: version, serial, mac, manufacturer=JUNG |
+| Firewall | No persistent rules; iptables managed at runtime by `firewall.sh` |
+| NetworkManager | Not installed |
+
+`/etc/network/interfaces` is a symlink to `/data/etc/network/interfaces` — the persistent partition owns network config.
+
+---
+
+## Hardware Configuration (`/boot/config.txt`)
+
+| Setting | Value |
+|---|---|
+| Bluetooth | **Disabled** (`dtoverlay=disable-bt`) |
+| WiFi | **Disabled** (`dtoverlay=disable-wifi`) |
+| UART | **Enabled** (`enable_uart=1`) — used for NCP co-processor |
+| Audio | Disabled (`dtparam=audio=off`) |
+| GPU memory | 4 MB (`gpu_mem=4`) |
+| SD overclock | 50 MHz → 100 MHz (`dtoverlay=sdtweak,overclock_50=100`) |
+| LEDs | GPIO 4 (LAN/act trigger), 17 (BT), 27 (Cloud) — outputs, low on boot |
+| I2C / SPI / I2S | All commented out / disabled |
+
+Boot cmdline: root on `/dev/mmcblk0p2`, ext4, `elevator=deadline`, Plymouth disabled, loglevel=3.
+
+BT Mesh is entirely offloaded to the Silicon Labs co-processor via UART — the Pi's own BT radio is disabled.
+
+---
+
+## Users & Authentication
+
+| Account | UID | Shell | Password |
+|---|---|---|---|
+| `root` | 0 | `/bin/bash` | Set (yescrypt) |
+| `service` | 999 | `/usr/sbin/nologin` | Locked (`!`) |
+| `www-data` | 33 | `/usr/sbin/nologin` | Locked |
+| `avahi` | 108 | `/usr/sbin/nologin` | Locked |
+
+- Root SSH login: **enabled** (`PermitRootLogin yes`)
+- No `authorized_keys` configured for any account
+- SSH host keys dated Dec 2020 (pre-date this firmware build — generated on first boot)
+- `PasswordAuthentication` defaults to `yes` (not explicitly set)
+- `/home/` is empty; no user home directories
+
+Custom profile scripts:
+- `/etc/profile.d/jung.sh` — colour PS1 with firmware version, extended history (99,999 entries with timestamps)
+- `/etc/profile.d/sshpwd.sh` — warns if SSH is enabled and default `pi` password is unchanged
+
+---
+
+## What's Not From Debian Repos
+
+All dpkg-managed packages come from official Raspbian/RPi Foundation Trixie repos. The following are out-of-band:
+
+| Item | Source | Notes |
+|---|---|---|
+| Node.js v22.22.0 | nodejs.org tarball → `/usr/local/node/` | Symlinked to `/usr/bin/node`; npm 10.9.4 |
+| `board_ctrl` binary | `lbc-gw-system` GitLab CI | Proprietary C daemon |
+| `lbc-gw-bt-tunnel_pi-zero` binary | `lbc-gw-bt-tunnel` GitLab CI | Has debug symbols (not stripped) |
+| All `/opt/*/dist/` JS | `lbc-gw-*` GitLab CI | Compiled TypeScript |
+| Silicon Labs `.gbl` firmware | Embedded SDK | NCP co-processor images |
+| ~39 "local" dpkg packages | Carried from Buster/Bullseye | `libssl1.1`, `libicu67`, `libpython3.9`, `libnettle6`, etc. — compatibility shims for proprietary binaries |
+
+No custom apt repositories configured.
+
+---
+
+## /data — Persistent Partition Layout
+
+All runtime state lives here. `/opt` and `/etc` are read-only firmware; everything that changes at runtime is in `/data`.
+
+```
+/data/
+├── middleware/res/          # BT mesh live state (project, CDB, IV index, seq no.)
+│   └── backups/res_1…6/    # 6 rollback snapshots
+├── api-server/res/          # API server config + logger config
+├── jungremote-client/res/   # Cloud client config
+├── matter-interface/res/    # Matter placeholder (empty)
+├── board_ctrl/ncp_ctrl/res/ # NCP controller state
+├── etc/
+│   ├── network/interfaces   # Active network config (eth0 DHCP)
+│   ├── network/rescue       # Static fallback (192.168.178.115/24)
+│   ├── dhcp/dhclient.conf   # DHCP client options
+│   └── nginx/               # TLS cert, key, DH params, fingerprint
+├── root/.gnupg/             # GPG keyring (symlinked from /root/.gnupg)
+└── update/update_check.sh   # A/B update manager
+```
+
+---
+
+## Update System
+
+`/data/update/update_check.sh` implements a full A/B partition update scheme:
+
+- Checks `https://software.jung.de/lbcgw/` for new versions (also supports USB/IBN offline)
+- Verifies GPG signature (key fingerprint `AE2C321F44CC904C8BD037CCDCF86435A471F117`) and decrypts with `mdecrypt`
+- Switches between `mmcblk0p2` (current) and `mmcblk0p3` on update
+- Backs up `/data` before flash; restores on rollback
+- Supports beta/experimental channels
+
+---
+
+## Key Architecture Takeaways
+
+1. **`board_ctrl` is the real init.** The single systemd unit that owns everything. It starts/monitors the Node.js processes (middleware, api-server, jungremote-client).
+
+2. **BT Mesh is fully offloaded.** The Pi's own BT radio is disabled. All mesh traffic flows: `middleware ↔ bt_tunnel ↔ UART ↔ Silicon Labs co-processor`.
+
+3. **Cloud connectivity is optional.** `jungremote-client` connects to `jung.de` cloud via Socket.io. All local control works without it.
+
+4. **`/data` is the source of truth.** Mesh state, certificates, network config all live on the persistent data partition. The root partition (`/opt`, `/etc`) is effectively stateless firmware.
+
+5. **nginx is the only external-facing surface.** Port 443 (and 80→redirect). No other ports in UFW profiles. The WAF (`6G.conf`) and DNS rebind protection make it reasonably hardened despite the self-signed cert.
+
+6. **Security weak spots.** Root SSH login enabled with password auth and no key pre-configuration. No persistent firewall rules. UART exposed (physical access to NCP co-processor).

--- a/docs/gateway-system-analysis.md
+++ b/docs/gateway-system-analysis.md
@@ -299,3 +299,62 @@ All runtime state lives here. `/opt` and `/etc` are read-only firmware; everythi
 5. **nginx is the only external-facing surface.** Port 443 (and 80→redirect). No other ports in UFW profiles. The WAF (`6G.conf`) and DNS rebind protection make it reasonably hardened despite the self-signed cert.
 
 6. **Security weak spots.** Root SSH login enabled with password auth and no key pre-configuration. No persistent firewall rules. UART exposed (physical access to NCP co-processor).
+
+---
+
+## Companion partitions and live captures
+
+This analysis is built primarily from the active root partition (`sdc2`), but the
+larger dump contains more:
+
+### Partition layout (A/B + boot + data)
+
+| Partition | Role | Contents |
+|---|---|---|
+| `sdc1` | Boot (FAT) | Kernel, DTBs, `bootcode.bin`, `config.txt`, GPU firmware. pi-gen base 2020-12-02. |
+| `sdc2` | Root slot **A** (active) | Firmware **2.1.3 (2840)** — the subject of this doc. |
+| `sdc3` | Root slot **B** (previous) | Firmware **2.0.0 (2242)** — the prior image, kept for rollback. |
+| `sdc4` | Persistent `/data` | Live runtime state (mesh DB, certs, tokens, update history). |
+
+This confirms the A/B update scheme: the bootloader flips between `sdc2`/`sdc3`,
+and `/data` (`sdc4`) is shared across both slots. `sdc4/update/history.txt`
+records a real update (2026-05-12) doing, in order: save `/data` → migrate →
+update `fstab` → flash boot partition → update bootloader config → mark slot
+active. The on-disk device DB in this image is empty (a reset/test gateway).
+
+### Matter — provisioned but inactive
+
+`sdc4/matter-interface/matter_setup_data.json` holds real commissioning data:
+vendor `0x1429`, product `11`, discriminator `1538`, and a SPAKE2+ verifier +
+salt. But the bridge daemon is not installed (the `res/` directory is empty and
+nothing references it), so it is staged for a future firmware rather than active.
+See [matter-bridge.md](matter-bridge.md).
+
+### Secrets present on `/data` (`sdc4`)
+
+The data partition contains live secrets — handle the dump accordingly
+(`disk_dump/` is gitignored):
+
+- BT-Mesh `netKeys` / `appKeys` in `middleware/res*/bt_mesh_project.json` (the
+  mesh encryption keys — enough for direct mesh control).
+- nginx private key `etc/nginx/svs.key`.
+- Cloud token `jungremote-client/res/api_token.tk` and the per-user API token
+  secrets in `api-server/res/tokens/*.tkn` (these sign the gateway's JWTs).
+
+### Live WebSocket capture (`disk_dump/ws-capture/`)
+
+A real session from a **production** gateway (fw 1.5.0), separate from the disk
+image. It validates the protocol the integration depends on:
+
+- Connect frame order: `message → version → functions → groups → scenes` — the
+  gateway pushes the full `scenes` list on connect (what the scene platform
+  relies on).
+- `functions` shape `{id, type, label, parent_groups, datapoints}` and `scenes`
+  shape `{id, label, related_functions, value}` match the integration's models.
+- Device types seen in the wild: `OnOff`, `ColorLight`, `Socket`, `RockerSwitch`
+  only — no covers/thermostats/dimmers/measurement in this installation, so those
+  platforms remain unverified against hardware.
+
+`disk_dump/config_entry-junghome-*.json` is a Home Assistant diagnostics export
+of this integration (v1.2.0b15, 36 devices) from the same live install; it
+confirms host/token redaction works.

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -93,8 +93,19 @@ Common `values` keys by device type:
 | Switch / light on-off | `switch` = `"0"` / `"1"` |
 | Dimmer | `brightness` = `"0".."100"` (device scale) |
 | Tunable white | `color_temperature` = Kelvin, e.g. `"2700"` |
+| Cover position | `level` = `"0".."100"` (device scale; see note below) |
+| Cover move / stop | `level_move` = `"1"` / `"-1"` (move) / `"0"` (stop) |
+| Cover slat tilt | `angle` = `"0".."100"` |
+| Thermostat target | `temperature_ctrl` = °C, e.g. `"21.5"` (range 5..30) |
+| Thermostat preset | `temperature_ctrl_preset` = `none` / `frost` / `eco` / `comfort` |
 | Status LED (rocker) | `status_led` = `"0"` / `"1"` |
 | Rocker press (read-only events) | `up_request` / `down_request` / `trigger_request` = `"1"` |
+
+> **Cover `level` direction is unconfirmed.** The dump used to reverse-engineer
+> this was factory-reset (no live cover), and neither the gateway nor its docs
+> state whether `level` is percent-open or percent-closed. The integration
+> assumes percent-*closed* (HA position = `100 - level`). Verify against
+> hardware; the inversion lives in one place (`cover.py` `_to_ha`/`_to_device`).
 
 ### Other command types
 
@@ -117,6 +128,9 @@ Any failure is returned as a `message` frame:
 
 - State updates arrive as `datapoint` broadcasts; the coordinator matches them to
   entities. Commands are sent as `datapoint` set frames.
+- The coordinator consumes the `scenes` / `scenes-new` / `scenes-deleted`
+  broadcasts to populate the scene platform (recall is REST-only). `groups`
+  broadcasts are still ignored.
 - Reconnect on drop: the gateway sends the full `functions`/`groups`/`scenes`
   snapshot again on every new connection, so re-syncing is automatic.
 - Watch `functions` / `*-new` / `*-deleted` frames to pick up devices added or

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,12 +1,14 @@
 """Tests for the Jung Home data update coordinator."""
 
-from unittest.mock import Mock, patch
+import json
+from typing import Self
+from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -59,3 +61,91 @@ async def test_no_reload_when_device_ids_stable(hass: HomeAssistant) -> None:
             [{"id": "idSAME", "label": "Katilas"}]
         )
     reload.assert_not_called()
+
+
+def _coordinator_with_ws(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
+    coordinator = _coordinator(hass)
+    ws = AsyncMock()
+    ws.closed = False
+    coordinator.websocket = ws
+    return coordinator
+
+
+async def test_cover_climate_command_payloads(hass: HomeAssistant) -> None:
+    """The new command methods build the expected datapoint set frames."""
+    coordinator = _coordinator_with_ws(hass)
+    await coordinator.set_level("dp-1", 75)
+    await coordinator.move_level("dp-1", 0)
+    await coordinator.set_angle("dp-2", 60)
+    await coordinator.set_temperature("dp-3", 22.5)
+    await coordinator.set_temperature_preset("dp-3", "eco")
+
+    sent = [
+        json.loads(c.args[0]) for c in coordinator.websocket.send_str.call_args_list
+    ]
+    assert sent[0]["data"]["values"] == [{"key": "level", "value": "75"}]
+    assert sent[1]["data"]["values"] == [{"key": "level_move", "value": "0"}]
+    assert sent[2]["data"]["values"] == [{"key": "angle", "value": "60"}]
+    assert sent[3]["data"]["values"] == [{"key": "temperature_ctrl", "value": "22.5"}]
+    assert sent[4]["data"]["values"] == [
+        {"key": "temperature_ctrl_preset", "value": "eco"}
+    ]
+
+
+async def test_scenes_broadcast_full_new_deleted(hass: HomeAssistant) -> None:
+    """scenes / scenes-new / scenes-deleted maintain the cached scene list."""
+    coordinator = _coordinator(hass)
+    coordinator._handle_scenes_broadcast(
+        "scenes", [{"id": "id1", "label": "A"}, {"id": "id2", "label": "B"}]
+    )
+    assert {s["id"] for s in coordinator.scenes} == {"id1", "id2"}
+
+    coordinator._handle_scenes_broadcast("scenes-new", [{"id": "id3", "label": "C"}])
+    assert {s["id"] for s in coordinator.scenes} == {"id1", "id2", "id3"}
+
+    coordinator._handle_scenes_broadcast(
+        "scenes-deleted", [{"id": "id1", "label": "A"}]
+    )
+    assert {s["id"] for s in coordinator.scenes} == {"id2", "id3"}
+
+
+class _FakeResponse:
+    def __init__(self, exc: Exception | None = None) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self._exc is not None:
+            raise self._exc
+
+
+async def test_activate_scene_posts_to_rest(hass: HomeAssistant) -> None:
+    coordinator = _coordinator(hass)
+    session = Mock()
+    session.post = Mock(return_value=_FakeResponse())
+    with patch(
+        "custom_components.junghome.coordinator.async_get_clientsession",
+        return_value=session,
+    ):
+        await coordinator.activate_scene("id0002")
+    url = session.post.call_args.args[0]
+    assert url.endswith("/api/junghome/scenes/id0002")
+
+
+async def test_activate_scene_raises_on_error(hass: HomeAssistant) -> None:
+    coordinator = _coordinator(hass)
+    session = Mock()
+    session.post = Mock(return_value=_FakeResponse(aiohttp.ClientError("boom")))
+    with (
+        patch(
+            "custom_components.junghome.coordinator.async_get_clientsession",
+            return_value=session,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await coordinator.activate_scene("idX")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1000,7 +1000,9 @@ async def test_dimmer_brightness_command(hass: HomeAssistant, init_integration) 
     assert sb.call_args.args[1] == 100  # 255 HA -> 100 device
 
 
-async def test_cover_created_and_position(hass: HomeAssistant, init_integration) -> None:
+async def test_cover_created_and_position(
+    hass: HomeAssistant, init_integration
+) -> None:
     """Position is inverted: device level 30 (closed%) -> HA position 70 (open%)."""
     state = hass.states.get("cover.bedroom_blind")
     assert state is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,7 +60,7 @@ DEVICES = [
     },
     {
         "id": "iddim1",
-        "type": "ColorLight",
+        "type": "DimmerLight",
         "label": "Dimmer",
         "datapoints": [
             {
@@ -72,6 +72,48 @@ DEVICES = [
                 "id": "iddim1-002",
                 "type": "brightness",
                 "values": [{"key": "brightness", "value": "30"}],
+            },
+        ],
+    },
+    {
+        "id": "idblind1",
+        "type": "PositionAndAngle",
+        "label": "Bedroom Blind",
+        "datapoints": [
+            {
+                "id": "idblind1-001",
+                "type": "level",
+                # device level 30% closed -> HA position 70 (open)
+                "values": [{"key": "level", "value": "30"}],
+            },
+            {
+                "id": "idblind1-002",
+                "type": "angle",
+                "values": [{"key": "angle", "value": "40"}],
+            },
+        ],
+    },
+    {
+        "id": "idrtr1",
+        "type": "Thermostat",
+        "label": "Living Room",
+        "datapoints": [
+            {
+                "id": "idrtr1-001",
+                "type": "temperature_ctrl",
+                "values": [
+                    {"key": "temperature_ctrl", "value": "21.5"},
+                    {"key": "temperature_ctrl_preset", "value": "comfort"},
+                ],
+            },
+            {
+                "id": "idrtr1-010",
+                "type": "quantity",
+                "values": [
+                    {"key": "quantity", "value": "20.0"},
+                    {"key": "quantity_label", "value": "Temperature "},
+                    {"key": "quantity_unit", "value": "°C"},
+                ],
             },
         ],
     },
@@ -101,6 +143,22 @@ DEVICES = [
                     {"key": "quantity", "value": "42"},
                     {"key": "quantity_label", "value": "Status "},
                     {"key": "quantity_unit", "value": "?"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "idmeas1",
+        "type": "Measurement",
+        "label": "Hallway Sensor",
+        "datapoints": [
+            {
+                "id": "idmeas1-010",
+                "type": "quantity",
+                "values": [
+                    {"key": "quantity", "value": "120"},
+                    {"key": "quantity_label", "value": "Illuminance "},
+                    {"key": "quantity_unit", "value": "lux"},
                 ],
             },
         ],
@@ -918,3 +976,131 @@ async def test_migration_per_item_error_leaves_flag_unset(
     assert entry.data.get("stable_ids_migrated") is not True
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_dimmer_light_created(hass: HomeAssistant, init_integration) -> None:
+    """A DimmerLight (switch + brightness, no color temp) becomes a brightness light."""
+    state = hass.states.get("light.dimmer")
+    assert state is not None
+    assert state.attributes["supported_color_modes"] == ["brightness"]
+    # 30% device brightness -> round(30 * 255 / 100) = 77
+    # (light is off in the fixture, so brightness is reported but state is off)
+
+
+async def test_dimmer_brightness_command(hass: HomeAssistant, init_integration) -> None:
+    coordinator = init_integration.runtime_data
+    with patch.object(coordinator, "set_brightness", AsyncMock()) as sb:
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": "light.dimmer", "brightness": 255},
+            blocking=True,
+        )
+    assert sb.called
+    assert sb.call_args.args[1] == 100  # 255 HA -> 100 device
+
+
+async def test_cover_created_and_position(hass: HomeAssistant, init_integration) -> None:
+    """Position is inverted: device level 30 (closed%) -> HA position 70 (open%)."""
+    state = hass.states.get("cover.bedroom_blind")
+    assert state is not None
+    assert state.attributes["current_position"] == 70
+    assert state.attributes["current_tilt_position"] == 40
+    assert state.state == "open"
+
+
+async def test_cover_commands(hass: HomeAssistant, init_integration) -> None:
+    coordinator = init_integration.runtime_data
+    with (
+        patch.object(coordinator, "set_level", AsyncMock()) as sl,
+        patch.object(coordinator, "set_angle", AsyncMock()) as sa,
+        patch.object(coordinator, "move_level", AsyncMock()) as ml,
+    ):
+        await hass.services.async_call(
+            "cover", "open_cover", {"entity_id": "cover.bedroom_blind"}, blocking=True
+        )
+        await hass.services.async_call(
+            "cover", "close_cover", {"entity_id": "cover.bedroom_blind"}, blocking=True
+        )
+        await hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": "cover.bedroom_blind", "position": 25},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "cover", "stop_cover", {"entity_id": "cover.bedroom_blind"}, blocking=True
+        )
+        await hass.services.async_call(
+            "cover",
+            "set_cover_tilt_position",
+            {"entity_id": "cover.bedroom_blind", "tilt_position": 60},
+            blocking=True,
+        )
+    # open -> device level 0, close -> device level 100, position 25 -> device 75
+    assert [c.args[1] for c in sl.call_args_list] == [0, 100, 75]
+    assert sa.call_args.args[1] == 60
+    assert ml.call_args.args[1] == 0  # stop
+
+
+async def test_climate_created(hass: HomeAssistant, init_integration) -> None:
+    state = hass.states.get("climate.living_room")
+    assert state is not None
+    assert state.attributes["temperature"] == 21.5
+    assert state.attributes["preset_mode"] == "comfort"
+    # Current temperature read from the sibling °C quantity datapoint.
+    assert state.attributes["current_temperature"] == 20.0
+
+
+async def test_climate_commands(hass: HomeAssistant, init_integration) -> None:
+    coordinator = init_integration.runtime_data
+    with (
+        patch.object(coordinator, "set_temperature", AsyncMock()) as st,
+        patch.object(coordinator, "set_temperature_preset", AsyncMock()) as sp,
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {"entity_id": "climate.living_room", "temperature": 22.5},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "climate",
+            "set_preset_mode",
+            {"entity_id": "climate.living_room", "preset_mode": "eco"},
+            blocking=True,
+        )
+    assert st.call_args.args[1] == 22.5
+    assert sp.call_args.args[1] == "eco"
+
+
+async def test_measurement_sensor_created(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A Measurement function's quantity surfaces as a sensor (lux -> illuminance)."""
+    state = hass.states.get("sensor.hallway_sensor_illuminance")
+    assert state is not None
+    assert state.state == "120.0"
+    assert state.attributes["unit_of_measurement"] == "lx"
+    assert state.attributes["device_class"] == "illuminance"
+
+
+async def test_scene_created_and_activated(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Scenes arrive over the WebSocket and recall via REST with a re-resolved id."""
+    coordinator = init_integration.runtime_data
+    coordinator._handle_websocket_message(
+        {
+            "type": "scenes",
+            "data": [{"id": "idscene1", "label": "Movie Night"}],
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("scene.movie_night") is not None
+
+    with patch.object(coordinator, "activate_scene", AsyncMock()) as act:
+        await hass.services.async_call(
+            "scene", "turn_on", {"entity_id": "scene.movie_night"}, blocking=True
+        )
+    assert act.call_args.args[0] == "idscene1"


### PR DESCRIPTION
Gap analysis against the gateway disk dump surfaced device/function types the integration silently ignored. This closes them and cuts beta **1.2.0b17**.

## New platforms
- **cover** — `Position` / `PositionAndAngle` blinds: open/close/stop, set position, slat tilt.
- **climate** — `Thermostat`: target temp (5–30 °C), presets (none/frost/eco/comfort), current temp from a sibling °C quantity.
- **scene** — gateway scenes captured from the WebSocket `scenes` broadcast, recalled over REST (`POST /scenes/{id}`).

## Fixes
- **light** — `DimmerLight` produced no entity (capability was gated on the type name). Capabilities now follow the datapoints present.
- **sensor** — `Measurement` functions now surface as sensors; added `lux`/`lx` → illuminance, `%` unit kept.

## Plumbing
- Coordinator: `set_level`/`move_level`/`set_angle`/`set_temperature`/`set_temperature_preset`/`activate_scene` + `Scene` model.
- `strings.json`/`en.json`: `scene_not_found` exception.
- Tests extended to 88 (dimmer, cover incl. inversion, climate, scene, Measurement). ruff + mypy clean.
- Docs: function-type→platform map, WebSocket command keys, companion-partition analysis, README supported list.

## Caveat
No cover/thermostat/dimmer/Measurement hardware exists in any available dump, so these four are **unverified against real hardware** — in particular the blind position direction (assumed percent-closed; isolated to `_to_ha`/`_to_device` in `cover.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)