### PR TITLE
Fix dimmer brightness on turn-on + richer diagnostics (handshake + support summary)

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -67,6 +67,10 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         self.groups: list[dict[str, Any]] = []
         # Bounded log of recent raw WebSocket frames for diagnostics.
         self.ws_frame_log: deque[str] = deque(maxlen=WS_FRAME_LOG_SIZE)
+        # Latest raw frame of each type, so the connect-time handshake
+        # (functions/groups/scenes/version) is always present in diagnostics even
+        # when the rolling log above has churned past it on a busy gateway.
+        self.ws_last_frame_by_type: dict[str, str] = {}
         # Stable-slug -> volatile device id, to detect firmware-update id changes.
         self._device_ids: dict[str, str] = {}
         self._ws_task: asyncio.Task[None] | None = None
@@ -289,10 +293,23 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 self.ws_connected = False
 
     def _log_ws_frame(self, raw: str) -> None:
-        """Append a truncated raw WebSocket frame to the diagnostics log."""
+        """Record a raw WebSocket frame for diagnostics.
+
+        Appends to the rolling recent-frames buffer and also keeps the latest
+        frame of each type. The frame `type` is read from the *full* payload
+        before truncation, so a large `functions` handshake frame is still keyed
+        correctly even though its stored body is truncated.
+        """
+        frame_type = None
+        try:
+            frame_type = json.loads(raw).get("type")
+        except (json.JSONDecodeError, AttributeError):
+            pass
         if len(raw) > WS_FRAME_MAX_CHARS:
             raw = raw[:WS_FRAME_MAX_CHARS] + "…[truncated]"
         self.ws_frame_log.append(raw)
+        if isinstance(frame_type, str):
+            self.ws_last_frame_by_type[frame_type] = raw
 
     def _handle_websocket_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages."""

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+from collections import deque
 from datetime import timedelta
 from typing import Any, cast
 from urllib.parse import quote
@@ -23,6 +24,15 @@ _LOGGER = logging.getLogger(__name__)
 # WebSocket reconnect backoff bounds (seconds).
 INITIAL_RECONNECT_DELAY = 1
 MAX_RECONNECT_DELAY = 60
+
+# Diagnostics: a bounded log of the most recent raw WebSocket frames so a
+# downloadable report shows what the gateway actually sends (the connect-time
+# handshake — version/message/functions/groups/scenes — plus live datapoint
+# pushes) against how we parse it. Frames carry no secrets (the token is a
+# connect header, never a frame body), but can be large, so each is truncated and
+# only the most recent are kept.
+WS_FRAME_LOG_SIZE = 60
+WS_FRAME_MAX_CHARS = 2000
 
 # Config entry carrying the coordinator as runtime_data.
 type JungHomeConfigEntry = ConfigEntry[JungHomeDataUpdateCoordinator]
@@ -51,6 +61,12 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # platform discovers from this; recall goes over REST because the
         # WebSocket `scene` command is unimplemented on the gateway.
         self.scenes: list[Scene] = []
+        # Last `groups` broadcast (per-room capability metadata, e.g. which groups
+        # advertise color_temperature_range). Not consumed by any entity; kept for
+        # diagnostics so unimplemented capabilities are visible.
+        self.groups: list[dict[str, Any]] = []
+        # Bounded log of recent raw WebSocket frames for diagnostics.
+        self.ws_frame_log: deque[str] = deque(maxlen=WS_FRAME_LOG_SIZE)
         # Stable-slug -> volatile device id, to detect firmware-update id changes.
         self._device_ids: dict[str, str] = {}
         self._ws_task: asyncio.Task[None] | None = None
@@ -228,6 +244,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
                         _LOGGER.debug("Received WebSocket message: %s", msg.data)
+                        self._log_ws_frame(msg.data)
                         try:
                             data = json.loads(msg.data)
                             if isinstance(data, list):
@@ -270,6 +287,12 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             finally:
                 self.websocket = None
                 self.ws_connected = False
+
+    def _log_ws_frame(self, raw: str) -> None:
+        """Append a truncated raw WebSocket frame to the diagnostics log."""
+        if len(raw) > WS_FRAME_MAX_CHARS:
+            raw = raw[:WS_FRAME_MAX_CHARS] + "…[truncated]"
+        self.ws_frame_log.append(raw)
 
     def _handle_websocket_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages."""
@@ -330,8 +353,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         elif isinstance(data, list):
             if msg_type in ("scenes", "scenes-new", "scenes-deleted"):
                 self._handle_scenes_broadcast(msg_type, data)
+            elif msg_type == "groups":
+                # Full groups list (on connect and on change). Not consumed by any
+                # entity, but kept for diagnostics (capability metadata).
+                self.groups = [g for g in data if isinstance(g, dict)]
             else:
-                # groups broadcasts — not consumed by any entity; ignore.
                 _LOGGER.debug("Received %s broadcast (%d items)", msg_type, len(data))
         else:
             _LOGGER.warning(

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -95,7 +95,11 @@ async def async_get_config_entry_diagnostics(
         "scenes": coordinator.scenes,
         "group_count": len(coordinator.groups),
         "groups": coordinator.groups,
-        # The most recent raw WebSocket frames (handshake + live pushes), so the
-        # real wire format can be matched against our parsing.
+        # The most recent raw WebSocket frames (live pushes), so the real wire
+        # format can be matched against our parsing...
         "recent_websocket_frames": list(coordinator.ws_frame_log),
+        # ...plus the latest frame of each type, which always retains the
+        # connect-time handshake (functions / groups / scenes / version) even on a
+        # spammy gateway where the rolling log above has churned past it.
+        "latest_websocket_frame_by_type": coordinator.ws_last_frame_by_type,
     }

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from .coordinator import JungHomeConfigEntry
+    from .models import Device
 
 # The gateway token is a bearer credential; never include it in a downloadable
 # report. The host (gateway IP/hostname) is mild PII and diagnostics are often
@@ -19,23 +21,81 @@ if TYPE_CHECKING:
 # main thing that makes a diagnostics dump useful for debugging.
 TO_REDACT = {CONF_TOKEN, "token", CONF_HOST, "host"}
 
+# Function/datapoint types the integration turns into entities. These mirror the
+# platform discovery (light/switch/sensor/event/cover/climate). The
+# `support_summary` flags anything a gateway reports that is NOT in these sets, so
+# an unsupported device or datapoint shows up in a downloadable report (the main
+# thing needed to extend support beyond what we currently parse).
+_HANDLED_FUNCTION_TYPES = {
+    "OnOff",
+    "DimmerLight",
+    "ColorLight",
+    "Socket",
+    "Measurement",
+    "Position",
+    "PositionAndAngle",
+    "Thermostat",
+    "RockerSwitch",
+}
+_HANDLED_DATAPOINT_TYPES = {
+    "switch",
+    "brightness",
+    "color_temperature",
+    "quantity",
+    "level",
+    "angle",
+    "temperature_ctrl",
+    "up_request",
+    "down_request",
+    "trigger_request",
+    "status_led",
+}
+
+
+def _support_summary(devices: list[Device]) -> dict[str, Any]:
+    """Count device/datapoint types and flag any the integration doesn't handle."""
+    function_types: Counter[str] = Counter(d.get("type") or "Unknown" for d in devices)
+    datapoint_types: Counter[str] = Counter(
+        dp.get("type") or "unknown" for d in devices for dp in d.get("datapoints", [])
+    )
+    return {
+        "function_types": dict(function_types),
+        "unhandled_function_types": sorted(
+            t for t in function_types if t not in _HANDLED_FUNCTION_TYPES
+        ),
+        "datapoint_types": dict(datapoint_types),
+        "unhandled_datapoint_types": sorted(
+            t for t in datapoint_types if t not in _HANDLED_DATAPOINT_TYPES
+        ),
+    }
+
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: JungHomeConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
+    devices = coordinator.data or []
     return {
         "entry": {
             "data": async_redact_data(entry.data, TO_REDACT),
             "title": entry.title,
         },
         "gateway_version": coordinator.gateway_version,
-        "device_count": len(coordinator.data or []),
-        "devices": coordinator.data or [],
-        # Scenes are a separate coordinator data category (not backed by a
-        # device); include them so a diagnostics dump is complete for debugging
-        # scene discovery/recall. Scene labels are retained like device labels.
+        # Quick map of what the gateway exposes vs what we implement — the first
+        # thing to check when matching real hardware against our support.
+        "support_summary": _support_summary(devices),
+        "device_count": len(devices),
+        "devices": devices,
+        # Scenes and groups are separate coordinator data categories (not backed by
+        # a device). Groups carry per-room capability metadata; both are kept so a
+        # dump is complete for debugging discovery/recall and spotting capabilities
+        # we don't yet implement.
         "scene_count": len(coordinator.scenes),
         "scenes": coordinator.scenes,
+        "group_count": len(coordinator.groups),
+        "groups": coordinator.groups,
+        # The most recent raw WebSocket frames (handshake + live pushes), so the
+        # real wire format can be matched against our parsing.
+        "recent_websocket_frames": list(coordinator.ws_frame_log),
     }

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -194,6 +194,13 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         self._is_on = True
         if self._has_brightness and "brightness" in kwargs:
             await self._set_brightness(kwargs["brightness"])
+        elif self._has_brightness:
+            # No explicit brightness: the device restores its own level on
+            # power-on. Don't guess — showing a kept/stale value looked like the
+            # light jumping to 100%. Clear it and let the device's own brightness
+            # report populate the real current value (its WS push, or the periodic
+            # poll as a fallback).
+            self._brightness = None
         if self._has_color_temp and "color_temp_kelvin" in kwargs:
             await self._set_color_temp(kwargs["color_temp_kelvin"])
         self.async_write_ha_state()

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b23",
+  "version": "1.2.0b24",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -440,16 +440,17 @@ async def test_switch_echo_does_not_reset_brightness(
     )
 
 
-async def test_brightness_preserved_across_off_on(
+async def test_plain_turn_on_waits_for_device_brightness(
     hass: HomeAssistant, init_integration
 ) -> None:
-    """Device brightness 0 (reported while off) must not blank the slider on off->on.
+    """A plain turn-on clears the optimistic brightness and waits for the device.
 
-    The dimmer reports brightness 0 when off (on/off is the switch datapoint), so
-    applying that 0 would briefly show the light at 0% on the next turn-on, before
-    the device echoes the restored level a frame later.
+    Without an explicit brightness the device restores its own level; the
+    integration must not keep a stale/guessed value (which looked like the light
+    jumping to 100%) — it clears brightness and applies what the device reports.
     """
     coordinator = init_integration.runtime_data
+    # Set a high brightness via the slider (optimistic 200).
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -458,33 +459,27 @@ async def test_brightness_preserved_across_off_on(
     )
     assert hass.states.get("light.strip").attributes["brightness"] == 200
 
-    # Turn off: the device echoes switch=0 and then brightness=0.
-    coordinator._handle_websocket_message(
-        {
-            "type": "datapoint",
-            "data": {"id": "idcolor1-001", "values": [{"key": "switch", "value": "0"}]},
-        }
+    # A plain toggle-on must NOT keep 200; brightness is cleared, pending report.
+    await hass.services.async_call(
+        "light", "turn_on", {"entity_id": "light.strip"}, blocking=True
     )
+    await hass.async_block_till_done()
+    assert hass.states.get("light.strip").attributes.get("brightness") is None
+
+    # The device then reports its restored level; that is what shows.
     coordinator._handle_websocket_message(
         {
             "type": "datapoint",
             "data": {
                 "id": "idcolor1-002",
-                "values": [{"key": "brightness", "value": "0"}],
+                "values": [{"key": "brightness", "value": "80"}],
             },
         }
     )
     await hass.async_block_till_done()
-    assert hass.states.get("light.strip").state == "off"
-
-    # Turn back on (no brightness): the slider must show the kept level, not 0%.
-    await hass.services.async_call(
-        "light", "turn_on", {"entity_id": "light.strip"}, blocking=True
+    assert hass.states.get("light.strip").attributes["brightness"] == round(
+        80 * 255 / 100
     )
-    await hass.async_block_till_done()
-    state = hass.states.get("light.strip")
-    assert state.state == "on"
-    assert state.attributes["brightness"] == 200
 
 
 async def test_status_led_update(hass: HomeAssistant, init_integration) -> None:
@@ -558,6 +553,7 @@ async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
     coordinator.scenes = [{"id": "s1", "label": "Movie"}]
     coordinator.groups = [{"id": "g1", "name": "Living room"}]
     coordinator.ws_frame_log.append('{"type":"version","data":"1.5.0"}')
+    coordinator.ws_last_frame_by_type = {"functions": '{"type":"functions"}'}
     diag = await async_get_config_entry_diagnostics(hass, init_integration)
     assert diag["device_count"] == len(DEVICES)
     assert diag["gateway_version"] == "1.5.0"
@@ -570,6 +566,7 @@ async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
     assert diag["group_count"] == 1
     assert diag["groups"] == [{"id": "g1", "name": "Living room"}]
     assert '{"type":"version"' in diag["recent_websocket_frames"][0]
+    assert diag["latest_websocket_frame_by_type"]["functions"] == '{"type":"functions"}'
     # Every type the fixture uses is handled, so nothing is flagged unsupported.
     assert diag["support_summary"]["unhandled_function_types"] == []
     assert diag["support_summary"]["unhandled_datapoint_types"] == []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,6 +20,7 @@ from custom_components.junghome.const import DOMAIN, device_slug
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.cover import JungHomeCover
 from custom_components.junghome.diagnostics import (
+    _support_summary,
     async_get_config_entry_diagnostics,
 )
 from custom_components.junghome.event import JungHomeEventEntity
@@ -555,6 +556,8 @@ async def test_light_external_change_applied(
 async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
     coordinator = init_integration.runtime_data
     coordinator.scenes = [{"id": "s1", "label": "Movie"}]
+    coordinator.groups = [{"id": "g1", "name": "Living room"}]
+    coordinator.ws_frame_log.append('{"type":"version","data":"1.5.0"}')
     diag = await async_get_config_entry_diagnostics(hass, init_integration)
     assert diag["device_count"] == len(DEVICES)
     assert diag["gateway_version"] == "1.5.0"
@@ -563,6 +566,37 @@ async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
     # Scenes are a separate coordinator data category, surfaced for debugging.
     assert diag["scene_count"] == 1
     assert diag["scenes"] == [{"id": "s1", "label": "Movie"}]
+    # Groups, raw WebSocket frames and the support summary are surfaced too.
+    assert diag["group_count"] == 1
+    assert diag["groups"] == [{"id": "g1", "name": "Living room"}]
+    assert '{"type":"version"' in diag["recent_websocket_frames"][0]
+    # Every type the fixture uses is handled, so nothing is flagged unsupported.
+    assert diag["support_summary"]["unhandled_function_types"] == []
+    assert diag["support_summary"]["unhandled_datapoint_types"] == []
+    assert diag["support_summary"]["function_types"]["ColorLight"] >= 1
+
+
+def test_support_summary_flags_unhandled_types() -> None:
+    """An unknown function/datapoint type is surfaced in the support summary."""
+    devices = [
+        {
+            "id": "a",
+            "type": "OnOff",
+            "label": "A",
+            "datapoints": [{"id": "a-1", "type": "switch", "values": []}],
+        },
+        {
+            "id": "b",
+            "type": "FutureGizmo",
+            "label": "B",
+            "datapoints": [{"id": "b-1", "type": "mystery", "values": []}],
+        },
+    ]
+    summary = _support_summary(devices)
+    assert summary["unhandled_function_types"] == ["FutureGizmo"]
+    assert summary["unhandled_datapoint_types"] == ["mystery"]
+    assert summary["function_types"]["OnOff"] == 1
+    assert summary["datapoint_types"]["switch"] == 1
 
 
 async def test_stale_device_pruned(hass: HomeAssistant) -> None:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -346,3 +346,26 @@ async def test_handle_message_non_dict_is_ignored(hass: HomeAssistant) -> None:
     """A non-dict message payload hits the defensive guard and is ignored."""
     coordinator = _coordinator(hass)
     coordinator._handle_websocket_message(["not-a-dict"])  # type: ignore[arg-type]
+
+
+async def test_groups_broadcast_is_stored(hass: HomeAssistant) -> None:
+    """A `groups` broadcast is cached for diagnostics (not consumed by entities)."""
+    coordinator = _coordinator(hass)
+    coordinator._handle_websocket_message(
+        {"type": "groups", "data": [{"id": "g1", "name": "Living room"}, "junk"]}
+    )
+    # Non-dict items are filtered out.
+    assert coordinator.groups == [{"id": "g1", "name": "Living room"}]
+    # An unrelated list broadcast (e.g. devices) is just debug-logged, not stored.
+    coordinator._handle_websocket_message({"type": "devices", "data": [{"id": "d"}]})
+    assert coordinator.groups == [{"id": "g1", "name": "Living room"}]
+
+
+async def test_ws_frame_log_truncates_large_frames(hass: HomeAssistant) -> None:
+    """The diagnostics frame log keeps recent frames and truncates large ones."""
+    coordinator = _coordinator(hass)
+    coordinator._log_ws_frame("x" * 5000)
+    coordinator._log_ws_frame("short")
+    assert coordinator.ws_frame_log[-1] == "short"
+    assert coordinator.ws_frame_log[0].endswith("…[truncated]")
+    assert len(coordinator.ws_frame_log[0]) < 5000

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -369,3 +369,18 @@ async def test_ws_frame_log_truncates_large_frames(hass: HomeAssistant) -> None:
     assert coordinator.ws_frame_log[-1] == "short"
     assert coordinator.ws_frame_log[0].endswith("…[truncated]")
     assert len(coordinator.ws_frame_log[0]) < 5000
+
+
+async def test_ws_frame_log_keeps_latest_per_type(hass: HomeAssistant) -> None:
+    """The latest frame of each type is retained (handshake survives churn)."""
+    coordinator = _coordinator(hass)
+    # A large functions handshake frame: body truncates, but its type is read
+    # from the full payload first, so it is still keyed as "functions".
+    big = '{"type":"functions","data":[' + ",".join(['{"id":"x"}'] * 500) + "]}"
+    coordinator._log_ws_frame(big)
+    coordinator._log_ws_frame('{"type":"version","data":"1.5.0"}')
+    coordinator._log_ws_frame("not json")  # unparseable -> not keyed by type
+    by_type = coordinator.ws_last_frame_by_type
+    assert by_type["functions"].endswith("…[truncated]")
+    assert by_type["version"] == '{"type":"version","data":"1.5.0"}'
+    assert set(by_type) == {"functions", "version"}


### PR DESCRIPTION
Addresses hardware feedback plus makes diagnostics genuinely useful for matching real gateway traffic.

## Fix: dimmer brightness jumped to ~100% on plain turn-on
A plain toggle-on of a dimmable light showed ~100% instead of the real level. The
earlier "keep last brightness / ignore device-reported 0" change meant a turn-on
*without* an explicit brightness displayed the kept (often max) value rather than
what the device actually restores to. Now a plain turn-on **clears** brightness
and lets the device's own report populate the real current value (its WS push, or
the periodic poll as a fallback) — it no longer guesses. Setting brightness via
the slider is unchanged (the explicit value is applied).

*Behaviour note:* immediately after a plain turn-on the brightness shows briefly
as unknown until the device reports — by design ("wait for it to report"), and it
avoids both the old 0% flash and the wrong 100%.

## Diagnostics: richer, and reliable for matching
- **`support_summary`** — counts of every function/datapoint type the gateway
  reports + `unhandled_function_types` / `unhandled_datapoint_types`, flagging any
  device/datapoint we don't yet implement.
- **`recent_websocket_frames`** — rolling log of recent raw frames.
- **`latest_websocket_frame_by_type`** — the latest raw frame of *each* type, so
  the connect-time handshake (functions / groups / scenes / version) is **always**
  present even on a spammy gateway where the rolling log has churned past it. (The
  frame `type` is read from the full payload before truncation, so the big
  `functions` frame is still keyed correctly.)
- **`groups`** — the gateway's groups broadcast (capability metadata) is cached.

Note: the **full device list is always present** regardless of WS spam — `devices`
and `support_summary` come from the REST `/functions` fetch, not the frame buffer.

No secrets added: token + host stay redacted; frames never carry the token.

## Verified
`mypy --strict` clean · `ruff` + format clean · **132 tests pass, 99.53% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)