### PR TITLE
Ignore device brightness 0 so off→on doesn't flash 0%

### DIFF
--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -167,9 +167,16 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         if self._brightness_datapoint_id and self._should_refresh(
             self._brightness_datapoint_id
         ):
-            self._brightness = self._get_brightness_from_datapoint(
+            new_brightness = self._get_brightness_from_datapoint(
                 self._find_datapoint(self._brightness_datapoint_id)
             )
+            # The device reports brightness 0 when the light is off (on/off is the
+            # separate switch datapoint). Ignore a 0 so an off->on transition keeps
+            # the last level instead of briefly showing 0% until the device echoes
+            # the restored brightness a frame later. HA delivers "set brightness 0"
+            # as turn_off, so a genuine "on at 0%" never occurs.
+            if new_brightness:
+                self._brightness = new_brightness
         if self._color_temp_datapoint_id and self._should_refresh(
             self._color_temp_datapoint_id
         ):

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b21",
+  "version": "1.2.0b22",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -434,6 +434,53 @@ async def test_switch_echo_does_not_reset_brightness(
     )
 
 
+async def test_brightness_preserved_across_off_on(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Device brightness 0 (reported while off) must not blank the slider on off->on.
+
+    The dimmer reports brightness 0 when off (on/off is the switch datapoint), so
+    applying that 0 would briefly show the light at 0% on the next turn-on, before
+    the device echoes the restored level a frame later.
+    """
+    coordinator = init_integration.runtime_data
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.strip", "brightness": 200},
+        blocking=True,
+    )
+    assert hass.states.get("light.strip").attributes["brightness"] == 200
+
+    # Turn off: the device echoes switch=0 and then brightness=0.
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": "idcolor1-001", "values": [{"key": "switch", "value": "0"}]},
+        }
+    )
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idcolor1-002",
+                "values": [{"key": "brightness", "value": "0"}],
+            },
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("light.strip").state == "off"
+
+    # Turn back on (no brightness): the slider must show the kept level, not 0%.
+    await hass.services.async_call(
+        "light", "turn_on", {"entity_id": "light.strip"}, blocking=True
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("light.strip")
+    assert state.state == "on"
+    assert state.attributes["brightness"] == 200
+
+
 async def test_status_led_update(hass: HomeAssistant, init_integration) -> None:
     coordinator = init_integration.runtime_data
     coordinator._handle_websocket_message(


### PR DESCRIPTION
Follow-up to #75. That fix stopped the *switch* echo from clobbering brightness
during a slider drag, but a second flicker path remained — **off→on briefly
shows 0%**.

## Root cause
The dimmer reports `brightness = 0` when the light is **off** (on/off is the
separate `switch` datapoint). So while off, the brightness datapoint becomes 0,
and on the next **off→on** the light is `on` but brightness is still 0 until the
device echoes the restored level a frame later → momentary 0% in the UI.

## Fix
Ignore a device-reported brightness of **0** in the light's update handler. For a
dimmer, 0 means off — already tracked by the switch datapoint — and HA delivers
"set brightness 0" to the integration as `turn_off`, so a genuine "on at 0%"
never occurs. The last non-zero level is kept across the off/on cycle.

A regression test drives the full off (switch=0 + brightness=0) → on sequence and
asserts the slider keeps its level instead of dropping to 0.

## Verified
`mypy --strict` clean · `ruff` + format clean · **115 tests pass, 98.23%
coverage** (light.py 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)