### PR TITLE
Fix brightness/position UI flicker from sibling-datapoint echoes

### DIFF
--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -214,10 +214,16 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        level_dp = self._find_datapoint(self._level_datapoint_id)
-        if level_dp:
-            self._position = self._get_position_from_datapoint(level_dp)
-        if self._angle_datapoint_id is not None:
+        # Refresh position/tilt only from their own datapoint's push (see
+        # JungHomeEntity._should_refresh) so a level echo can't momentarily reset
+        # tilt to the stale snapshot value, and vice versa.
+        if self._should_refresh(self._level_datapoint_id):
+            level_dp = self._find_datapoint(self._level_datapoint_id)
+            if level_dp:
+                self._position = self._get_position_from_datapoint(level_dp)
+        if self._angle_datapoint_id is not None and self._should_refresh(
+            self._angle_datapoint_id
+        ):
             angle_dp = self._find_datapoint(self._angle_datapoint_id)
             if angle_dp:
                 self._tilt = self._get_tilt_from_datapoint(angle_dp)

--- a/custom_components/junghome/entity.py
+++ b/custom_components/junghome/entity.py
@@ -80,3 +80,16 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
             (dp for dp in device.get("datapoints", []) if dp.get("id") == datapoint_id),
             None,
         )
+
+    def _should_refresh(self, datapoint_id: str) -> bool:
+        """Whether the attribute backed by ``datapoint_id`` should refresh now.
+
+        The gateway sends each datapoint change as its own WebSocket frame, so on
+        a push only the pushed datapoint's attribute should be re-read. Refreshing
+        a *sibling* attribute here would read a not-yet-updated (stale) snapshot —
+        e.g. a switch=on echo arriving before the brightness echo would momentarily
+        reset the brightness slider to the old value (a UI flicker). On a REST poll
+        (``pushed_datapoint_id`` is None) every datapoint is fresh, so refresh all.
+        """
+        pushed = self.coordinator.pushed_datapoint_id
+        return pushed is None or pushed == datapoint_id

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -156,20 +156,27 @@ class JungHomeLight(JungHomeEntity, LightEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug("Handling coordinator update for light %s", self._name)
-        datapoint = self._find_datapoint(self._datapoint["id"])
-        if datapoint:
-            self._is_on = self._get_state_from_datapoint(datapoint)
-            # Refresh brightness/color_temp from their datapoints independently.
-            if self._brightness_datapoint_id:
-                self._brightness = self._get_brightness_from_datapoint(
-                    self._find_datapoint(self._brightness_datapoint_id)
-                )
-            if self._color_temp_datapoint_id:
-                self._color_temp = self._get_color_temp_from_datapoint(
-                    self._find_datapoint(self._color_temp_datapoint_id)
-                )
-            _LOGGER.debug("Updated state for light %s: %s", self._name, self._is_on)
-            self.async_write_ha_state()
+        # Refresh each attribute only from its own datapoint's push, so a switch=on
+        # echo arriving before the brightness echo can't momentarily reset the
+        # brightness slider to the stale snapshot value (UI flicker). On a REST
+        # poll (no push marker) all three refresh together.
+        if self._should_refresh(self._datapoint["id"]):
+            switch_dp = self._find_datapoint(self._datapoint["id"])
+            if switch_dp:
+                self._is_on = self._get_state_from_datapoint(switch_dp)
+        if self._brightness_datapoint_id and self._should_refresh(
+            self._brightness_datapoint_id
+        ):
+            self._brightness = self._get_brightness_from_datapoint(
+                self._find_datapoint(self._brightness_datapoint_id)
+            )
+        if self._color_temp_datapoint_id and self._should_refresh(
+            self._color_temp_datapoint_id
+        ):
+            self._color_temp = self._get_color_temp_from_datapoint(
+                self._find_datapoint(self._color_temp_datapoint_id)
+            )
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b20",
+  "version": "1.2.0b21",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -388,6 +388,52 @@ async def test_colorlight_brightness_and_color_update(
     assert state.attributes["brightness"] == round(80 * 255 / 100)
 
 
+async def test_switch_echo_does_not_reset_brightness(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A switch=on echo must not clobber the optimistic brightness (UI flicker).
+
+    The gateway echoes switch-on and brightness as separate frames; the switch
+    one arrives first, while coordinator data still holds the old brightness.
+    Re-reading brightness on that frame would momentarily reset the slider.
+    """
+    coordinator = init_integration.runtime_data
+    # Drag brightness up: HA turns the light on AND sets brightness optimistically.
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.strip", "brightness": 200},
+        blocking=True,
+    )
+    assert hass.states.get("light.strip").attributes["brightness"] == 200
+
+    # The switch=on echo arrives FIRST; the brightness datapoint in coordinator
+    # data still holds the old "50". This must NOT reset brightness to ~128.
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": "idcolor1-001", "values": [{"key": "switch", "value": "1"}]},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("light.strip").attributes["brightness"] == 200
+
+    # The brightness echo then lands and is applied normally.
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idcolor1-002",
+                "values": [{"key": "brightness", "value": "80"}],
+            },
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("light.strip").attributes["brightness"] == round(
+        80 * 255 / 100
+    )
+
+
 async def test_status_led_update(hass: HomeAssistant, init_integration) -> None:
     coordinator = init_integration.runtime_data
     coordinator._handle_websocket_message(


### PR DESCRIPTION
## Symptom
Adjusting a ColorLight's brightness in the UI (e.g. 0 → 40%) flips the slider
**40 → 0 → 40** — it momentarily snaps back to the old value, then settles.

## Root cause
HA sends `turn_on` *with* brightness as a single service call, and the
integration issues **two** gateway commands (switch-on, then brightness —
deliberately, to avoid power-on resets). The gateway echoes them as **two
separate WebSocket frames**, and the `switch` frame arrives **before** the
`brightness` frame:

```
< {"type":"datapoint","data":{"id":"…-001","type":"switch","values":[{"key":"switch","value":"1"}]}}
< {"type":"datapoint","data":{"id":"…-002","type":"brightness","values":[{"key":"brightness","value":"32"}]}}
```

`JungHomeLight._handle_coordinator_update` re-read **all** of on/brightness/
colour-temp on every coordinator update. So when the switch echo landed, it
re-read brightness from `coordinator.data` — where the brightness datapoint was
**still the old value** (the brightness echo hadn't arrived yet) — and reset the
optimistic value. The brightness frame then restored it. No duplicate frames are
involved; it's purely the frame ordering. (Surfaced after the old echo-debounce
was removed — nothing now protects the optimistic value during that gap.)

## Fix
Add `JungHomeEntity._should_refresh(datapoint_id)`, backed by the coordinator's
existing `pushed_datapoint_id` marker (already used by the event platform), and
refresh each attribute **only from its own datapoint's push** — refreshing all on
a REST poll (marker `None`). Applied to light (on / brightness / colour-temp) and
cover (position / tilt, which has the identical latent pattern for a combined
position+tilt change).

A new test reproduces the exact ordering (switch echo first) and asserts
brightness is not reset.

## Verified
`mypy --strict` clean · `ruff` + format clean · **114 tests pass, 98.22%
coverage** (light.py & entity.py 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)