### PR TITLE
Include scenes in diagnostics

### DIFF
--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -33,4 +33,9 @@ async def async_get_config_entry_diagnostics(
         "gateway_version": coordinator.gateway_version,
         "device_count": len(coordinator.data or []),
         "devices": coordinator.data or [],
+        # Scenes are a separate coordinator data category (not backed by a
+        # device); include them so a diagnostics dump is complete for debugging
+        # scene discovery/recall. Scene labels are retained like device labels.
+        "scene_count": len(coordinator.scenes),
+        "scenes": coordinator.scenes,
     }

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b19",
+  "version": "1.2.0b20",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -455,11 +455,16 @@ async def test_light_external_change_applied(
 
 
 async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
+    coordinator = init_integration.runtime_data
+    coordinator.scenes = [{"id": "s1", "label": "Movie"}]
     diag = await async_get_config_entry_diagnostics(hass, init_integration)
     assert diag["device_count"] == len(DEVICES)
     assert diag["gateway_version"] == "1.5.0"
     assert diag["entry"]["data"][CONF_TOKEN] == "**REDACTED**"
     assert diag["entry"]["data"][CONF_HOST] == "**REDACTED**"
+    # Scenes are a separate coordinator data category, surfaced for debugging.
+    assert diag["scene_count"] == 1
+    assert diag["scenes"] == [{"id": "s1", "label": "Movie"}]
 
 
 async def test_stale_device_pruned(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## What
A maximum-quality audit of the integration (now grown to cover/climate/scene
platforms + a shared `JungHomeEntity` base) found the codebase in excellent
platinum shape — one concrete completeness gap: `coordinator.scenes` is a
first-class data category, but the diagnostics download only dumped `devices`.

Add `scenes` + `scene_count` so scene discovery/recall issues are debuggable from
a diagnostics report. Scene labels are retained like device labels (the existing
`TO_REDACT` policy still redacts only token + host).

## Verified (full gate, current main + this change)
- `mypy --strict` clean (14 files); explicit-`Any` all genuine boundaries — the
  cover/climate/scene platforms carry no payload `Any`
- `ruff check` + `ruff format --check` clean
- **113 tests pass, 98.22% coverage** (diagnostics.py 100%)

## Audit notes (no action needed)
The new platforms are TypedDict-typed, reuse the shared base + `datapoint_value`
helper, clamp untrusted values, URL-escape the scene id in `activate_scene`, and
handle the volatile-scene-id / in-flight-removal race. Translations are in sync,
README documents the new device types, and quality-scale rules are all backed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)