### PR TITLE
Release 1.2.0

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0b25",
+  "version": "1.2.0",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
Cuts the first **stable** `1.2.0` release, promoting the `1.2.0b1`–`1.2.0b25` beta series to final. Version-only change (`manifest.json`: `1.2.0b25` → `1.2.0`); no code changes.

Highlights shipped across the beta series now going stable:
- New platforms: `cover` (position + tilt), `climate` (thermostats, target temp/presets incl. on/off), `scene` (dynamic scene entities).
- Shared `JungHomeEntity` base + `models.py` TypedDicts (`mypy --strict` clean).
- Anti-flicker per-datapoint refresh; dimmable on/off waits for the device's own brightness report instead of guessing 100%.
- Diagnostics: support summary (flags unhandled function/datapoint types), scenes/groups, recent WebSocket frames, and the full untruncated connect-time handshake per frame type.

After merge, tag `v1.2.0` triggers `release.yml` to publish the stable GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)