### PR TITLE
Scene recall event + review refactor (b18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ Import the blueprint by URL (Settings → Automations & scenes → Blueprints �
 Import), select **all** of the button's event entities (JUNG alternates between
 the up/down events), and assign actions for single / double / hold.
 
+# Scenes
+
+Scenes defined in the JUNG app appear as Home Assistant **`scene.*` entities** —
+activating one (or calling `scene.turn_on`) recalls it on the gateway.
+
+The gateway also reports when a scene is recalled **by any source**, including a
+physical wall button. The integration re-emits that as a Home Assistant event,
+`junghome_scene_recalled`, so you can trigger automations from a physical scene
+button:
+
+```yaml
+automation:
+  - trigger:
+      - platform: event
+        event_type: junghome_scene_recalled
+        event_data:
+          label: "Išjungti WC"
+    action:
+      - service: notify.notify
+        data:
+          message: "WC scene was triggered"
+```
+
+The event data is `{ scene_id, label, entry_id }`.
+
 # How updates work
 
 The integration is **local push**: it holds a WebSocket to the gateway and
@@ -89,8 +114,12 @@ reconnects automatically with backoff. No cloud and no account are involved.
 
 # Known limitations
 
-- **Scenes and groups** defined in the JUNG app aren't exposed; use Home
-  Assistant scenes/areas instead.
+- **Groups** defined in the JUNG app aren't exposed; use Home Assistant areas
+  instead. (Scenes *are* exposed — see [Scenes](#scenes).)
+- **Covers, thermostats, scenes and measurement sensors are not yet verified
+  against real hardware** — they're implemented from the gateway protocol but I
+  don't own those devices. Feedback welcome, especially whether a blind's
+  open/closed position reads the right way round.
 - **Metering sockets report instantaneous power (W) and current (A), not
   cumulative energy (kWh)**, so they can't go straight onto the Energy Dashboard.
   To track energy/cost, add a Riemann-sum
@@ -101,7 +130,10 @@ reconnects automatically with backoff. No cloud and no account are involved.
   [blueprint](#button-automations-rocker-switches).
 - The rocker **status-LED colour** can't be set from here (on/off only); colour
   is configured in the JUNG app or over BT-Mesh.
-- Curtains/covers, thermostats and the puck aren't supported yet.
+- The **puck** isn't supported yet.
+- Standalone **presence/motion sensors** (e.g. a JUNG "daviklis") aren't exposed
+  yet — they live in the gateway's lower-level `/devices` view, which this
+  integration doesn't read.
 - The gateway uses a **self-signed certificate**, so TLS verification is disabled
   for the local connection (expected for a LAN device).
 
@@ -119,12 +151,12 @@ device-mesh architecture are documented in **[docs/](docs/README.md)**. Release
 and HACS-publishing steps are in **[docs/publishing.md](docs/publishing.md)**.
 
 # TODO
-- Bring back binary sensors (motion/presence, which was previously removed).
+- Presence/motion binary sensors, sourced from the gateway's `/devices` view
+  (standalone sensors don't appear in the `/functions` data this integration
+  currently uses).
 - Puck support.
-
-Unlikely to be completed by me, since I don't have these devices:
-- Curtain control.
-- Thermostats.
+- Hardware verification of covers, thermostats and measurement sensors (these are
+  implemented but I don't own the devices — testers welcome).
 
 # Development / Testing
 

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -46,9 +46,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
     # Expose the coordinator as runtime data for the platforms.
     entry.runtime_data = coordinator
 
-    # Connect to the WebSocket for live updates
-    await coordinator.start()
-
     # One-time migration of registry entries from the gateway's volatile device
     # ids to firmware-stable, label-based ids. Must run while the gateway's ids
     # still match the registry (i.e. before the platforms create new entities).
@@ -60,6 +57,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
 
     # Forward the setup to the appropriate platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Connect to the WebSocket only after the platforms exist, so live pushes
+    # (datapoint updates, scene broadcasts/recalls) flow to registered entities
+    # rather than being dispatched into the void during setup. The initial state
+    # already came from async_config_entry_first_refresh() above.
+    await coordinator.start()
 
     # Prune HA devices the gateway no longer reports (quality-scale stale-devices).
     @callback

--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -25,12 +25,11 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug, stable_unique_id
+from .const import datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
 from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,11 +92,13 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_discover_climates))
 
 
-class JungHomeClimate(CoordinatorEntity[JungHomeDataUpdateCoordinator], ClimateEntity):
+class JungHomeClimate(JungHomeEntity, ClimateEntity):
     """Representation of a Jung Home thermostat."""
 
-    _attr_has_entity_name = True
     _attr_name = None
+    # Drives attribute translations (the custom `frost` preset has no HA core
+    # string). With _attr_name = None the entity still adopts the device name.
+    _attr_translation_key = "thermostat"
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
     _attr_min_temp = DEFAULT_MIN_TEMP
@@ -118,8 +119,7 @@ class JungHomeClimate(CoordinatorEntity[JungHomeDataUpdateCoordinator], ClimateE
         ctrl_datapoint: Datapoint,
     ) -> None:
         """Initialize the thermostat."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = ctrl_datapoint
         self._ctrl_datapoint_id = ctrl_datapoint["id"]
         self._name = device.get("label", "Jung Thermostat")
@@ -147,24 +147,6 @@ class JungHomeClimate(CoordinatorEntity[JungHomeDataUpdateCoordinator], ClimateE
     def preset_mode(self) -> str | None:
         """Return the active preset."""
         return self._preset_mode
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this thermostat."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
-
-    @property
-    def available(self) -> bool:
-        """Return if the device is available."""
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set a new target temperature."""
@@ -194,23 +176,9 @@ class JungHomeClimate(CoordinatorEntity[JungHomeDataUpdateCoordinator], ClimateE
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        device = next(
-            (
-                d
-                for d in self.coordinator.data or []
-                if d.get("id") == self._device["id"]
-            ),
-            None,
-        )
+        device = self._current_device()
         if device:
-            ctrl_dp = next(
-                (
-                    dp
-                    for dp in device.get("datapoints", [])
-                    if dp.get("id") == self._ctrl_datapoint_id
-                ),
-                None,
-            )
+            ctrl_dp = self._find_datapoint(self._ctrl_datapoint_id)
             if ctrl_dp:
                 self._target_temperature = self._get_target_from_datapoint(ctrl_dp)
                 self._preset_mode = self._get_preset_from_datapoint(ctrl_dp)
@@ -218,43 +186,33 @@ class JungHomeClimate(CoordinatorEntity[JungHomeDataUpdateCoordinator], ClimateE
         self.async_write_ha_state()
 
     def _get_target_from_datapoint(self, datapoint: Datapoint | None) -> float | None:
-        if not datapoint:
+        value = datapoint_value(datapoint, "temperature_ctrl")
+        if value is None:
             return None
-        for value in datapoint.get("values", []):
-            if value["key"] == "temperature_ctrl":
-                try:
-                    return float(value["value"])
-                except (TypeError, ValueError):
-                    return None
-        return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     def _get_preset_from_datapoint(self, datapoint: Datapoint | None) -> str | None:
-        if not datapoint:
+        value = datapoint_value(datapoint, "temperature_ctrl_preset")
+        if value is None:
             return None
-        for value in datapoint.get("values", []):
-            if value["key"] == "temperature_ctrl_preset":
-                return _DEVICE_TO_HA_PRESET.get(value["value"])
-        return None
+        return _DEVICE_TO_HA_PRESET.get(value)
 
     def _get_current_temperature(self, device: Device) -> float | None:
         """Read an ambient temperature from a sibling °C quantity datapoint, if any."""
         for dp in device.get("datapoints", []):
             if dp.get("type") != "quantity":
                 continue
-            unit = next(
-                (
-                    (v.get("value") or "").strip().lower()
-                    for v in dp.get("values", [])
-                    if v.get("key") == "quantity_unit"
-                ),
-                None,
-            )
+            unit = (datapoint_value(dp, "quantity_unit") or "").strip().lower()
             if unit not in ("°c", "c"):
                 continue
-            for v in dp.get("values", []):
-                if v.get("key") == "quantity":
-                    try:
-                        return float(v["value"])
-                    except (TypeError, ValueError):
-                        return None
+            value = datapoint_value(dp, "quantity")
+            if value is None:
+                continue
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
         return None

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -7,6 +7,21 @@ from .models import Datapoint, Device
 DOMAIN = "junghome"
 
 
+def datapoint_value(datapoint: Datapoint | None, key: str) -> str | None:
+    """Return the value for ``key`` in a datapoint's ``values``, or ``None``.
+
+    Centralises the "scan the ``[{key, value}, ...]`` list for a key" loop that
+    every platform otherwise repeats. Callers convert/interpret the raw string
+    value themselves (``== "1"``, ``float(...)``, scaling, ...).
+    """
+    if not datapoint:
+        return None
+    for value in datapoint.get("values", []):
+        if value.get("key") == key:
+            return value.get("value")
+    return None
+
+
 def datapoint_suffix(datapoint_id: str) -> str:
     """Return the stable element index of a datapoint id.
 

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -363,12 +363,13 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         The gateway broadcasts ``{"type":"scene","data":{...scene...}}`` whenever a
         scene is activated — including by a physical button, not just by this
         integration. Re-emitting it on the HA event bus lets users automate on
-        "scene X was recalled". The frame is sometimes delivered more than once
-        for a single recall, so automations should be idempotent (e.g. ``mode:
-        single`` with a short cooldown).
+        "scene X was recalled".
         """
         scene_id = data.get("id")
         label = data.get("label")
+        if scene_id is None:
+            _LOGGER.debug("Ignoring scene recall frame without an id: %s", data)
+            return
         _LOGGER.debug("Scene recalled: %s (%s)", label, scene_id)
         event_data: dict[str, Any] = {"scene_id": scene_id, "label": label}
         if self.config_entry is not None:

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -276,6 +276,14 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         data = message.get("data")
         msg_type = message.get("type")
         if isinstance(data, dict):
+            if msg_type == "scene":
+                # A scene was recalled (e.g. from a physical button). This is a
+                # different frame from the `scenes` list broadcast: data is the
+                # recalled scene object, not a datapoint. Without this branch it
+                # would fall through to the datapoint lookup below and log a
+                # spurious "no matching datapoint" warning.
+                self._handle_scene_recall(data)
+                return
             datapoint_id = data.get("id")
             if not datapoint_id:
                 _LOGGER.error(
@@ -348,6 +356,24 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             removed = {s.get("id") for s in items}
             self.scenes = [s for s in self.scenes if s.get("id") not in removed]
         self.async_update_listeners()
+
+    def _handle_scene_recall(self, data: dict[str, Any]) -> None:
+        """Fire a Home Assistant event when the gateway reports a scene recall.
+
+        The gateway broadcasts ``{"type":"scene","data":{...scene...}}`` whenever a
+        scene is activated — including by a physical button, not just by this
+        integration. Re-emitting it on the HA event bus lets users automate on
+        "scene X was recalled". The frame is sometimes delivered more than once
+        for a single recall, so automations should be idempotent (e.g. ``mode:
+        single`` with a short cooldown).
+        """
+        scene_id = data.get("id")
+        label = data.get("label")
+        _LOGGER.debug("Scene recalled: %s (%s)", label, scene_id)
+        event_data: dict[str, Any] = {"scene_id": scene_id, "label": label}
+        if self.config_entry is not None:
+            event_data["entry_id"] = self.config_entry.entry_id
+        self.hass.bus.async_fire(f"{DOMAIN}_scene_recalled", event_data)
 
     def _apply_gateway_version(self) -> None:
         """Push the gateway firmware version onto our devices in the registry.

--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -32,12 +32,11 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug, stable_unique_id
+from .const import datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
 from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,8 +49,12 @@ _MOVE_STOP = 0
 
 
 def _to_ha(device_level: int) -> int:
-    """Convert a device level (% closed) to a Home Assistant position (% open)."""
-    return 100 - device_level
+    """Convert a device level (% closed) to a Home Assistant position (% open).
+
+    Clamped to 0..100: the gateway level is untrusted JSON, and an out-of-range
+    value would otherwise produce an invalid HA position and break ``is_closed``.
+    """
+    return max(0, min(100, 100 - device_level))
 
 
 def _to_device(ha_position: int) -> int:
@@ -97,12 +100,11 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_discover_covers))
 
 
-class JungHomeCover(CoordinatorEntity[JungHomeDataUpdateCoordinator], CoverEntity):
+class JungHomeCover(JungHomeEntity, CoverEntity):
     """Representation of a Jung Home cover (blind / shutter)."""
 
     # The cover is the device's main feature, so it adopts the device name
     # (entity_id `cover.<device>`).
-    _attr_has_entity_name = True
     _attr_name = None
     _attr_device_class = CoverDeviceClass.BLIND
 
@@ -113,8 +115,7 @@ class JungHomeCover(CoordinatorEntity[JungHomeDataUpdateCoordinator], CoverEntit
         level_datapoint: Datapoint,
     ) -> None:
         """Initialize the cover."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = level_datapoint
         self._level_datapoint_id = level_datapoint["id"]
         self._angle_datapoint = next(
@@ -166,28 +167,6 @@ class JungHomeCover(CoordinatorEntity[JungHomeDataUpdateCoordinator], CoverEntit
             return None
         return self._position == 0
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this cover."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
-
-    @property
-    def available(self) -> bool:
-        """Return if the device is available.
-
-        Matches the other platforms: a live WebSocket link is the primary
-        availability signal, falling back to the last REST poll.
-        """
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
-
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover fully."""
         await self.coordinator.set_level(self._level_datapoint_id, _to_device(100))
@@ -212,6 +191,10 @@ class JungHomeCover(CoordinatorEntity[JungHomeDataUpdateCoordinator], CoverEntit
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self.coordinator.move_level(self._level_datapoint_id, _MOVE_STOP)
+        # A stop ends travel at an unknown position, so the optimistic
+        # open/close/set_position write is now stale. Re-read the real level
+        # instead of waiting up to a minute for the next REST poll.
+        await self.coordinator.async_request_refresh()
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the slats fully open."""
@@ -236,58 +219,31 @@ class JungHomeCover(CoordinatorEntity[JungHomeDataUpdateCoordinator], CoverEntit
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        device = next(
-            (
-                d
-                for d in self.coordinator.data or []
-                if d.get("id") == self._device["id"]
-            ),
-            None,
-        )
-        if device:
-            level_dp = next(
-                (
-                    dp
-                    for dp in device.get("datapoints", [])
-                    if dp.get("id") == self._level_datapoint_id
-                ),
-                None,
-            )
-            if level_dp:
-                self._position = self._get_position_from_datapoint(level_dp)
-            if self._angle_datapoint_id is not None:
-                angle_dp = next(
-                    (
-                        dp
-                        for dp in device.get("datapoints", [])
-                        if dp.get("id") == self._angle_datapoint_id
-                    ),
-                    None,
-                )
-                if angle_dp:
-                    self._tilt = self._get_tilt_from_datapoint(angle_dp)
+        level_dp = self._find_datapoint(self._level_datapoint_id)
+        if level_dp:
+            self._position = self._get_position_from_datapoint(level_dp)
+        if self._angle_datapoint_id is not None:
+            angle_dp = self._find_datapoint(self._angle_datapoint_id)
+            if angle_dp:
+                self._tilt = self._get_tilt_from_datapoint(angle_dp)
         self.async_write_ha_state()
 
     def _get_position_from_datapoint(self, datapoint: Datapoint | None) -> int | None:
         """Extract the HA position (% open) from a level datapoint."""
-        if not datapoint:
+        value = datapoint_value(datapoint, "level")
+        if value is None:
             return None
-        for value in datapoint.get("values", []):
-            if value["key"] == "level":
-                try:
-                    return _to_ha(round(float(value["value"])))
-                except (TypeError, ValueError):
-                    return None
-        return None
+        try:
+            return _to_ha(round(float(value)))
+        except (TypeError, ValueError):
+            return None
 
     def _get_tilt_from_datapoint(self, datapoint: Datapoint | None) -> int | None:
         """Extract the tilt position (0..100) from an angle datapoint."""
-        if not datapoint:
+        value = datapoint_value(datapoint, "angle")
+        if value is None:
             return None
-        for value in datapoint.get("values", []):
-            if value["key"] == "angle":
-                try:
-                    return round(float(value["value"]))
-                except (TypeError, ValueError):
-                    return None
-        return None
+        try:
+            return round(float(value))
+        except (TypeError, ValueError):
+            return None

--- a/custom_components/junghome/entity.py
+++ b/custom_components/junghome/entity.py
@@ -1,0 +1,82 @@
+"""Shared base entity for Jung Home device platforms.
+
+Every device-backed platform (light, switch, sensor, event, cover, climate)
+repeated the same ``device_info``, ``available`` and coordinator-data lookups.
+This base centralises them. The scene platform is intentionally *not* based on
+it — scenes have no backing device.
+
+Behaviour preserved exactly: ``device_info`` produces the same dict as before,
+``available`` keys off the same ``ws_connected or last_update_success`` signal,
+and the lookup helpers return the same objects the inline ``next(...)`` calls
+did. Subclasses keep their own ``unique_id``/naming and their own
+``_handle_coordinator_update`` write logic (which intentionally differs between
+platforms).
+"""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, device_slug
+from .coordinator import JungHomeDataUpdateCoordinator
+from .models import Datapoint, Device
+
+
+class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
+    """Base for entities backed by a Jung Home device."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: Device,
+    ) -> None:
+        """Initialise with the coordinator and the device this entity belongs to."""
+        super().__init__(coordinator)
+        self._device = device
+
+    @property
+    def available(self) -> bool:
+        """Return if the device is available.
+
+        A live WebSocket link means the gateway is reachable, so it is the
+        primary availability signal; fall back to the last REST poll result
+        until the socket first connects (or while it is reconnecting). Keeping
+        this on the base means every entity on a device goes (un)available
+        together rather than diverging on a transient poll miss.
+        """
+        return self.coordinator.ws_connected or self.coordinator.last_update_success
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information, linking the entity to its Jung Home device."""
+        return {
+            "identifiers": {(DOMAIN, device_slug(self._device))},
+            "name": self._device.get("label", "Jung Device"),
+            "manufacturer": "Jung",
+            "model": self._device.get("type", "Unknown Model"),
+            "sw_version": self._device.get("sw_version")
+            or self.coordinator.gateway_version
+            or "Unknown Version",
+        }
+
+    def _current_device(self) -> Device | None:
+        """Return this entity's device from the latest coordinator data."""
+        return next(
+            (
+                d
+                for d in self.coordinator.data or []
+                if d.get("id") == self._device["id"]
+            ),
+            None,
+        )
+
+    def _find_datapoint(self, datapoint_id: str) -> Datapoint | None:
+        """Return a datapoint by id from this entity's current device data."""
+        device = self._current_device()
+        if device is None:
+            return None
+        return next(
+            (dp for dp in device.get("datapoints", []) if dp.get("id") == datapoint_id),
+            None,
+        )

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -4,12 +4,11 @@ import logging
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug, stable_unique_id
+from .const import datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
 from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,14 +65,11 @@ async def async_setup_entry(
 # ------------------------------------------
 # 🔹 EVENT ENTITY (For UI Integration)
 # ------------------------------------------
-class JungHomeEventEntity(
-    CoordinatorEntity[JungHomeDataUpdateCoordinator], EventEntity
-):
+class JungHomeEventEntity(JungHomeEntity, EventEntity):
     """Event entity for Jung Home button presses."""
 
     _attr_event_types = ["pressed", "depressed"]
     _attr_device_class = EventDeviceClass.BUTTON
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -82,8 +78,7 @@ class JungHomeEventEntity(
         datapoint: Datapoint,
     ) -> None:
         """Initialize the event entity."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = datapoint
         dp_type = datapoint.get("type", "Unknown")
         translation_key = _EVENT_TRANSLATION_KEYS.get(dp_type)
@@ -93,30 +88,6 @@ class JungHomeEventEntity(
             self._attr_name = dp_type
         self._attr_unique_id = stable_unique_id(device, datapoint, "event")
         # Icon comes from icons.json (icon-translations).
-
-    @property
-    def available(self) -> bool:
-        """Return if the device is available.
-
-        Matches the light/socket/LED entities: a live WebSocket link is the
-        primary availability signal, falling back to the last REST poll, so an
-        event entity doesn't go unavailable on a transient REST-poll miss while
-        the WebSocket (which actually delivers its presses) is still connected.
-        """
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for this event entity."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -134,22 +105,7 @@ class JungHomeEventEntity(
         # write state below, so availability tracks the gateway connection without
         # ever emitting a phantom press.
         if self.coordinator.pushed_datapoint_id == self._datapoint["id"]:
-            device = next(
-                (
-                    d
-                    for d in self.coordinator.data or []
-                    if d.get("id") == self._device["id"]
-                ),
-                None,
-            )
-            datapoint = next(
-                (
-                    dp
-                    for dp in (device["datapoints"] if device else [])
-                    if dp.get("id") == self._datapoint["id"]
-                ),
-                None,
-            )
+            datapoint = self._find_datapoint(self._datapoint["id"])
             if datapoint:
                 event_type = (
                     "pressed"
@@ -165,10 +121,4 @@ class JungHomeEventEntity(
 
         Scoped to this datapoint's own type so bundled request keys don't merge.
         """
-        for value in datapoint.get("values", []):
-            if (
-                value.get("key") == self._datapoint.get("type")
-                and value.get("value") == "1"
-            ):
-                return True
-        return False
+        return datapoint_value(datapoint, self._datapoint.get("type", "")) == "1"

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -6,12 +6,11 @@ from typing import Any
 from homeassistant.components.light import LightEntity
 from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug, stable_unique_id
+from .const import datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
 from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,13 +53,12 @@ async def async_setup_entry(
     config_entry.async_on_unload(coordinator.async_add_listener(_discover_lights))
 
 
-class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntity):
+class JungHomeLight(JungHomeEntity, LightEntity):
     """Representation of a Jung Home light."""
 
     # The light is the device's main feature, so it adopts the device name. With
     # has_entity_name the entity_id is `light.<device>` instead of the old
     # `light.<device>_<device>` (label was previously baked into the name too).
-    _attr_has_entity_name = True
     _attr_name = None
 
     def __init__(
@@ -70,8 +68,7 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         datapoint: Datapoint,
     ) -> None:
         """Initialize the light."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = datapoint
         # Find related datapoints (brightness / color_temperature) for ColorLight
         self._brightness_datapoint = next(
@@ -156,68 +153,25 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         """Return the color temperature in Kelvin (device-native)."""
         return self._color_temp
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this light."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},  # Link to the device
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug("Handling coordinator update for light %s", self._name)
-        device = next(
-            (
-                d
-                for d in self.coordinator.data or []
-                if d.get("id") == self._device["id"]
-            ),
-            None,
-        )
-        if device:
-            datapoint = next(
-                (
-                    dp
-                    for dp in device.get("datapoints", [])
-                    if dp.get("id") == self._datapoint["id"]
-                ),
-                None,
-            )
-            if datapoint:
-                self._is_on = self._get_state_from_datapoint(datapoint)
-                if self._has_brightness:
-                    # Update brightness/color_temp from their respective datapoints (if available)
-                    if self._brightness_datapoint_id:
-                        brightness_dp = next(
-                            (
-                                dp
-                                for dp in device.get("datapoints", [])
-                                if dp.get("id") == self._brightness_datapoint_id
-                            ),
-                            None,
-                        )
-                        self._brightness = self._get_brightness_from_datapoint(
-                            brightness_dp
-                        )
-                    if self._color_temp_datapoint_id:
-                        color_dp = next(
-                            (
-                                dp
-                                for dp in device.get("datapoints", [])
-                                if dp.get("id") == self._color_temp_datapoint_id
-                            ),
-                            None,
-                        )
-                        self._color_temp = self._get_color_temp_from_datapoint(color_dp)
-                _LOGGER.debug("Updated state for light %s: %s", self._name, self._is_on)
-                self.async_write_ha_state()
+        datapoint = self._find_datapoint(self._datapoint["id"])
+        if datapoint:
+            self._is_on = self._get_state_from_datapoint(datapoint)
+            if self._has_brightness:
+                # Update brightness/color_temp from their respective datapoints.
+                if self._brightness_datapoint_id:
+                    self._brightness = self._get_brightness_from_datapoint(
+                        self._find_datapoint(self._brightness_datapoint_id)
+                    )
+                if self._color_temp_datapoint_id:
+                    self._color_temp = self._get_color_temp_from_datapoint(
+                        self._find_datapoint(self._color_temp_datapoint_id)
+                    )
+            _LOGGER.debug("Updated state for light %s: %s", self._name, self._is_on)
+            self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
@@ -239,41 +193,21 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
         self._is_on = False
         self.async_write_ha_state()
 
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed for this entity."""
-        return False
-
-    @property
-    def available(self) -> bool:
-        """Return if the device is available.
-
-        A live WebSocket link means the gateway is reachable, so it is the
-        primary availability signal; fall back to the last REST poll result
-        until the socket first connects (or while it is reconnecting).
-        """
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
-
     def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         """Extract the state of the light from its datapoint."""
-        for value in datapoint.get("values", []):
-            if value["key"] == "switch":
-                return value["value"] == "1"
-        return False
+        return datapoint_value(datapoint, "switch") == "1"
 
     def _get_brightness_from_datapoint(self, datapoint: Datapoint | None) -> int:
         """Extract the brightness of the light from its datapoint."""
-        if not datapoint:
+        value = datapoint_value(datapoint, "brightness")
+        if value is None:
             return 0
-        for value in datapoint.get("values", []):
-            if value["key"] == "brightness":
-                try:
-                    raw = int(value["value"])
-                except (TypeError, ValueError):
-                    raw = 0
-                # Device reports 0-100; convert linearly to HA 0-255
-                return round(raw * 255 / 100)
-        return 0
+        try:
+            raw = int(value)
+        except (TypeError, ValueError):
+            raw = 0
+        # Device reports 0-100; convert linearly to HA 0-255
+        return round(raw * 255 / 100)
 
     def _ha_to_raw_brightness(self, ha_brightness: int) -> int:
         """Convert Home Assistant 0-255 brightness to device raw scale (0-100)."""
@@ -284,16 +218,14 @@ class JungHomeLight(CoordinatorEntity[JungHomeDataUpdateCoordinator], LightEntit
 
     def _get_color_temp_from_datapoint(self, datapoint: Datapoint | None) -> int | None:
         """Extract the color temperature of the light from its datapoint."""
-        if not datapoint:
+        value = datapoint_value(datapoint, "color_temperature")
+        if value is None:
             return None
-        for value in datapoint.get("values", []):
-            if value["key"] == "color_temperature":
-                try:
-                    # Device reports Kelvin; store Kelvin
-                    return int(value["value"])
-                except (TypeError, ValueError):
-                    return None
-        return None
+        try:
+            # Device reports Kelvin; store Kelvin
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     async def _set_brightness(self, brightness: int) -> None:
         """Set the brightness of the light."""

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b17",
+  "version": "1.2.0b18",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/scene.py
+++ b/custom_components/junghome/scene.py
@@ -41,23 +41,36 @@ async def async_setup_entry(
 ) -> None:
     """Set up Jung Home scenes from a config entry."""
     coordinator = entry.runtime_data
-    known: set[str] = set()
+    entities: dict[str, JungHomeScene] = {}
 
     @callback
     def _discover_scenes() -> None:
-        """Add entities for any scenes not yet created."""
-        new_entities: list[JungHomeScene] = []
+        """Add scenes that appeared and remove scenes the gateway deleted.
+
+        Unlike the device platforms (which prune whole devices in __init__),
+        scenes have no backing device, so they are added and removed here as the
+        gateway's ``scenes`` / ``scenes-deleted`` broadcasts change the list.
+        """
+        current: dict[str, str] = {}  # unique_id -> label
         for scene in coordinator.scenes or []:
             label = scene.get("label")
-            if not label:
-                continue
-            uid = f"{_scene_slug(label)}_scene"
-            if uid in known:
-                continue
-            known.add(uid)
-            new_entities.append(JungHomeScene(coordinator, label, uid))
+            if label:
+                current[f"{_scene_slug(label)}_scene"] = label
+
+        new_entities: list[JungHomeScene] = []
+        for uid, label in current.items():
+            if uid not in entities:
+                entity = JungHomeScene(coordinator, label, uid)
+                entities[uid] = entity
+                new_entities.append(entity)
         if new_entities:
             async_add_entities(new_entities)
+
+        # Drop entities whose scene no longer exists, so a deleted scene doesn't
+        # linger as an always-failing entity.
+        for uid in list(entities):
+            if uid not in current:
+                hass.async_create_task(entities.pop(uid).async_remove())
 
     _discover_scenes()
     entry.async_on_unload(coordinator.async_add_listener(_discover_scenes))
@@ -66,6 +79,10 @@ async def async_setup_entry(
 class JungHomeScene(CoordinatorEntity[JungHomeDataUpdateCoordinator], SceneEntity):
     """Representation of a Jung Home scene."""
 
+    # Scenes have no backing JUNG device, so (like Home Assistant's own scene
+    # platform) the scene's own label is the entity name rather than a
+    # device-prefixed one. This is why the scene entity does not use
+    # JungHomeEntity and sets has_entity_name = False with an explicit name.
     _attr_has_entity_name = False
 
     def __init__(

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -18,12 +18,11 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug, stable_unique_id
+from .const import datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
 from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,22 +77,9 @@ async def async_setup_entry(
             if device.get("type") in ("Socket", "Measurement"):
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "quantity":
-                        label = next(
-                            (
-                                (value.get("value") or "").strip()
-                                for value in datapoint.get("values", [])
-                                if value.get("key") == "quantity_label"
-                            ),
-                            None,
-                        )
-                        unit = next(
-                            (
-                                value.get("value")
-                                for value in datapoint.get("values", [])
-                                if value.get("key") == "quantity_unit"
-                            ),
-                            None,
-                        )
+                        raw_label = datapoint_value(datapoint, "quantity_label")
+                        label = raw_label.strip() if raw_label else None
+                        unit = datapoint_value(datapoint, "quantity_unit")
                         if label and unit:
                             uid = stable_unique_id(
                                 device, datapoint, label.replace(" ", "_").lower()
@@ -112,13 +98,12 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_discover_sensors))
 
 
-class JungHomeQuantity(CoordinatorEntity[JungHomeDataUpdateCoordinator], SensorEntity):
+class JungHomeQuantity(JungHomeEntity, SensorEntity):
     """Representation of a Jung Home quantity."""
 
     # Secondary entity on the device; HA prepends the device name, so the
     # entity_id becomes `sensor.<device>_<quantity>` (the label is no longer
     # baked into the entity name).
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -129,8 +114,7 @@ class JungHomeQuantity(CoordinatorEntity[JungHomeDataUpdateCoordinator], SensorE
         unit: str,
     ) -> None:
         """Initialize the quantity."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = datapoint
         self._attr_name = label
         self._name = f"{device.get('label', 'Jung Device')} {label}"  # for logging
@@ -163,17 +147,6 @@ class JungHomeQuantity(CoordinatorEntity[JungHomeDataUpdateCoordinator], SensorE
         return self._unique_id
 
     @property
-    def available(self) -> bool:
-        """Return if the device is available.
-
-        Matches the light/socket/LED/event entities: a live WebSocket link is the
-        primary availability signal, falling back to the last REST poll, so all
-        entities on a device go (un)available together rather than the sensor
-        diverging on a transient poll miss.
-        """
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
-
-    @property
     def native_value(self) -> float | str | None:
         """Return the measured value (numeric when the unit has a state class)."""
         if self._value is None:
@@ -185,50 +158,17 @@ class JungHomeQuantity(CoordinatorEntity[JungHomeDataUpdateCoordinator], SensorE
                 return None
         return self._value
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this quantity."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},  # Link to the device
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug("Handling coordinator update for quantity %s", self._name)
-        device = next(
-            (
-                d
-                for d in self.coordinator.data or []
-                if d.get("id") == self._device["id"]
-            ),
-            None,
-        )
-        if device:
-            datapoint = next(
-                (
-                    dp
-                    for dp in device.get("datapoints", [])
-                    if dp.get("id") == self._datapoint["id"]
-                ),
-                None,
-            )
-            if datapoint:
-                self._value = self._get_value_from_datapoint(datapoint)
-                _LOGGER.debug(
-                    "Updated state for quantity %s: %s", self._name, self._value
-                )
-                self.async_write_ha_state()
+        datapoint = self._find_datapoint(self._datapoint["id"])
+        if datapoint:
+            self._value = self._get_value_from_datapoint(datapoint)
+            _LOGGER.debug("Updated state for quantity %s: %s", self._name, self._value)
+            self.async_write_ha_state()
 
     def _get_value_from_datapoint(self, datapoint: Datapoint) -> str | None:
         """Extract the value of the quantity from its datapoint."""
-        for value in datapoint.get("values", []):
-            if value["key"] == "quantity":
-                return str(value["value"])
-        return None
+        value = datapoint_value(datapoint, "quantity")
+        return None if value is None else str(value)

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -54,6 +54,17 @@
     }
   },
   "entity": {
+    "climate": {
+      "thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "frost": "Frost protection"
+            }
+          }
+        }
+      }
+    },
     "event": {
       "up": { "name": "Up" },
       "down": { "name": "Down" },

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -5,12 +5,11 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug, stable_unique_id
+from .const import datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
 from .models import Datapoint, Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,12 +57,11 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(_discover_switches))
 
 
-class JungHomeSocket(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEntity):
+class JungHomeSocket(JungHomeEntity, SwitchEntity):
     """Representation of a Jung Home socket."""
 
     # The socket is the device's main feature, so it adopts the device name
     # (entity_id `switch.<device>`, not the old `switch.<device>_<device>`).
-    _attr_has_entity_name = True
     _attr_name = None
     _attr_device_class = SwitchDeviceClass.OUTLET
 
@@ -74,8 +72,7 @@ class JungHomeSocket(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
         datapoint: Datapoint,
     ) -> None:
         """Initialize the socket."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = datapoint
         self._name = device.get("label", "Jung Socket")
         # Firmware-stable id derived from the label, not the volatile device id.
@@ -92,46 +89,15 @@ class JungHomeSocket(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
         """Return the state of the socket."""
         return self._is_on
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this socket."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},  # Link to the device
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug("Handling coordinator update for socket %s", self._name)
-        device = next(
-            (
-                d
-                for d in self.coordinator.data or []
-                if d.get("id") == self._device["id"]
-            ),
-            None,
-        )
-        if device:
-            datapoint = next(
-                (
-                    dp
-                    for dp in device.get("datapoints", [])
-                    if dp.get("id") == self._datapoint["id"]
-                ),
-                None,
-            )
-            if datapoint:
-                self._is_on = self._get_state_from_datapoint(datapoint)
-                _LOGGER.debug(
-                    "Updated state for socket %s: %s", self._name, self._is_on
-                )
-                self.async_write_ha_state()
+        datapoint = self._find_datapoint(self._datapoint["id"])
+        if datapoint:
+            self._is_on = self._get_state_from_datapoint(datapoint)
+            _LOGGER.debug("Updated state for socket %s: %s", self._name, self._is_on)
+            self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the socket on."""
@@ -147,36 +113,17 @@ class JungHomeSocket(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
         self._is_on = False
         self.async_write_ha_state()
 
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed for this entity."""
-        return False
-
-    @property
-    def available(self) -> bool:
-        """Return if the device is available.
-
-        A live WebSocket link means the gateway is reachable, so it is the
-        primary availability signal; fall back to the last REST poll result
-        until the socket first connects (or while it is reconnecting).
-        """
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
-
     def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         """Extract the state of the socket from its datapoint."""
-        for value in datapoint.get("values", []):
-            if value["key"] == "switch":
-                return value["value"] == "1"
-        return False
+        return datapoint_value(datapoint, "switch") == "1"
 
 
-class JungHomeSwitch(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEntity):
+class JungHomeSwitch(JungHomeEntity, SwitchEntity):
     """Representation of a Jung Home status LED as a switch entity."""
 
     # Secondary entity on the rocker device; HA prepends the device name, so the
     # entity_id becomes `switch.<device>_status_led`. The name comes from the
     # entity.switch.status_led translation.
-    _attr_has_entity_name = True
     _attr_translation_key = "status_led"
 
     def __init__(
@@ -186,47 +133,18 @@ class JungHomeSwitch(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
         datapoint: Datapoint,
     ) -> None:
         """Initialize the status LED switch."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._datapoint = datapoint
         self._attr_unique_id = stable_unique_id(device, datapoint, "switch")
         self._attr_is_on = self._get_state_from_datapoint(datapoint)
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for the rocker this LED belongs to."""
-        return {
-            "identifiers": {(DOMAIN, device_slug(self._device))},
-            "name": self._device.get("label", "Jung Device"),
-            "manufacturer": "Jung",
-            "model": self._device.get("type", "Unknown Model"),
-            "sw_version": self._device.get("sw_version")
-            or self.coordinator.gateway_version
-            or "Unknown Version",
-        }
-
     def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
-        for value in datapoint.get("values", []):
-            if value["key"] == "status_led":
-                return value["value"] == "1"
-        return False
+        return datapoint_value(datapoint, "status_led") == "1"
 
     @property
     def is_on(self) -> bool | None:
         """Return whether the status LED is on."""
         return self._attr_is_on
-
-    @property
-    def available(self) -> bool:
-        """Return if the device is available.
-
-        Matches the light/socket entities: a live WebSocket link is the primary
-        availability signal, falling back to the last REST poll. (Inheriting the
-        CoordinatorEntity default would key only on the 1-minute REST poll, so a
-        transient poll miss would mark this LED unavailable while the light on the
-        same device stayed up.)
-        """
-        return self.coordinator.ws_connected or self.coordinator.last_update_success
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the status LED on."""
@@ -247,22 +165,7 @@ class JungHomeSwitch(CoordinatorEntity[JungHomeDataUpdateCoordinator], SwitchEnt
     @callback
     def _handle_coordinator_update(self) -> None:
         _LOGGER.debug("Updating switch for %s", self._attr_unique_id)
-        device = next(
-            (
-                d
-                for d in self.coordinator.data or []
-                if d.get("id") == self._device["id"]
-            ),
-            None,
-        )
-        datapoint = next(
-            (
-                dp
-                for dp in (device["datapoints"] if device else [])
-                if dp.get("id") == self._datapoint["id"]
-            ),
-            None,
-        )
+        datapoint = self._find_datapoint(self._datapoint["id"])
         if datapoint is not None:
             self._attr_is_on = self._get_state_from_datapoint(datapoint)
         # Write unconditionally (even when the datapoint is momentarily absent) so

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -54,6 +54,17 @@
     }
   },
   "entity": {
+    "climate": {
+      "thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "frost": "Frost protection"
+            }
+          }
+        }
+      }
+    },
     "event": {
       "up": { "name": "Up" },
       "down": { "name": "Down" },

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -80,11 +80,11 @@ scene object (note: singular `scene` with an object, distinct from the plural
   } }
 ```
 
-Observed behaviour: a single recall is sometimes delivered as **two identical
-frames**. The integration re-emits each recall on the Home Assistant event bus as
+The integration re-emits each recall on the Home Assistant event bus as
 `junghome_scene_recalled` (`{scene_id, label, entry_id}`) so automations can react
-to physical scene buttons; because of the duplicate delivery, such automations
-should be idempotent (`mode: single` with a short cooldown).
+to physical scene buttons. (One recall produces one frame — back-to-back
+duplicates you may see while testing are just the scene being triggered twice,
+e.g. a double press.)
 
 ## Client → server commands
 

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -63,6 +63,29 @@ A pushed `datapoint` frame carries the updated datapoint object, e.g.:
   } }
 ```
 
+### Scene recall (`scene`, singular)
+
+When a scene is activated — including by a **physical button**, not just via the
+REST recall — the gateway broadcasts a `scene` frame whose `data` is the recalled
+scene object (note: singular `scene` with an object, distinct from the plural
+`scenes` list broadcast):
+
+```jsonc
+{ "type": "scene",
+  "data": {
+    "id": "id0001",
+    "label": "Išjungti WC",
+    "related_functions": [ "id9dc9e42e3bbb3da", "idef507c9c9a01d16" ],
+    "value": "0001"
+  } }
+```
+
+Observed behaviour: a single recall is sometimes delivered as **two identical
+frames**. The integration re-emits each recall on the Home Assistant event bus as
+`junghome_scene_recalled` (`{scene_id, label, entry_id}`) so automations can react
+to physical scene buttons; because of the duplicate delivery, such automations
+should be idempotent (`mode: single` with a short cooldown).
+
 ## Client → server commands
 
 Send a JSON frame with a `type`. An optional `message_id` is echoed back on the
@@ -129,8 +152,9 @@ Any failure is returned as a `message` frame:
 - State updates arrive as `datapoint` broadcasts; the coordinator matches them to
   entities. Commands are sent as `datapoint` set frames.
 - The coordinator consumes the `scenes` / `scenes-new` / `scenes-deleted`
-  broadcasts to populate the scene platform (recall is REST-only). `groups`
-  broadcasts are still ignored.
+  broadcasts to populate the scene platform (recall is REST-only). The singular
+  `scene` recall frame is re-emitted as a `junghome_scene_recalled` HA event.
+  `groups` broadcasts are still ignored.
 - Reconnect on drop: the gateway sends the full `functions`/`groups`/`scenes`
   snapshot again on every new connection, so re-syncing is automatic.
 - Watch `functions` / `*-new` / `*-deleted` frames to pick up devices added or

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -149,3 +149,25 @@ async def test_activate_scene_raises_on_error(hass: HomeAssistant) -> None:
         pytest.raises(HomeAssistantError),
     ):
         await coordinator.activate_scene("idX")
+
+
+async def test_scene_recall_fires_event(hass: HomeAssistant) -> None:
+    """A `scene` recall frame fires junghome_scene_recalled (not a datapoint)."""
+    coordinator = _coordinator(hass)
+    events = []
+    hass.bus.async_listen(f"{DOMAIN}_scene_recalled", events.append)
+    coordinator._handle_websocket_message(
+        {
+            "type": "scene",
+            "data": {
+                "id": "id0001",
+                "label": "Išjungti WC",
+                "related_functions": [],
+                "value": "0001",
+            },
+        }
+    )
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["scene_id"] == "id0001"
+    assert events[0].data["label"] == "Išjungti WC"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -171,3 +171,15 @@ async def test_scene_recall_fires_event(hass: HomeAssistant) -> None:
     assert len(events) == 1
     assert events[0].data["scene_id"] == "id0001"
     assert events[0].data["label"] == "Išjungti WC"
+
+
+async def test_scene_recall_without_id_is_ignored(hass: HomeAssistant) -> None:
+    """A scene recall frame with no id fires no event."""
+    coordinator = _coordinator(hass)
+    events = []
+    hass.bus.async_listen(f"{DOMAIN}_scene_recalled", events.append)
+    coordinator._handle_websocket_message(
+        {"type": "scene", "data": {"label": "No id here"}}
+    )
+    await hass.async_block_till_done()
+    assert events == []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,8 @@ from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -13,13 +15,16 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome import async_unload_entry
+from custom_components.junghome.climate import JungHomeClimate
 from custom_components.junghome.const import DOMAIN, device_slug
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
+from custom_components.junghome.cover import JungHomeCover
 from custom_components.junghome.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 from custom_components.junghome.event import JungHomeEventEntity
 from custom_components.junghome.light import JungHomeLight
+from custom_components.junghome.scene import JungHomeScene, _scene_slug
 from custom_components.junghome.sensor import JungHomeQuantity
 from custom_components.junghome.switch import JungHomeSocket, JungHomeSwitch
 
@@ -90,6 +95,18 @@ DEVICES = [
                 "id": "idblind1-002",
                 "type": "angle",
                 "values": [{"key": "angle", "value": "40"}],
+            },
+        ],
+    },
+    {
+        "id": "idblind2",
+        "type": "Position",
+        "label": "Kitchen Shade",
+        "datapoints": [
+            {
+                "id": "idblind2-001",
+                "type": "level",
+                "values": [{"key": "level", "value": "0"}],
             },
         ],
     },
@@ -1106,3 +1123,255 @@ async def test_scene_created_and_activated(
             "scene", "turn_on", {"entity_id": "scene.movie_night"}, blocking=True
         )
     assert act.call_args.args[0] == "idscene1"
+
+
+def _cover(
+    coordinator: JungHomeDataUpdateCoordinator, with_angle: bool = True
+) -> JungHomeCover:
+    dps = [{"id": "b-1", "type": "level", "values": [{"key": "level", "value": "30"}]}]
+    if with_angle:
+        dps.append(
+            {"id": "b-2", "type": "angle", "values": [{"key": "angle", "value": "40"}]}
+        )
+    device = {
+        "id": "b",
+        "type": "PositionAndAngle" if with_angle else "Position",
+        "label": "B",
+        "datapoints": dps,
+    }
+    return JungHomeCover(coordinator, device, dps[0])
+
+
+async def test_cover_position_only_has_no_tilt(hass: HomeAssistant, init_integration):
+    """A Position (level-only) device exposes no tilt and creates a cover."""
+    state = hass.states.get("cover.kitchen_shade")
+    assert state is not None
+    assert state.attributes.get("current_tilt_position") is None
+    assert not (
+        state.attributes["supported_features"] & CoverEntityFeature.SET_TILT_POSITION
+    )
+
+
+async def test_cover_extractors_defensive(hass: HomeAssistant) -> None:
+    """Cover value extractors tolerate missing/garbage datapoints."""
+    cover = _cover(_bare_coordinator(hass))
+    assert cover._get_position_from_datapoint(None) is None
+    assert cover._get_tilt_from_datapoint(None) is None
+    assert (
+        cover._get_position_from_datapoint(
+            {"id": "x", "values": [{"key": "level", "value": "NaN"}]}
+        )
+        is None
+    )
+    assert (
+        cover._get_tilt_from_datapoint(
+            {"id": "x", "values": [{"key": "angle", "value": "NaN"}]}
+        )
+        is None
+    )
+    assert cover._get_position_from_datapoint({"id": "x", "values": []}) is None
+
+
+async def test_cover_is_closed_none_when_position_unknown(hass: HomeAssistant) -> None:
+    """is_closed is None when the level can't be read."""
+    cover = _cover(_bare_coordinator(hass))
+    cover._position = None
+    assert cover.is_closed is None
+
+
+async def test_cover_tilt_commands(hass: HomeAssistant) -> None:
+    """open/close tilt drive the angle command to 100/0."""
+    coordinator = _bare_coordinator(hass)
+    cover = _cover(coordinator)
+    with (
+        patch.object(coordinator, "set_angle", AsyncMock()) as sa,
+        patch.object(cover, "async_write_ha_state"),
+    ):
+        await cover.async_open_cover_tilt()
+        await cover.async_close_cover_tilt()
+    assert [c.args[1] for c in sa.call_args_list] == [100, 0]
+
+
+async def test_cover_stop_requests_refresh(hass: HomeAssistant) -> None:
+    """Stop sends level_move 0 and re-reads the real position."""
+    coordinator = _bare_coordinator(hass)
+    cover = _cover(coordinator)
+    with (
+        patch.object(coordinator, "move_level", AsyncMock()) as ml,
+        patch.object(coordinator, "async_request_refresh", AsyncMock()) as rr,
+    ):
+        await cover.async_stop_cover()
+    ml.assert_called_once()
+    rr.assert_called_once()
+
+
+async def test_cover_handle_update_missing_device_noops(hass: HomeAssistant) -> None:
+    """Cover update writes state even when the device is gone."""
+    cover = _cover(_bare_coordinator(hass))  # coordinator.data is []
+    with patch.object(cover, "async_write_ha_state") as write_state:
+        cover._handle_coordinator_update()
+    write_state.assert_called_once()
+
+
+def _climate(
+    coordinator: JungHomeDataUpdateCoordinator,
+    current_unit: str | None = "°C",
+    target: str = "21.5",
+    preset: str = "comfort",
+) -> JungHomeClimate:
+    dps = [
+        {
+            "id": "t-1",
+            "type": "temperature_ctrl",
+            "values": [
+                {"key": "temperature_ctrl", "value": target},
+                {"key": "temperature_ctrl_preset", "value": preset},
+            ],
+        }
+    ]
+    if current_unit is not None:
+        dps.append(
+            {
+                "id": "t-10",
+                "type": "quantity",
+                "values": [
+                    {"key": "quantity", "value": "20.0"},
+                    {"key": "quantity_unit", "value": current_unit},
+                ],
+            }
+        )
+    device = {"id": "t", "type": "Thermostat", "label": "T", "datapoints": dps}
+    return JungHomeClimate(coordinator, device, dps[0])
+
+
+async def test_climate_extractors_defensive(hass: HomeAssistant) -> None:
+    """Climate target/preset extractors tolerate missing/garbage datapoints."""
+    climate = _climate(_bare_coordinator(hass))
+    assert climate._get_target_from_datapoint(None) is None
+    assert (
+        climate._get_target_from_datapoint(
+            {"id": "x", "values": [{"key": "temperature_ctrl", "value": "abc"}]}
+        )
+        is None
+    )
+    assert climate._get_preset_from_datapoint(None) is None
+    # An unknown device preset maps to None.
+    assert (
+        climate._get_preset_from_datapoint(
+            {"id": "x", "values": [{"key": "temperature_ctrl_preset", "value": "huh"}]}
+        )
+        is None
+    )
+
+
+async def test_climate_current_temperature_paths(hass: HomeAssistant) -> None:
+    """current_temperature ignores non-°C siblings and unparseable values."""
+    coordinator = _bare_coordinator(hass)
+    # A "%" sibling is not a temperature -> None.
+    assert _climate(coordinator, current_unit="%").current_temperature is None
+    # No sibling quantity at all -> None.
+    assert _climate(coordinator, current_unit=None).current_temperature is None
+    # A °C sibling with a garbage value -> None.
+    climate = _climate(coordinator)
+    assert (
+        climate._get_current_temperature(
+            {
+                "datapoints": [
+                    {
+                        "type": "quantity",
+                        "values": [
+                            {"key": "quantity", "value": "abc"},
+                            {"key": "quantity_unit", "value": "°C"},
+                        ],
+                    }
+                ]
+            }
+        )
+        is None
+    )
+
+
+async def test_climate_set_temperature_without_value_noops(hass: HomeAssistant) -> None:
+    coordinator = _bare_coordinator(hass)
+    climate = _climate(coordinator)
+    with patch.object(coordinator, "set_temperature", AsyncMock()) as st:
+        await climate.async_set_temperature()
+    st.assert_not_called()
+
+
+async def test_climate_unknown_preset_noops(hass: HomeAssistant) -> None:
+    coordinator = _bare_coordinator(hass)
+    climate = _climate(coordinator)
+    with patch.object(coordinator, "set_temperature_preset", AsyncMock()) as sp:
+        await climate.async_set_preset_mode("nonsense")
+    sp.assert_not_called()
+
+
+async def test_climate_set_hvac_mode_is_noop(hass: HomeAssistant) -> None:
+    """The single-mode thermostat accepts set_hvac_mode without sending anything."""
+    coordinator = _bare_coordinator(hass)
+    climate = _climate(coordinator)
+    with patch.object(coordinator, "send_websocket_message", AsyncMock()) as send:
+        await climate.async_set_hvac_mode(HVACMode.HEAT)  # must not raise
+    send.assert_not_called()
+
+
+async def test_climate_handle_update_missing_device_noops(hass: HomeAssistant) -> None:
+    climate = _climate(_bare_coordinator(hass))  # coordinator.data is []
+    with patch.object(climate, "async_write_ha_state") as write_state:
+        climate._handle_coordinator_update()
+    write_state.assert_called_once()
+
+
+def test_scene_slug_fallback() -> None:
+    """Unsluggable labels fall back to a stable 'scene' slug."""
+    assert _scene_slug("") == "scene"
+    assert _scene_slug("Movie Night") == "movie_night"
+
+
+async def test_scene_removed_when_deleted(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A scene the gateway deletes has its entity removed."""
+    coordinator = init_integration.runtime_data
+    coordinator._handle_websocket_message(
+        {"type": "scenes", "data": [{"id": "s1", "label": "Movie Night"}]}
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("scene.movie_night") is not None
+    # Gateway removes it (scene list now empty) -> the live entity is removed,
+    # leaving only a restored/unavailable placeholder that can't be activated.
+    coordinator._handle_websocket_message({"type": "scenes", "data": []})
+    await hass.async_block_till_done()
+    state = hass.states.get("scene.movie_night")
+    assert state is None or state.state == "unavailable"
+
+
+async def test_scene_activate_raises_when_missing(hass: HomeAssistant) -> None:
+    """Activating a scene absent from the coordinator raises a translated error."""
+    coordinator = _bare_coordinator(hass)
+    coordinator.scenes = []
+    scene = JungHomeScene(coordinator, "Ghost", "ghost_scene")
+    with pytest.raises(HomeAssistantError):
+        await scene.async_activate()
+
+
+async def test_scene_reresolves_id_after_firmware_change(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Activation re-resolves the volatile scene id from the stable label."""
+    coordinator = init_integration.runtime_data
+    coordinator._handle_websocket_message(
+        {"type": "scenes", "data": [{"id": "old", "label": "Movie Night"}]}
+    )
+    await hass.async_block_till_done()
+    # Firmware update regenerates the scene id under the same label.
+    coordinator._handle_websocket_message(
+        {"type": "scenes", "data": [{"id": "new", "label": "Movie Night"}]}
+    )
+    await hass.async_block_till_done()
+    with patch.object(coordinator, "activate_scene", AsyncMock()) as act:
+        await hass.services.async_call(
+            "scene", "turn_on", {"entity_id": "scene.movie_night"}, blocking=True
+        )
+    assert act.call_args.args[0] == "new"


### PR DESCRIPTION
Cuts beta **1.2.0b18**. Two strands:

## 1. Scene recall handling
The gateway broadcasts `{"type":"scene","data":{...}}` when a scene is recalled (incl. from a physical button). It was misrouted into the datapoint lookup (spurious warning, recall dropped). Now routed to a handler that re-emits each recall as a **`junghome_scene_recalled`** HA event (`{scene_id, label, entry_id}`) so automations can react to physical scene buttons. Documented in `docs/gateway-websocket.md` and the README.

## 2. Code review (5 parallel agents) — refactor + fixes
**Maintainability (behavior-preserving):** new `entity.py` `JungHomeEntity` base centralises `device_info`, `available`, and the coordinator-data lookups; new `datapoint_value()` helper. light/switch/sensor/event/cover/climate inherit it, dropping ~25 duplicated blocks. unique_ids, the event push-guard, and the conditional/unconditional write split are preserved.

**Correctness / robustness:**
- climate: translate the custom `frost` preset (keeps the platinum `entity-translations` rule honest).
- cover: `stop` requests a refresh (no stale optimistic position); inverted position clamped to 0..100.
- coordinator: ignore scene-recall frames without an id.
- `__init__`: start the WebSocket after platforms exist so pushes reach entities.
- scene: remove entities when the gateway deletes the scene.

**Tests:** cover/climate defensive extractors, tilt, stop-refresh, Position-only device, missing-device updates; scene removal / id re-resolution / not-found; scene-recall-without-id guard. Coverage **98%**; ruff + strict mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)