### PR TITLE
Thermostat on/off (HVAC OFF/HEAT) + coverage to 99.5%

### DIFF
--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -1,16 +1,14 @@
 """Climate platform for Jung Home (Thermostat / room temperature regulator).
 
-A ``Thermostat`` function exposes a ``temperature_ctrl`` datapoint with two
-keys (see ``cdb_types_datapoints.json``):
+A ``Thermostat`` function exposes three datapoints (see
+``cdb_types_datapoints.json`` / ``cdb_types_functions.json``):
 
-- ``temperature_ctrl`` — the target temperature in °C (range 5..30).
-- ``temperature_ctrl_preset`` — ``none`` / ``frost`` / ``eco`` / ``comfort``.
-
-The function carries no ambient reading, so ``current_temperature`` is only
-populated if the device also exposes a sibling temperature ``quantity``
-datapoint; otherwise it stays ``None``. (That sibling reading is surfaced only
-here as ``current_temperature`` — sensor discovery does not turn a Thermostat's
-quantity into a standalone sensor entity.)
+- ``switch`` — on/off (``0`` / ``1``), mapped to HVAC mode OFF / HEAT.
+- ``temperature_ctrl`` — the target temperature in °C (range 5..30) plus a
+  ``temperature_ctrl_preset`` key (``none`` / ``frost`` / ``eco`` / ``comfort``).
+- ``quantity`` — the room temperature reading, surfaced here as
+  ``current_temperature``. (Sensor discovery does not turn a Thermostat's
+  quantity into a standalone sensor entity; it is only the ambient reading.)
 """
 
 import logging
@@ -105,10 +103,6 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
     _attr_target_temperature_step = 0.5
     _attr_min_temp = DEFAULT_MIN_TEMP
     _attr_max_temp = DEFAULT_MAX_TEMP
-    # The RTR regulates heating; there is no gateway "off" for the function, so a
-    # single HEAT mode is exposed (HA requires a non-empty hvac_modes list).
-    _attr_hvac_modes = [HVACMode.HEAT]
-    _attr_hvac_mode = HVACMode.HEAT
     _attr_preset_modes = [PRESET_NONE, PRESET_FROST, PRESET_ECO, PRESET_COMFORT]
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
@@ -126,6 +120,20 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self._ctrl_datapoint_id = ctrl_datapoint["id"]
         self._name = device.get("label", "Jung Thermostat")
         self._attr_unique_id = stable_unique_id(device, ctrl_datapoint)
+        # The Thermostat function carries a `switch` datapoint for on/off; map it
+        # to HVAC OFF/HEAT. A thermostat without one (defensive) stays HEAT-only,
+        # and HA requires a non-empty hvac_modes list either way.
+        switch_dp = next(
+            (dp for dp in device.get("datapoints", []) if dp.get("type") == "switch"),
+            None,
+        )
+        self._switch_datapoint_id = switch_dp.get("id") if switch_dp else None
+        self._attr_hvac_modes = (
+            [HVACMode.OFF, HVACMode.HEAT]
+            if self._switch_datapoint_id is not None
+            else [HVACMode.HEAT]
+        )
+        self._attr_hvac_mode = self._get_hvac_mode_from_datapoint(switch_dp)
         self._target_temperature = self._get_target_from_datapoint(ctrl_datapoint)
         self._preset_mode = self._get_preset_from_datapoint(ctrl_datapoint)
         self._current_temperature = self._get_current_temperature(device)
@@ -167,20 +175,47 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Accept the single supported HVAC mode (no-op)."""
-        # Only HEAT is exposed; nothing to send to the gateway.
+        """Turn the thermostat on (HEAT) or off via its switch datapoint."""
+        if self._switch_datapoint_id is None:
+            return  # no on/off control on this thermostat
+        if hvac_mode == HVACMode.OFF:
+            await self.coordinator.turn_off_switch(self._switch_datapoint_id)
+        else:
+            await self.coordinator.turn_on_switch(self._switch_datapoint_id)
+        self._attr_hvac_mode = hvac_mode
+        self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         device = self._current_device()
-        if device:
+        if device is None:
+            self.async_write_ha_state()
+            return
+        # Refresh each attribute only from its own datapoint's push (see
+        # JungHomeEntity._should_refresh) so a switch echo can't clobber an
+        # optimistic target/preset write, and vice versa.
+        if self._should_refresh(self._ctrl_datapoint_id):
             ctrl_dp = self._find_datapoint(self._ctrl_datapoint_id)
             if ctrl_dp:
                 self._target_temperature = self._get_target_from_datapoint(ctrl_dp)
                 self._preset_mode = self._get_preset_from_datapoint(ctrl_dp)
-            self._current_temperature = self._get_current_temperature(device)
+        if self._switch_datapoint_id is not None and self._should_refresh(
+            self._switch_datapoint_id
+        ):
+            self._attr_hvac_mode = self._get_hvac_mode_from_datapoint(
+                self._find_datapoint(self._switch_datapoint_id)
+            )
+        # The ambient reading is read-only (never set optimistically), so always
+        # refresh it from the latest data.
+        self._current_temperature = self._get_current_temperature(device)
         self.async_write_ha_state()
+
+    def _get_hvac_mode_from_datapoint(self, datapoint: Datapoint | None) -> HVACMode:
+        """Map the switch datapoint to an HVAC mode (OFF only when explicitly off)."""
+        if datapoint is not None and datapoint_value(datapoint, "switch") == "0":
+            return HVACMode.OFF
+        return HVACMode.HEAT
 
     def _get_target_from_datapoint(self, datapoint: Datapoint | None) -> float | None:
         value = datapoint_value(datapoint, "temperature_ctrl")

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b22",
+  "version": "1.2.0b23",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -155,7 +155,9 @@ class JungHomeQuantity(JungHomeEntity, SensorEntity):
             # Reject NaN/inf (which float() parses): they would pollute the
             # long-term-statistics / energy pipeline for a numeric sensor.
             return numeric if math.isfinite(numeric) else None
-        return self._value
+        # Unreachable: every sensor gets a state class (mapped, or MEASUREMENT for
+        # an unknown unit), so this only exists to satisfy the return type.
+        return self._value  # pragma: no cover
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -116,6 +116,11 @@ DEVICES = [
         "label": "Living Room",
         "datapoints": [
             {
+                "id": "idrtr1-000",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "1"}],
+            },
+            {
                 "id": "idrtr1-001",
                 "type": "temperature_ctrl",
                 "values": [
@@ -1171,6 +1176,53 @@ async def test_climate_created(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes["preset_mode"] == "comfort"
     # Current temperature read from the sibling °C quantity datapoint.
     assert state.attributes["current_temperature"] == 20.0
+    # The switch datapoint (value "1") maps to HVAC HEAT, with OFF available.
+    assert state.state == "heat"
+    assert set(state.attributes["hvac_modes"]) == {"off", "heat"}
+
+
+async def test_climate_hvac_on_off(hass: HomeAssistant, init_integration) -> None:
+    """HVAC OFF / HEAT drives the thermostat's switch datapoint."""
+    coordinator = init_integration.runtime_data
+    assert hass.states.get("climate.living_room").state == "heat"
+    with (
+        patch.object(coordinator, "turn_off_switch", AsyncMock()) as off,
+        patch.object(coordinator, "turn_on_switch", AsyncMock()) as on,
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": "climate.living_room", "hvac_mode": "off"},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": "climate.living_room", "hvac_mode": "heat"},
+            blocking=True,
+        )
+    off.assert_called_once_with("idrtr1-000")
+    on.assert_called_once_with("idrtr1-000")
+
+
+async def test_climate_hvac_mode_follows_switch_echo(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A switch=0 echo flips the thermostat to OFF without touching target/preset."""
+    coordinator = init_integration.runtime_data
+    assert hass.states.get("climate.living_room").state == "heat"
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": "idrtr1-000", "values": [{"key": "switch", "value": "0"}]},
+        }
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.living_room")
+    assert state.state == "off"
+    # Target temperature/preset unchanged by the switch echo.
+    assert state.attributes["temperature"] == 21.5
+    assert state.attributes["preset_mode"] == "comfort"
 
 
 async def test_climate_commands(hass: HomeAssistant, init_integration) -> None:
@@ -1333,17 +1385,26 @@ def _climate(
     current_unit: str | None = "°C",
     target: str = "21.5",
     preset: str = "comfort",
+    switch: str | None = None,
 ) -> JungHomeClimate:
-    dps = [
-        {
-            "id": "t-1",
-            "type": "temperature_ctrl",
-            "values": [
-                {"key": "temperature_ctrl", "value": target},
-                {"key": "temperature_ctrl_preset", "value": preset},
-            ],
-        }
-    ]
+    ctrl_dp = {
+        "id": "t-1",
+        "type": "temperature_ctrl",
+        "values": [
+            {"key": "temperature_ctrl", "value": target},
+            {"key": "temperature_ctrl_preset", "value": preset},
+        ],
+    }
+    dps = [ctrl_dp]
+    if switch is not None:
+        dps.insert(
+            0,
+            {
+                "id": "t-0",
+                "type": "switch",
+                "values": [{"key": "switch", "value": switch}],
+            },
+        )
     if current_unit is not None:
         dps.append(
             {
@@ -1356,7 +1417,20 @@ def _climate(
             }
         )
     device = {"id": "t", "type": "Thermostat", "label": "T", "datapoints": dps}
-    return JungHomeClimate(coordinator, device, dps[0])
+    return JungHomeClimate(coordinator, device, ctrl_dp)
+
+
+async def test_climate_hvac_mode_from_switch_value(hass: HomeAssistant) -> None:
+    """Switch 1/0 maps to HEAT/OFF; a thermostat without a switch stays HEAT-only."""
+    coord = _bare_coordinator(hass)
+    on = _climate(coord, switch="1")
+    assert on._attr_hvac_mode == HVACMode.HEAT
+    assert set(on._attr_hvac_modes) == {HVACMode.OFF, HVACMode.HEAT}
+    off = _climate(coord, switch="0")
+    assert off._attr_hvac_mode == HVACMode.OFF
+    none = _climate(coord)  # no switch datapoint
+    assert none._switch_datapoint_id is None
+    assert none._attr_hvac_modes == [HVACMode.HEAT]
 
 
 async def test_climate_extractors_defensive(hass: HomeAssistant) -> None:
@@ -1442,10 +1516,10 @@ async def test_climate_unknown_preset_noops(hass: HomeAssistant) -> None:
     sp.assert_not_called()
 
 
-async def test_climate_set_hvac_mode_is_noop(hass: HomeAssistant) -> None:
-    """The single-mode thermostat accepts set_hvac_mode without sending anything."""
+async def test_switchless_thermostat_hvac_mode_is_noop(hass: HomeAssistant) -> None:
+    """A thermostat without a switch datapoint accepts set_hvac_mode but sends nothing."""
     coordinator = _bare_coordinator(hass)
-    climate = _climate(coordinator)
+    climate = _climate(coordinator)  # no switch datapoint
     with patch.object(coordinator, "send_websocket_message", AsyncMock()) as send:
         await climate.async_set_hvac_mode(HVACMode.HEAT)  # must not raise
     send.assert_not_called()
@@ -1456,6 +1530,108 @@ async def test_climate_handle_update_missing_device_noops(hass: HomeAssistant) -
     with patch.object(climate, "async_write_ha_state") as write_state:
         climate._handle_coordinator_update()
     write_state.assert_called_once()
+
+
+async def test_climate_current_temp_skips_valueless_quantity(
+    hass: HomeAssistant,
+) -> None:
+    """A °C quantity datapoint with no value is skipped (current_temperature None)."""
+    coordinator = _bare_coordinator(hass)
+    device = {
+        "id": "t",
+        "type": "Thermostat",
+        "label": "T",
+        "datapoints": [
+            {
+                "id": "t-1",
+                "type": "temperature_ctrl",
+                "values": [{"key": "temperature_ctrl", "value": "21"}],
+            },
+            {
+                "id": "t-10",
+                "type": "quantity",
+                "values": [{"key": "quantity_unit", "value": "°C"}],  # no value key
+            },
+        ],
+    }
+    climate = JungHomeClimate(coordinator, device, device["datapoints"][0])
+    assert climate.current_temperature is None
+
+
+async def test_cover_set_tilt_without_angle_noops(hass: HomeAssistant) -> None:
+    """_set_tilt is a no-op on a position-only cover (no angle datapoint)."""
+    coordinator = _bare_coordinator(hass)
+    cover = _cover(coordinator, with_angle=False)
+    assert cover._angle_datapoint_id is None
+    with patch.object(coordinator, "set_angle", AsyncMock()) as set_angle:
+        await cover._set_tilt(50)
+    set_angle.assert_not_called()
+
+
+async def test_sensor_native_value_rejects_nan(hass: HomeAssistant) -> None:
+    """A NaN reading on a numeric sensor yields None (never pollutes statistics)."""
+    coordinator = _bare_coordinator(hass)
+    device = {"id": "s", "type": "Socket", "label": "S", "datapoints": []}
+    dp = {"id": "s-1", "values": [{"key": "quantity", "value": "nan"}]}
+    # An unknown unit makes a numeric MEASUREMENT sensor; NaN must read as None.
+    quantity = JungHomeQuantity(coordinator, device, dp, "Status", "?")
+    assert quantity.native_value is None
+
+
+async def test_malformed_cover_and_thermostat_skipped(hass: HomeAssistant) -> None:
+    """A Position with no level / Thermostat with no temperature_ctrl is skipped."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="m", data={CONF_HOST: "h", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    devices = [
+        {"id": "badc", "type": "Position", "label": "Bad Cover", "datapoints": []},
+        {"id": "badt", "type": "Thermostat", "label": "Bad Therm", "datapoints": []},
+    ]
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=devices),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    assert hass.states.get("cover.bad_cover") is None
+    assert hass.states.get("climate.bad_therm") is None
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_migration_device_repoint_error_isolated(hass: HomeAssistant) -> None:
+    """A failure re-pointing a device identifier is isolated and blocks the done flag."""
+    dev_reg = dr.async_get(hass)
+
+    def prepare(entry: MockConfigEntry) -> None:
+        # A device under the old volatile gateway id, so the migration tries to
+        # re-point it (the only path that calls async_update_device with
+        # new_identifiers).
+        dev_reg.async_get_or_create(
+            config_entry_id=entry.entry_id, identifiers={(DOMAIN, "idlight1")}
+        )
+
+    orig = dr.DeviceRegistry.async_update_device
+
+    def boom(self, device_id, **kwargs):
+        if "new_identifiers" in kwargs:
+            raise RuntimeError("boom")  # only the migration re-point fails
+        return orig(self, device_id, **kwargs)
+
+    with patch.object(dr.DeviceRegistry, "async_update_device", boom):
+        entry = await _setup_with_registry(hass, prepare)
+
+    # Setup succeeds, but the per-device error means migration isn't marked done.
+    assert entry.data.get("stable_ids_migrated") is not True
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 def test_scene_slug_fallback() -> None:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -288,3 +288,61 @@ async def test_update_data_raises_update_failed_on_timeout(
         pytest.raises(UpdateFailed),
     ):
         await coordinator._async_update_data()
+
+
+async def test_update_data_5xx_maps_to_update_failed(hass: HomeAssistant) -> None:
+    """A non-auth ClientResponseError (e.g. 500) surfaces as UpdateFailed."""
+    coordinator = _coordinator(hass)
+    err = aiohttp.ClientResponseError(Mock(), (), status=500)
+    with (
+        patch.object(
+            coordinator, "_fetch_devices_from_api", AsyncMock(side_effect=err)
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+async def test_ws_handshake_non_auth_error_reconnects(hass: HomeAssistant) -> None:
+    """A non-401/403 handshake error reconnects with backoff (not reauth)."""
+    coordinator = _coordinator(hass)
+    err = aiohttp.WSServerHandshakeError(Mock(), (), status=500, message="x")
+    calls: list[int] = []
+
+    async def flaky(self: JungHomeDataUpdateCoordinator) -> None:
+        calls.append(1)
+        if len(calls) == 1:
+            raise err
+        self._closing = True  # clean exit on the second attempt
+
+    with (
+        patch.object(JungHomeDataUpdateCoordinator, "_run_websocket", flaky),
+        patch("custom_components.junghome.coordinator.asyncio.sleep", AsyncMock()),
+    ):
+        await coordinator._websocket_loop()
+    assert len(calls) == 2  # reconnected rather than giving up
+
+
+async def test_send_raises_when_send_str_fails(hass: HomeAssistant) -> None:
+    """A send failure on a live socket surfaces as HomeAssistantError."""
+    coordinator = _coordinator(hass)
+    ws = AsyncMock()
+    ws.closed = False
+    ws.send_str = AsyncMock(side_effect=RuntimeError("boom"))
+    coordinator.websocket = ws
+    with pytest.raises(HomeAssistantError):
+        await coordinator.send_websocket_message({"type": "datapoint"})
+
+
+async def test_ws_message_without_datapoint_id_is_ignored(hass: HomeAssistant) -> None:
+    """A datapoint frame with a dict payload but no id is logged and ignored."""
+    coordinator = _coordinator(hass)
+    coordinator._handle_websocket_message(  # must not raise
+        {"type": "datapoint", "data": {"values": []}}
+    )
+
+
+async def test_handle_message_non_dict_is_ignored(hass: HomeAssistant) -> None:
+    """A non-dict message payload hits the defensive guard and is ignored."""
+    coordinator = _coordinator(hass)
+    coordinator._handle_websocket_message(["not-a-dict"])  # type: ignore[arg-type]


### PR DESCRIPTION
## Schema check
Examined the gateway middleware dump (`…/middleware/dist/const/cdb_types_functions.json`
+ `cdb_types_datapoints.json`, and the `ip_events.d.ts` / `jung-home-functions.d.ts`
WebSocket/type models). Findings:

- **Covers — complete.** `Position=[level]`, `PositionAndAngle=[level, angle]`;
  the `level` datapoint's two keys (`level` %, `level_move` -1/0/1) and `angle`
  are all handled (position via `set_level`, stop via `move_level(0)`, tilt via
  `set_angle`).
- **Thermostats — were incomplete.** `Thermostat=[switch, quantity, temperature_ctrl]`
  — but `climate.py` ignored the **`switch`** datapoint, so the thermostat
  couldn't be turned off from HA.

(Caveat: this gateway's captured data has no live cover/thermostat — only
OnOff/ColorLight/Socket — so both were built from the schema, not observed
hardware; same unverifiable-on-hardware caveat as the cover direction.)

## Change
Map the thermostat `switch` to HVAC **OFF / HEAT**:
- discover the `switch` datapoint; `hvac_modes = [OFF, HEAT]` when present
  (HEAT-only fallback otherwise); `hvac_mode` follows switch 0/1
- `async_set_hvac_mode` drives it via the coordinator's existing
  `turn_on_switch` / `turn_off_switch`
- `_handle_coordinator_update` refreshes `hvac_mode` with the same
  `_should_refresh` selectivity as light/cover (no echo clobber)

## Coverage 98.25% → 99.52%
Thermostat on/off + switch-echo tests, plus reachable-branch tests (non-auth
fetch/handshake errors, send failure, non-dict/idless WS frames, malformed
cover/thermostat discovery, device-repoint migration error, NaN sensor reading).
Only `config_flow.py`'s `async_show_progress` step branches remain (a pre-existing
gap). The lone unreachable `native_value` fallthrough is a scoped `# pragma`.

## Verified
`mypy --strict` clean · `ruff` + format clean · **128 tests pass, 99.52% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)