### PR TITLE
Keep full (untruncated) handshake frames in diagnostics

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -295,21 +295,22 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     def _log_ws_frame(self, raw: str) -> None:
         """Record a raw WebSocket frame for diagnostics.
 
-        Appends to the rolling recent-frames buffer and also keeps the latest
-        frame of each type. The frame `type` is read from the *full* payload
-        before truncation, so a large `functions` handshake frame is still keyed
-        correctly even though its stored body is truncated.
+        The per-type store keeps the latest frame of each type IN FULL — it holds
+        at most one frame per type, so it cannot grow unbounded, and keeping the
+        connect-time handshake (functions/groups/scenes/version/message) complete
+        makes it directly comparable to the raw wire format. The rolling buffer,
+        which fills with high-frequency datapoint pushes, stays truncated.
         """
         frame_type = None
         try:
             frame_type = json.loads(raw).get("type")
         except (json.JSONDecodeError, AttributeError):
             pass
+        if isinstance(frame_type, str):
+            self.ws_last_frame_by_type[frame_type] = raw
         if len(raw) > WS_FRAME_MAX_CHARS:
             raw = raw[:WS_FRAME_MAX_CHARS] + "…[truncated]"
         self.ws_frame_log.append(raw)
-        if isinstance(frame_type, str):
-            self.ws_last_frame_by_type[frame_type] = raw
 
     def _handle_websocket_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages."""

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -98,8 +98,9 @@ async def async_get_config_entry_diagnostics(
         # The most recent raw WebSocket frames (live pushes), so the real wire
         # format can be matched against our parsing...
         "recent_websocket_frames": list(coordinator.ws_frame_log),
-        # ...plus the latest frame of each type, which always retains the
-        # connect-time handshake (functions / groups / scenes / version) even on a
-        # spammy gateway where the rolling log above has churned past it.
+        # ...plus the latest *full* (untruncated) frame of each type, which always
+        # retains the complete connect-time handshake (message / version /
+        # functions / groups / scenes) even on a spammy gateway where the rolling
+        # log above has churned past it.
         "latest_websocket_frame_by_type": coordinator.ws_last_frame_by_type,
     }

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b24",
+  "version": "1.2.0b25",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -372,15 +372,19 @@ async def test_ws_frame_log_truncates_large_frames(hass: HomeAssistant) -> None:
 
 
 async def test_ws_frame_log_keeps_latest_per_type(hass: HomeAssistant) -> None:
-    """The latest frame of each type is retained (handshake survives churn)."""
+    """The latest frame of each type is kept IN FULL (handshake survives churn)."""
     coordinator = _coordinator(hass)
-    # A large functions handshake frame: body truncates, but its type is read
-    # from the full payload first, so it is still keyed as "functions".
+    # A large functions handshake frame: it exceeds the rolling-log truncation
+    # cap, but the per-type store keeps it complete for direct wire comparison.
     big = '{"type":"functions","data":[' + ",".join(['{"id":"x"}'] * 500) + "]}"
+    assert len(big) > 2000
     coordinator._log_ws_frame(big)
     coordinator._log_ws_frame('{"type":"version","data":"1.5.0"}')
     coordinator._log_ws_frame("not json")  # unparseable -> not keyed by type
     by_type = coordinator.ws_last_frame_by_type
-    assert by_type["functions"].endswith("…[truncated]")
+    # Per-type store: full, untruncated.
+    assert by_type["functions"] == big
     assert by_type["version"] == '{"type":"version","data":"1.5.0"}'
     assert set(by_type) == {"functions", "version"}
+    # Rolling log: same large frame is truncated there.
+    assert coordinator.ws_frame_log[0].endswith("…[truncated]")


### PR DESCRIPTION
Your wscat capture is exactly what should be in the diagnostics. The
`latest_websocket_frame_by_type` field already captured the handshake types
(`message`/`version`/`functions`/`groups`/`scenes`), but truncated each to ~2 KB,
clipping the big `functions`/`groups` payloads.

That per-type store holds **at most one frame per type**, so it can't grow
unbounded — so it now keeps each frame **in full**, giving a diagnostics dump the
complete connect-time handshake, byte-for-byte comparable to the raw WS wire
format. The rolling `recent_websocket_frames` buffer (which fills with the spammy
datapoint pushes) stays truncated + bounded.

## Verified
`mypy --strict` clean · `ruff` + format clean · **132 tests pass, 99.53% coverage**
(coordinator.py 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)