### PR TITLE
Code-review hardening (b19)

### DIFF
--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -7,12 +7,14 @@ keys (see ``cdb_types_datapoints.json``):
 - ``temperature_ctrl_preset`` — ``none`` / ``frost`` / ``eco`` / ``comfort``.
 
 The function carries no ambient reading, so ``current_temperature`` is only
-populated if the device also exposes a temperature ``quantity`` datapoint;
-otherwise it stays ``None`` (the measured value, if any, shows up as a separate
-sensor entity).
+populated if the device also exposes a sibling temperature ``quantity``
+datapoint; otherwise it stays ``None``. (That sibling reading is surfaced only
+here as ``current_temperature`` — sensor discovery does not turn a Thermostat's
+quantity into a standalone sensor entity.)
 """
 
 import logging
+import math
 from typing import Any
 
 from homeassistant.components.climate import ClimateEntity
@@ -123,15 +125,10 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self._datapoint = ctrl_datapoint
         self._ctrl_datapoint_id = ctrl_datapoint["id"]
         self._name = device.get("label", "Jung Thermostat")
-        self._unique_id = stable_unique_id(device, ctrl_datapoint)
+        self._attr_unique_id = stable_unique_id(device, ctrl_datapoint)
         self._target_temperature = self._get_target_from_datapoint(ctrl_datapoint)
         self._preset_mode = self._get_preset_from_datapoint(ctrl_datapoint)
         self._current_temperature = self._get_current_temperature(device)
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID for the thermostat."""
-        return self._unique_id
 
     @property
     def target_temperature(self) -> float | None:
@@ -190,9 +187,14 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         if value is None:
             return None
         try:
-            return float(value)
+            target = float(value)
         except (TypeError, ValueError):
             return None
+        if not math.isfinite(target):
+            return None
+        # Clamp to the advertised range so an out-of-range gateway value doesn't
+        # surface a target outside the thermostat's declared min/max.
+        return max(DEFAULT_MIN_TEMP, min(DEFAULT_MAX_TEMP, target))
 
     def _get_preset_from_datapoint(self, datapoint: Datapoint | None) -> str | None:
         value = datapoint_value(datapoint, "temperature_ctrl_preset")
@@ -212,7 +214,11 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
             if value is None:
                 continue
             try:
-                return float(value)
+                ambient = float(value)
             except (TypeError, ValueError):
-                return None
+                # A malformed reading shouldn't abort the search for a usable
+                # sibling; keep looking rather than returning None outright.
+                continue
+            if math.isfinite(ambient):
+                return ambient
         return None

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -66,6 +66,8 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not self._host:
                 errors["base"] = "invalid_host"
             else:
+                # Populate the {host} flow_title placeholder for later steps.
+                self.context["title_placeholders"] = {"host": self._host}
                 await self.async_set_unique_id(self._host)
                 self._abort_if_unique_id_configured()
                 return await self.async_step_register()
@@ -123,6 +125,7 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Start reauth when the gateway rejects the stored token."""
         self._host = entry_data[CONF_HOST]
+        self.context["title_placeholders"] = {"host": self._host}
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -5,6 +5,7 @@ import json
 import logging
 from datetime import timedelta
 from typing import Any, cast
+from urllib.parse import quote
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -153,7 +154,10 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     async def activate_scene(self, scene_id: str) -> None:
         """Activate a scene via REST (the WebSocket scene command is unimplemented)."""
         session = async_get_clientsession(self.hass, verify_ssl=False)
-        url = f"https://{self.config['host']}/api/junghome/scenes/{scene_id}"
+        # scene_id comes from untrusted gateway JSON; percent-encode it so a
+        # crafted id can't break out of the path segment (e.g. via ?/#//).
+        safe_scene_id = quote(str(scene_id), safe="")
+        url = f"https://{self.config['host']}/api/junghome/scenes/{safe_scene_id}"
         headers = {
             "token": f"{self.config['token']}",
             "Content-Type": "application/json",

--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -126,7 +126,7 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
             self._angle_datapoint.get("id") if self._angle_datapoint else None
         )
         self._name = device.get("label", "Jung Cover")
-        self._unique_id = stable_unique_id(device, level_datapoint)
+        self._attr_unique_id = stable_unique_id(device, level_datapoint)
 
         features = (
             CoverEntityFeature.OPEN
@@ -144,11 +144,6 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
 
         self._position = self._get_position_from_datapoint(level_datapoint)
         self._tilt = self._get_tilt_from_datapoint(self._angle_datapoint)
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID for the cover."""
-        return self._unique_id
 
     @property
     def current_cover_position(self) -> int | None:
@@ -244,6 +239,8 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
         if value is None:
             return None
         try:
-            return round(float(value))
+            # Clamp to 0..100, mirroring the position guard in _to_ha: the
+            # untrusted angle must satisfy HA's tilt-position contract.
+            return max(0, min(100, round(float(value))))
         except (TypeError, ValueError):
             return None

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -102,22 +102,26 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         # Device brightness scale is 0-100 (device) — Home Assistant uses 0-255
         self._name = device.get("label", "Jung Light")
         # Firmware-stable id derived from the label, not the volatile device id.
-        self._unique_id = stable_unique_id(device, datapoint)
+        self._attr_unique_id = stable_unique_id(device, datapoint)
         self._is_on = self._get_state_from_datapoint(datapoint)
 
-        if self._has_brightness:
-            # Read brightness and color_temp from their specific datapoints (if present)
-            self._brightness: int | None = self._get_brightness_from_datapoint(
-                self._brightness_datapoint
-            )
-            self._color_temp: int | None = self._get_color_temp_from_datapoint(
-                self._color_temp_datapoint
-            )
+        # Brightness and color temperature are read independently: a device could
+        # (unusually) expose color_temperature without a brightness datapoint, and
+        # COLOR_TEMP still needs its kelvin range set, so this is not gated on
+        # _has_brightness.
+        self._brightness: int | None = (
+            self._get_brightness_from_datapoint(self._brightness_datapoint)
+            if self._has_brightness
+            else None
+        )
+        self._color_temp: int | None = (
+            self._get_color_temp_from_datapoint(self._color_temp_datapoint)
+            if self._has_color_temp
+            else None
+        )
+        if self._has_color_temp:
             self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
             self._attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
-        else:
-            self._brightness = None
-            self._color_temp = None
 
         # Color mode is fixed by the device's capabilities (datapoints), not by
         # the current value. Home Assistant requires supported_color_modes to be
@@ -132,11 +136,6 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         else:
             self._attr_supported_color_modes = {ColorMode.ONOFF}
             self._attr_color_mode = ColorMode.ONOFF
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID for the light."""
-        return self._unique_id
 
     @property
     def is_on(self) -> bool | None:
@@ -160,16 +159,15 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         datapoint = self._find_datapoint(self._datapoint["id"])
         if datapoint:
             self._is_on = self._get_state_from_datapoint(datapoint)
-            if self._has_brightness:
-                # Update brightness/color_temp from their respective datapoints.
-                if self._brightness_datapoint_id:
-                    self._brightness = self._get_brightness_from_datapoint(
-                        self._find_datapoint(self._brightness_datapoint_id)
-                    )
-                if self._color_temp_datapoint_id:
-                    self._color_temp = self._get_color_temp_from_datapoint(
-                        self._find_datapoint(self._color_temp_datapoint_id)
-                    )
+            # Refresh brightness/color_temp from their datapoints independently.
+            if self._brightness_datapoint_id:
+                self._brightness = self._get_brightness_from_datapoint(
+                    self._find_datapoint(self._brightness_datapoint_id)
+                )
+            if self._color_temp_datapoint_id:
+                self._color_temp = self._get_color_temp_from_datapoint(
+                    self._find_datapoint(self._color_temp_datapoint_id)
+                )
             _LOGGER.debug("Updated state for light %s: %s", self._name, self._is_on)
             self.async_write_ha_state()
 
@@ -206,8 +204,9 @@ class JungHomeLight(JungHomeEntity, LightEntity):
             raw = int(value)
         except (TypeError, ValueError):
             raw = 0
-        # Device reports 0-100; convert linearly to HA 0-255
-        return round(raw * 255 / 100)
+        # Device reports 0-100; convert linearly to HA 0-255, clamping the
+        # untrusted gateway value into HA's documented 0-255 brightness range.
+        return max(0, min(255, round(raw * 255 / 100)))
 
     def _ha_to_raw_brightness(self, ha_brightness: int) -> int:
         """Convert Home Assistant 0-255 brightness to device raw scale (0-100)."""
@@ -222,10 +221,12 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         if value is None:
             return None
         try:
-            # Device reports Kelvin; store Kelvin
-            return int(value)
+            kelvin = int(value)
         except (TypeError, ValueError):
             return None
+        # Clamp to the advertised range so an out-of-range gateway value doesn't
+        # violate the declared min/max color-temperature contract.
+        return max(DEFAULT_MIN_KELVIN, min(DEFAULT_MAX_KELVIN, kelvin))
 
     async def _set_brightness(self, brightness: int) -> None:
         """Set the brightness of the light."""

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b18",
+  "version": "1.2.0b19",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/scene.py
+++ b/custom_components/junghome/scene.py
@@ -42,6 +42,21 @@ async def async_setup_entry(
     """Set up Jung Home scenes from a config entry."""
     coordinator = entry.runtime_data
     entities: dict[str, JungHomeScene] = {}
+    # unique_ids with an in-flight async_remove(). Kept out of `entities` only
+    # once removal completes (see _remove_scene), so a same-tick re-add can't
+    # construct a duplicate entity with the same unique_id while the old one is
+    # still deregistering.
+    removing: set[str] = set()
+
+    async def _remove_scene(uid: str) -> None:
+        try:
+            await entities[uid].async_remove()
+        finally:
+            entities.pop(uid, None)
+            removing.discard(uid)
+        # The scene may have reappeared during removal; re-run discovery so it is
+        # re-added rather than lost.
+        _discover_scenes()
 
     @callback
     def _discover_scenes() -> None:
@@ -59,7 +74,9 @@ async def async_setup_entry(
 
         new_entities: list[JungHomeScene] = []
         for uid, label in current.items():
-            if uid not in entities:
+            # Skip uids still deregistering — re-adding now would collide on the
+            # unique_id; _remove_scene re-runs discovery once removal completes.
+            if uid not in entities and uid not in removing:
                 entity = JungHomeScene(coordinator, label, uid)
                 entities[uid] = entity
                 new_entities.append(entity)
@@ -67,10 +84,14 @@ async def async_setup_entry(
             async_add_entities(new_entities)
 
         # Drop entities whose scene no longer exists, so a deleted scene doesn't
-        # linger as an always-failing entity.
+        # linger as an always-failing entity. The removal is an entry-scoped
+        # background task (cancelled on unload, exceptions tracked).
         for uid in list(entities):
-            if uid not in current:
-                hass.async_create_task(entities.pop(uid).async_remove())
+            if uid not in current and uid not in removing:
+                removing.add(uid)
+                entry.async_create_background_task(
+                    hass, _remove_scene(uid), name=f"junghome_scene_remove_{uid}"
+                )
 
     _discover_scenes()
     entry.async_on_unload(coordinator.async_add_listener(_discover_scenes))

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -1,6 +1,7 @@
 """Sensor platform for Jung Home (socket energy quantities)."""
 
 import logging
+import math
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -119,7 +120,7 @@ class JungHomeQuantity(JungHomeEntity, SensorEntity):
         self._attr_name = label
         self._name = f"{device.get('label', 'Jung Device')} {label}"  # for logging
         # Firmware-stable id derived from the label, not the volatile device id.
-        self._unique_id = stable_unique_id(
+        self._attr_unique_id = stable_unique_id(
             device, datapoint, label.replace(" ", "_").lower()
         )
         mapped = _UNIT_MAP.get(unit.strip().lower())
@@ -142,20 +143,18 @@ class JungHomeQuantity(JungHomeEntity, SensorEntity):
         self._value = self._get_value_from_datapoint(datapoint)
 
     @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID for the quantity."""
-        return self._unique_id
-
-    @property
     def native_value(self) -> float | str | None:
         """Return the measured value (numeric when the unit has a state class)."""
         if self._value is None:
             return None
         if self._attr_state_class is not None:
             try:
-                return float(self._value)
+                numeric = float(self._value)
             except (TypeError, ValueError):
                 return None
+            # Reject NaN/inf (which float() parses): they would pollute the
+            # long-term-statistics / energy pipeline for a numeric sensor.
+            return numeric if math.isfinite(numeric) else None
         return self._value
 
     @callback

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -76,13 +76,8 @@ class JungHomeSocket(JungHomeEntity, SwitchEntity):
         self._datapoint = datapoint
         self._name = device.get("label", "Jung Socket")
         # Firmware-stable id derived from the label, not the volatile device id.
-        self._unique_id = stable_unique_id(device, datapoint)
+        self._attr_unique_id = stable_unique_id(device, datapoint)
         self._is_on = self._get_state_from_datapoint(datapoint)
-
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID for the socket."""
-        return self._unique_id
 
     @property
     def is_on(self) -> bool | None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -881,6 +881,10 @@ async def test_sensor_value_extractor_defensive(hass: HomeAssistant) -> None:
     # native_value is None when the stored value is None.
     q._value = None
     assert q.native_value is None
+    # NaN/inf parse through float() but must not reach a numeric sensor's state.
+    for bad in ("nan", "inf", "-inf"):
+        q._value = bad
+        assert q.native_value is None
 
 
 async def test_command_failure_when_ws_down_surfaces(
@@ -1170,6 +1174,19 @@ async def test_cover_extractors_defensive(hass: HomeAssistant) -> None:
         is None
     )
     assert cover._get_position_from_datapoint({"id": "x", "values": []}) is None
+    # Out-of-range tilt is clamped to 0..100 (mirrors the position clamp).
+    assert (
+        cover._get_tilt_from_datapoint(
+            {"id": "x", "values": [{"key": "angle", "value": "150"}]}
+        )
+        == 100
+    )
+    assert (
+        cover._get_tilt_from_datapoint(
+            {"id": "x", "values": [{"key": "angle", "value": "-10"}]}
+        )
+        == 0
+    )
 
 
 async def test_cover_is_closed_none_when_position_unknown(hass: HomeAssistant) -> None:
@@ -1262,6 +1279,26 @@ async def test_climate_extractors_defensive(hass: HomeAssistant) -> None:
         )
         is None
     )
+    # Out-of-range target clamps to 5..30; non-finite values -> None.
+    assert (
+        climate._get_target_from_datapoint(
+            {"id": "x", "values": [{"key": "temperature_ctrl", "value": "99"}]}
+        )
+        == 30.0
+    )
+    assert (
+        climate._get_target_from_datapoint(
+            {"id": "x", "values": [{"key": "temperature_ctrl", "value": "-5"}]}
+        )
+        == 5.0
+    )
+    for bad in ("inf", "-inf", "nan"):
+        assert (
+            climate._get_target_from_datapoint(
+                {"id": "x", "values": [{"key": "temperature_ctrl", "value": bad}]}
+            )
+            is None
+        )
 
 
 async def test_climate_current_temperature_paths(hass: HomeAssistant) -> None:
@@ -1325,7 +1362,9 @@ async def test_climate_handle_update_missing_device_noops(hass: HomeAssistant) -
 
 def test_scene_slug_fallback() -> None:
     """Unsluggable labels fall back to a stable 'scene' slug."""
-    assert _scene_slug("") == "scene"
+    assert _scene_slug("") == "scene"  # empty -> falsy
+    assert _scene_slug("❤") == "scene"  # slugify maps to "unknown" -> fallback
+    assert _scene_slug("   ") == "scene"  # whitespace -> "unknown" -> fallback
     assert _scene_slug("Movie Night") == "movie_night"
 
 
@@ -1375,3 +1414,81 @@ async def test_scene_reresolves_id_after_firmware_change(
             "scene", "turn_on", {"entity_id": "scene.movie_night"}, blocking=True
         )
     assert act.call_args.args[0] == "new"
+
+
+async def test_light_brightness_and_color_temp_are_clamped(hass: HomeAssistant) -> None:
+    """Out-of-range gateway values are clamped to HA's contracts."""
+    light = _color_light(_bare_coordinator(hass))
+    # Device brightness 150 (>100) would scale to 383; clamp to 255.
+    assert (
+        light._get_brightness_from_datapoint(
+            {"id": "x", "values": [{"key": "brightness", "value": "150"}]}
+        )
+        == 255
+    )
+    # A negative value clamps to 0.
+    assert (
+        light._get_brightness_from_datapoint(
+            {"id": "x", "values": [{"key": "brightness", "value": "-10"}]}
+        )
+        == 0
+    )
+    # Color temp outside the advertised 2000-6500 K window is clamped.
+    assert (
+        light._get_color_temp_from_datapoint(
+            {"id": "x", "values": [{"key": "color_temperature", "value": "9000"}]}
+        )
+        == 6500
+    )
+    assert (
+        light._get_color_temp_from_datapoint(
+            {"id": "x", "values": [{"key": "color_temperature", "value": "1000"}]}
+        )
+        == 2000
+    )
+
+
+async def test_colortemp_light_without_brightness(hass: HomeAssistant) -> None:
+    """A ColorLight exposing color_temp but no brightness still tracks color temp.
+
+    Regression guard: the color_temp init used to be gated on _has_brightness, so
+    such a device advertised COLOR_TEMP yet reported color_temp_kelvin == None.
+    """
+    coordinator = _bare_coordinator(hass)
+    device = {
+        "id": "ct",
+        "type": "ColorLight",
+        "label": "CT",
+        "datapoints": [
+            {
+                "id": "ct-1",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "1"}],
+            },
+            {
+                "id": "ct-4",
+                "type": "color_temperature",
+                "values": [{"key": "color_temperature", "value": "3000"}],
+            },
+        ],
+    }
+    light = JungHomeLight(coordinator, device, device["datapoints"][0])
+    assert light.color_mode == "color_temp"
+    assert light.color_temp_kelvin == 3000
+    assert light.min_color_temp_kelvin == 2000
+    assert light.max_color_temp_kelvin == 6500
+
+
+async def test_cover_set_position_is_optimistic(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """set_cover_position writes the optimistic HA position immediately."""
+    coordinator = init_integration.runtime_data
+    with patch.object(coordinator, "set_level", AsyncMock()):
+        await hass.services.async_call(
+            "cover",
+            "set_cover_position",
+            {"entity_id": "cover.bedroom_blind", "position": 25},
+            blocking=True,
+        )
+    assert hass.states.get("cover.bedroom_blind").attributes["current_position"] == 25


### PR DESCRIPTION
Cuts beta **1.2.0b19**. Fixes surfaced by two multi-agent review passes (correctness, concurrency/lifecycle, HA quality-scale, security/robustness, tests), each verified against the code.

## Bugs / robustness
- **light**: clamp brightness 0..255 and color_temp 2000..6500; read color_temp independently of brightness so a `ColorLight` without a brightness datapoint still tracks color temperature (it previously advertised `COLOR_TEMP` but reported `None`).
- **climate**: clamp target temp to 5..30 and reject NaN/inf; current-temperature search skips a malformed sibling instead of aborting.
- **sensor**: reject NaN/inf for numeric sensors (would pollute long-term statistics / the energy dashboard).
- **cover**: clamp slat **tilt** to 0..100 (mirrors the position clamp — it was the one unclamped value path).
- **scene**: fix a delete→re-add `unique_id` collision race — the uid stays reserved until `async_remove()` completes, then discovery re-runs to re-add if the scene reappeared. Removal remains an entry-scoped background task.
- **coordinator**: percent-encode the untrusted `scene_id` before it goes into the recall URL.

## Cleanup / quality
- Drop five redundant `unique_id` properties in favour of `_attr_unique_id`.
- **config_flow**: set the `{host}` `flow_title` placeholder for the user/reauth flows (was zeroconf-only).
- Fix a misleading climate docstring about ambient-temperature sensors.

Tests extended to **113** (98% coverage); ruff + strict mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)