### PR TITLE
Fix awning cover inversion: per-cover invert option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,15 @@ JUNG HOME Gateway over its REST API and WebSocket.
     `Thermostat` → climate; `RockerSwitch` → event + switch (status LED).
     Scenes come from the WebSocket `scenes` broadcast and recall over REST
     (`POST /scenes/{id}`; the WebSocket `scene` command is unimplemented).
-    **Cover position convention is an unverified assumption** — the gateway
-    `level` is treated as percent-*closed* (HA position = `100 - level`); the
-    single inversion point is `_to_ha`/`_to_device` in `cover.py`.
+    **Cover position convention is confirmed against gateway firmware** — a
+    *close* maps to BT-Mesh "down" (`0x7FFF`, drives `level`→100%) and an *open*
+    to "up" (`0x8000`, →0%), so `level` is percent-*closed* (HA position =
+    `100 - level`), correct for roller shutters/blinds. **Awnings are mounted
+    the opposite way** and read inverted; users flag them in the options flow
+    (`CONF_INVERTED_COVERS`), which makes that cover use an identity mapping. The
+    single inversion point is `_to_ha`/`_to_device` in `cover.py` (both take an
+    `inverted` flag). Changing the inverted set reloads the entry (see
+    `async_reload_entry`, gated on an options snapshot in the coordinator).
 - `blueprints/automation/junghome/button_gestures.yaml` — shipped HA blueprint
   deriving single/double/hold from those raw edges. Users import it by URL; it is
   **not** distributed by HACS (HACS only installs `custom_components/`).

--- a/README.md
+++ b/README.md
@@ -10,18 +10,20 @@ Currently functional things:
 - BT S1 B2 U switch actuators.
 - Dimmers (DALI, etc.) - color and brightness as well as On/Off.
 - Sockets - On/Off, energy statistics, etc.
-- Blinds / shutters (covers) - open/close/stop, position, and slat tilt.
+- Blinds / shutters (covers) - open/close/stop, position, and slat tilt. Awnings,
+  which report position inverted, can be flagged in the integration's options.
 - Thermostats (room temperature regulators) - target temperature and presets.
 - Scenes - recall any Jung Home scene from Home Assistant.
 - Measurement sensors (e.g. ambient brightness on presence detectors).
 - IoT integration for Rocker Switches - allows triggering any script or automation in HomeAssistant via button presses.
 - Button LED On/Off (unfortunately, color can only be configured via app or BT Mesh/NRF).
 
-> Note: covers, thermostats, scenes and measurement sensors are implemented from
-> the gateway protocol but have **not yet been verified against real hardware**.
-> If you have such a device, feedback is very welcome — in particular whether a
-> blind's open/closed position reads the right way round (the direction is an
-> assumption; see `docs/gateway-websocket.md`).
+> Note: thermostats, scenes and measurement sensors are implemented from the
+> gateway protocol but have **not yet been fully verified against real hardware**,
+> so feedback is very welcome if you own one. Cover position direction is now
+> confirmed against the gateway firmware (percent-closed) and reads correctly for
+> roller shutters/blinds; **awnings** report it inverted, so flag them under
+> Settings → Devices & Services → Jung Home → **Configure**.
 
 All communication is via WebSockets. I've managed to reliably automate:
 - Single click
@@ -116,10 +118,11 @@ reconnects automatically with backoff. No cloud and no account are involved.
 
 - **Groups** defined in the JUNG app aren't exposed; use Home Assistant areas
   instead. (Scenes *are* exposed — see [Scenes](#scenes).)
-- **Covers, thermostats, scenes and measurement sensors are not yet verified
+- **Thermostats, scenes and measurement sensors are not yet fully verified
   against real hardware** — they're implemented from the gateway protocol but I
-  don't own those devices. Feedback welcome, especially whether a blind's
-  open/closed position reads the right way round.
+  don't own those devices. Feedback welcome. Cover position direction is
+  confirmed (percent-closed); **awnings** read inverted and can be flagged in the
+  integration's options to flip them.
 - **Metering sockets report instantaneous power (W) and current (A), not
   cumulative energy (kWh)**, so they can't go straight onto the Energy Dashboard.
   To track energy/cost, add a Riemann-sum

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -201,14 +201,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) ->
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> None:
-    """Reload when the stored host changes (e.g. zeroconf re-discovery).
+    """Reload when the stored host or the entry options change.
 
-    Registered as an update listener. The coordinator caches the host at
-    construction, so a host change in the stored data only takes effect after a
-    reload. Guard on an actual host change so reauth's token-only update (which
+    Registered as an update listener. The coordinator caches the host and an
+    options snapshot at construction, so a change to either only takes effect
+    after a reload (options drive cover inversion; the host drives the API/WS
+    target). Guard on an actual change so reauth's token-only update (which
     already reloads via ``async_update_reload_and_abort``) doesn't trigger a
     redundant second reload.
     """
     coordinator = entry.runtime_data
-    if coordinator.config.get("host") != entry.data.get("host"):
+    host_changed = coordinator.config.get("host") != entry.data.get("host")
+    options_changed = coordinator.options_snapshot != dict(entry.options)
+    if host_changed or options_changed:
         await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -10,10 +10,13 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.core import callback
+from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .const import DOMAIN
+from .const import CONF_INVERTED_COVERS, DOMAIN, stable_unique_id
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,10 +47,82 @@ def _normalize_host(host: str) -> str:
     return host.rstrip("/").lower()
 
 
+def _cover_choices(coordinator: JungHomeDataUpdateCoordinator) -> dict[str, str]:
+    """Map cover stable unique_id -> device label for the options selector.
+
+    Mirrors cover.py discovery (Position/PositionAndAngle with a level datapoint)
+    so the options flow lists exactly the covers the platform creates.
+    """
+    choices: dict[str, str] = {}
+    for device in coordinator.data or []:
+        if device.get("type") not in ("Position", "PositionAndAngle"):
+            continue
+        level_dp = next(
+            (dp for dp in device.get("datapoints", []) if dp.get("type") == "level"),
+            None,
+        )
+        if level_dp is None:
+            continue
+        uid = stable_unique_id(device, level_dp)
+        choices[uid] = device.get("label") or uid
+    return choices
+
+
+class JungHomeOptionsFlow(config_entries.OptionsFlow):
+    """Options: flag covers whose reported position is inverted (e.g. awnings)."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show/persist the set of inverted covers."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={CONF_INVERTED_COVERS: user_input.get(CONF_INVERTED_COVERS, [])}
+            )
+
+        entry: JungHomeConfigEntry = self.config_entry
+        coordinator = getattr(entry, "runtime_data", None)
+        choices = _cover_choices(coordinator) if coordinator is not None else {}
+        current = list(entry.options.get(CONF_INVERTED_COVERS, []))
+        # Keep any already-flagged cover that the gateway isn't currently
+        # reporting (e.g. offline) so saving the form doesn't silently clear it.
+        for uid in current:
+            choices.setdefault(uid, uid)
+        if not choices:
+            return self.async_abort(reason="no_covers")
+
+        options = [
+            selector.SelectOptionDict(value=uid, label=label)
+            for uid, label in sorted(choices.items(), key=lambda kv: kv[1].lower())
+        ]
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_INVERTED_COVERS, default=current
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=options,
+                        multiple=True,
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)
+
+
 class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Jung Home."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: JungHomeConfigEntry,
+    ) -> JungHomeOptionsFlow:
+        """Return the options flow handler."""
+        return JungHomeOptionsFlow()
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -6,6 +6,15 @@ from .models import Datapoint, Device
 
 DOMAIN = "junghome"
 
+# Options-flow key: the stable unique_ids of covers whose position the gateway
+# reports inverted relative to Home Assistant's convention. The gateway's native
+# `level` is percent-*closed* (firmware: closing drives the BT-Mesh Generic Level
+# toward 100 %, opening toward 0 %), which is correct for roller shutters/blinds.
+# Awnings (Markise) mount the motor the opposite way — "extended" is what the user
+# calls open — so for them the mapping must be flipped. There is no awning hint in
+# the gateway's function data, so the user marks them here. See cover.py.
+CONF_INVERTED_COVERS = "inverted_covers"
+
 
 def datapoint_value(datapoint: Datapoint | None, key: str) -> str | None:
     """Return the value for ``key`` in a datapoint's ``values``, or ``None``.

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -46,6 +46,10 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     ) -> None:
         """Initialize the coordinator."""
         self.config = config
+        # Snapshot of the entry options at setup, so the update listener can tell
+        # an options change (e.g. the inverted-covers set) from a token/host-only
+        # update and reload exactly when the platforms need rebuilding.
+        self.options_snapshot: dict[str, Any] = dict(config_entry.options)
         self.websocket: aiohttp.ClientWebSocketResponse | None = None
         self.ws_connected: bool = False
         # The datapoint id whose WebSocket push is being dispatched right now, or

--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -6,19 +6,25 @@ Two function types map here:
 - ``PositionAndAngle`` — a ``level`` datapoint plus an ``angle`` datapoint
   (slat tilt).
 
-## Position convention (hardware-verifiable assumption)
+## Position convention (confirmed against gateway firmware)
 
 The gateway's ``level`` datapoint is a 0-100 ``%`` value (Generic Level model).
-The dump used to build this integration was factory-reset, so it carries no live
-cover to confirm direction, and the gateway docs don't state it. This platform
-follows the common JUNG/European blind convention where ``level`` is **percent
-closed**, so it inverts to Home Assistant's "percent open" position:
+Its direction was confirmed from the gateway middleware (``disk_dump``): a *close*
+maps to BT-Mesh "down" (``0x7FFF`` ⇒ drives ``level`` toward 100 %) and an *open*
+to "up" (``0x8000`` ⇒ toward 0 %). So ``level`` is **percent closed**, which this
+platform inverts to Home Assistant's "percent open" position:
 
     ha_position = 100 - device_level
 
-If a real device turns out to report percent-open instead, flip ``_to_ha`` /
-``_to_device`` below (they are the single inversion point) — nothing else needs
-to change. The slat ``angle`` is mapped straight through (0-100%).
+This is correct for roller shutters/blinds. **Awnings (Markise) are mounted the
+opposite way** — the motor's "down/extended" is what the user calls *open* — so
+for them the position reads inverted (fully retracted shows as 100 % open). The
+gateway exposes no awning hint in its function data (both are ``Position``), and
+even has a per-device ``Blinds Invert Output`` firmware property, so direction is
+genuinely per-device. Such covers are flagged in the options flow
+(``CONF_INVERTED_COVERS``); a flagged cover uses an identity mapping
+(``ha_position = device_level``) instead. ``_to_ha`` / ``_to_device`` are the
+single inversion point. The slat ``angle`` is mapped straight through (0-100%).
 """
 
 import logging
@@ -34,7 +40,7 @@ from homeassistant.components.cover import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import datapoint_value, stable_unique_id
+from .const import CONF_INVERTED_COVERS, datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 from .entity import JungHomeEntity
 from .models import Datapoint, Device
@@ -48,18 +54,23 @@ PARALLEL_UPDATES = 0
 _MOVE_STOP = 0
 
 
-def _to_ha(device_level: int) -> int:
-    """Convert a device level (% closed) to a Home Assistant position (% open).
+def _to_ha(device_level: int, *, inverted: bool = False) -> int:
+    """Convert a device level to a Home Assistant position (% open).
+
+    For a normal cover the device level is percent-*closed*, so it inverts
+    (``100 - level``); for an ``inverted`` cover (e.g. an awning) the device level
+    already matches HA's percent-open convention and maps through unchanged.
 
     Clamped to 0..100: the gateway level is untrusted JSON, and an out-of-range
     value would otherwise produce an invalid HA position and break ``is_closed``.
     """
-    return max(0, min(100, 100 - device_level))
+    position = device_level if inverted else 100 - device_level
+    return max(0, min(100, position))
 
 
-def _to_device(ha_position: int) -> int:
-    """Convert a Home Assistant position (% open) to a device level (% closed)."""
-    return 100 - ha_position
+def _to_device(ha_position: int, *, inverted: bool = False) -> int:
+    """Convert a Home Assistant position (% open) to a device level."""
+    return ha_position if inverted else 100 - ha_position
 
 
 async def async_setup_entry(
@@ -70,6 +81,10 @@ async def async_setup_entry(
     """Set up Jung Home covers from a config entry."""
     coordinator = entry.runtime_data
     known: set[str] = set()
+    # Covers the user has flagged as inverted (e.g. awnings); their position maps
+    # through unchanged instead of being inverted. Read once here — an options
+    # change reloads the entry (see __init__.async_reload_entry), re-running setup.
+    inverted = set(entry.options.get(CONF_INVERTED_COVERS, []))
 
     @callback
     def _discover_covers() -> None:
@@ -92,7 +107,9 @@ async def async_setup_entry(
             if uid in known:
                 continue
             known.add(uid)
-            new_entities.append(JungHomeCover(coordinator, device, level_dp))
+            new_entities.append(
+                JungHomeCover(coordinator, device, level_dp, inverted=uid in inverted)
+            )
         if new_entities:
             async_add_entities(new_entities, update_before_add=True)
 
@@ -113,11 +130,15 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
         coordinator: JungHomeDataUpdateCoordinator,
         device: Device,
         level_datapoint: Datapoint,
+        *,
+        inverted: bool = False,
     ) -> None:
         """Initialize the cover."""
         super().__init__(coordinator, device)
         self._datapoint = level_datapoint
         self._level_datapoint_id = level_datapoint["id"]
+        # Awning-style cover whose level is reported percent-open, not -closed.
+        self._inverted = inverted
         self._angle_datapoint = next(
             (dp for dp in device.get("datapoints", []) if dp.get("type") == "angle"),
             None,
@@ -164,13 +185,17 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover fully."""
-        await self.coordinator.set_level(self._level_datapoint_id, _to_device(100))
+        await self.coordinator.set_level(
+            self._level_datapoint_id, _to_device(100, inverted=self._inverted)
+        )
         self._position = 100
         self.async_write_ha_state()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover fully."""
-        await self.coordinator.set_level(self._level_datapoint_id, _to_device(0))
+        await self.coordinator.set_level(
+            self._level_datapoint_id, _to_device(0, inverted=self._inverted)
+        )
         self._position = 0
         self.async_write_ha_state()
 
@@ -178,7 +203,7 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
         """Move the cover to a specific position."""
         ha_position = int(kwargs[ATTR_POSITION])
         await self.coordinator.set_level(
-            self._level_datapoint_id, _to_device(ha_position)
+            self._level_datapoint_id, _to_device(ha_position, inverted=self._inverted)
         )
         self._position = ha_position
         self.async_write_ha_state()
@@ -235,7 +260,7 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
         if value is None:
             return None
         try:
-            return _to_ha(round(float(value)))
+            return _to_ha(round(float(value)), inverted=self._inverted)
         except (TypeError, ValueError):
             return None
 

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -53,6 +53,20 @@
       "reconfigure_successful": "The gateway address was updated."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Jung Home cover options",
+        "description": "Select any covers whose position is reported inverted, such as awnings. Their position is flipped so fully closed reads as 0 percent (closed) and fully open as 100 percent (open). Leave roller shutters and blinds unselected.",
+        "data": {
+          "inverted_covers": "Inverted covers (awnings)"
+        }
+      }
+    },
+    "abort": {
+      "no_covers": "No covers were found on this gateway, so there is nothing to configure."
+    }
+  },
   "entity": {
     "climate": {
       "thermostat": {

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -53,6 +53,20 @@
       "reconfigure_successful": "The gateway address was updated."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Jung Home cover options",
+        "description": "Select any covers whose position is reported inverted, such as awnings. Their position is flipped so fully closed reads as 0 percent (closed) and fully open as 100 percent (open). Leave roller shutters and blinds unselected.",
+        "data": {
+          "inverted_covers": "Inverted covers (awnings)"
+        }
+      }
+    },
+    "abort": {
+      "no_covers": "No covers were found on this gateway, so there is nothing to configure."
+    }
+  },
   "entity": {
     "climate": {
       "thermostat": {

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -116,19 +116,26 @@ Common `values` keys by device type:
 | Switch / light on-off | `switch` = `"0"` / `"1"` |
 | Dimmer | `brightness` = `"0".."100"` (device scale) |
 | Tunable white | `color_temperature` = Kelvin, e.g. `"2700"` |
-| Cover position | `level` = `"0".."100"` (device scale; see note below) |
-| Cover move / stop | `level_move` = `"1"` / `"-1"` (move) / `"0"` (stop) |
+| Cover position | `level` = `"0".."100"` (device scale, percent-*closed*; see note) |
+| Cover move / stop | `level_move` = `"1"` (closing/down) / `"-1"` (opening/up) / `"0"` (stop) |
 | Cover slat tilt | `angle` = `"0".."100"` |
 | Thermostat target | `temperature_ctrl` = °C, e.g. `"21.5"` (range 5..30) |
 | Thermostat preset | `temperature_ctrl_preset` = `none` / `frost` / `eco` / `comfort` |
 | Status LED (rocker) | `status_led` = `"0"` / `"1"` |
 | Rocker press (read-only events) | `up_request` / `down_request` / `trigger_request` = `"1"` |
 
-> **Cover `level` direction is unconfirmed.** The dump used to reverse-engineer
-> this was factory-reset (no live cover), and neither the gateway nor its docs
-> state whether `level` is percent-open or percent-closed. The integration
-> assumes percent-*closed* (HA position = `100 - level`). Verify against
-> hardware; the inversion lives in one place (`cover.py` `_to_ha`/`_to_device`).
+> **Cover `level` is percent-*closed* (confirmed from gateway firmware).** In the
+> middleware (`btmesh_set_datapoint_service.js` + `datapoint_helper_methods.js`) a
+> *close* maps to BT-Mesh "down" (`0x7FFF` ⇒ drives the Generic Level toward
+> 100 %) and an *open* to "up" (`0x8000` ⇒ toward 0 %). So `level` 100 = fully
+> closed, 0 = fully open, and the integration uses HA position = `100 - level`.
+> This is correct for roller shutters/blinds. **Awnings (Markise) mount the motor
+> the opposite way** — fully retracted reports `level` 0 yet the user calls that
+> "closed" — so they read inverted. The gateway exposes no awning hint (both are
+> `Position`) and has a per-device `Blinds Invert Output` firmware property, so
+> direction is genuinely per-device: the integration lets users flag such covers
+> in its options flow, which switches that cover to an identity mapping. The
+> inversion lives in one place (`cover.py` `_to_ha`/`_to_device`).
 
 ### Other command types
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the Jung Home config flow."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -15,10 +16,28 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.junghome.config_flow import (
     CannotRegister,
     JungHomeConfigFlow,
+    _cover_choices,
     _normalize_host,
 )
-from custom_components.junghome.const import DOMAIN
+from custom_components.junghome.const import CONF_INVERTED_COVERS, DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
+
+# A single cover so the options flow has something to list. stable_unique_id =
+# slug("Awning") + suffix("idawn-001") = "awning_001".
+_COVERS = [
+    {
+        "id": "idawn",
+        "type": "Position",
+        "label": "Awning",
+        "datapoints": [
+            {
+                "id": "idawn-001",
+                "type": "level",
+                "values": [{"key": "level", "value": "0"}],
+            }
+        ],
+    }
+]
 
 
 def _flow(hass: HomeAssistant, host: str = "gw") -> JungHomeConfigFlow:
@@ -349,3 +368,88 @@ async def test_reauth_failed_step_shows_form(hass: HomeAssistant) -> None:
     result = await _flow(hass).async_step_reauth_failed()
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_failed"
+
+
+def test_cover_choices_skips_malformed_and_falls_back_to_uid() -> None:
+    """_cover_choices skips a Position without a level dp and labels blanks by uid."""
+    data = [
+        # No level datapoint -> skipped (mirrors cover.py discovery).
+        {"id": "x", "type": "Position", "label": "Lbl", "datapoints": []},
+        # Blank label -> the stable unique_id is used as the display label.
+        {
+            "id": "y",
+            "type": "Position",
+            "label": "",
+            "datapoints": [{"id": "y-001", "type": "level", "values": []}],
+        },
+    ]
+    assert _cover_choices(SimpleNamespace(data=data)) == {"y_001": "y_001"}
+
+
+async def test_options_flow_lists_and_saves_inverted_covers(
+    hass: HomeAssistant,
+) -> None:
+    """The options flow lists discovered covers and stores the chosen ids."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="gw", data={CONF_HOST: "gw", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    _, ws = _no_network()
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=_COVERS),
+        ),
+        ws,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {CONF_INVERTED_COVERS: ["awning_001"]}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+    assert entry.options[CONF_INVERTED_COVERS] == ["awning_001"]
+
+
+async def test_options_flow_aborts_without_covers(hass: HomeAssistant) -> None:
+    """With no covers (and none previously flagged) the options flow aborts."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="gw", data={CONF_HOST: "gw", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    fetch, ws = _no_network()  # fetch returns [] -> no covers
+    with fetch, ws:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_covers"
+
+
+async def test_options_flow_keeps_offline_flagged_cover(hass: HomeAssistant) -> None:
+    """A flagged cover the gateway isn't currently reporting is preserved."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="gw",
+        data={CONF_HOST: "gw", CONF_TOKEN: "t"},
+        options={CONF_INVERTED_COVERS: ["ghost_001"]},
+    )
+    entry.add_to_hass(hass)
+    fetch, ws = _no_network()  # no covers reported right now
+    with fetch, ws:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        # Not aborted: the already-flagged "ghost" cover stays selectable.
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {CONF_INVERTED_COVERS: ["ghost_001"]}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+    assert entry.options[CONF_INVERTED_COVERS] == ["ghost_001"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from homeassistant.components.climate.const import HVACMode
 from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -16,7 +17,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome import async_unload_entry
 from custom_components.junghome.climate import JungHomeClimate
-from custom_components.junghome.const import DOMAIN, device_slug
+from custom_components.junghome.const import CONF_INVERTED_COVERS, DOMAIN, device_slug
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.cover import JungHomeCover
 from custom_components.junghome.diagnostics import (
@@ -1198,6 +1199,99 @@ async def test_cover_commands(hass: HomeAssistant, init_integration) -> None:
     assert [c.args[1] for c in sl.call_args_list] == [0, 100, 75]
     assert sa.call_args.args[1] == 60
     assert ml.call_args.args[1] == 0  # stop
+
+
+async def test_cover_inverted_awning_position(hass: HomeAssistant) -> None:
+    """A flagged (awning) cover maps the gateway level straight through.
+
+    The reporter's awning sends level 0 when physically retracted ("closed") and
+    100 when extended ("open"). Inverted, HA reads those as 0/closed and 100/open
+    instead of the shutter convention's 100/open and 0/closed.
+    """
+    coordinator = _bare_coordinator(hass)
+
+    def _awning(level: str) -> JungHomeCover:
+        dps = [
+            {"id": "a-1", "type": "level", "values": [{"key": "level", "value": level}]}
+        ]
+        device = {"id": "a", "type": "Position", "label": "Awning", "datapoints": dps}
+        return JungHomeCover(coordinator, device, dps[0], inverted=True)
+
+    retracted = _awning("0")
+    assert retracted.current_cover_position == 0
+    assert retracted.is_closed is True
+
+    extended = _awning("100")
+    assert extended.current_cover_position == 100
+    assert extended.is_closed is False
+
+
+async def test_cover_inverted_commands_pass_through(hass: HomeAssistant) -> None:
+    """Inverted covers send the HA position to the gateway unchanged (no 100-x)."""
+    coordinator = _bare_coordinator(hass)
+    dps = [{"id": "a-1", "type": "level", "values": [{"key": "level", "value": "0"}]}]
+    device = {"id": "a", "type": "Position", "label": "Awning", "datapoints": dps}
+    cover = JungHomeCover(coordinator, device, dps[0], inverted=True)
+    with (
+        patch.object(coordinator, "set_level", AsyncMock()) as sl,
+        patch.object(cover, "async_write_ha_state"),
+    ):
+        await cover.async_open_cover()  # HA open -> device level 100
+        await cover.async_close_cover()  # HA close -> device level 0
+        await cover.async_set_cover_position(position=25)  # -> device level 25
+    assert [c.args[1] for c in sl.call_args_list] == [100, 0, 25]
+
+
+async def test_cover_inverted_via_options(hass: HomeAssistant) -> None:
+    """A cover listed in entry options uses the awning mapping end to end."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+        options={CONF_INVERTED_COVERS: ["bedroom_blind_001"]},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=DEVICES),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        # Flagged inverted: device level 30 -> HA position 30 (not the 70 a shutter
+        # would show); the unflagged kitchen shade keeps the inverting convention.
+        bedroom = hass.states.get("cover.bedroom_blind")
+        assert bedroom.attributes["current_position"] == 30
+        kitchen = hass.states.get("cover.kitchen_shade")
+        assert kitchen.attributes["current_position"] == 100  # device level 0 -> open
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_options_flow_inverts_cover_after_reload(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Saving the inverted-covers option reloads the entry and flips the cover."""
+    # Default (shutter) convention: device level 30 -> HA position 70.
+    assert hass.states.get("cover.bedroom_blind").attributes["current_position"] == 70
+
+    result = await hass.config_entries.options.async_init(init_integration.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_INVERTED_COVERS: ["bedroom_blind_001"]}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # The options change reloaded the entry; the blind now uses the awning mapping.
+    assert hass.states.get("cover.bedroom_blind").attributes["current_position"] == 30
+    assert init_integration.options[CONF_INVERTED_COVERS] == ["bedroom_blind_001"]
 
 
 async def test_climate_created(hass: HomeAssistant, init_integration) -> None:


### PR DESCRIPTION
## What

A user reported their **awning** reads inverted: physically fully closed shows `current_position: 100` / state *open* (firmware 2.1.3).

## Double-checking the direction (the question asked)

I traced the gateway firmware in the disk dump rather than re-guessing:

- **SET path** (`btmesh_set_datapoint_service.js`): a *close* → BT-Mesh "down" `0x7FFF` (+32767), an *open* → "up" `0x8000` (−32768).
- **Move mapping** (`datapoint_helper_methods.js`): `opening → -1 → up`, `closing → +1 → down`.
- **Scaling** (`convertRange`): linear, monotonic over `[-0x8000 … 0x7FFF] → [0 … 100]`.

Chaining these: **close drives `level` → 100 %, open → 0 %**, i.e. `level` is **percent-closed**. So the existing `100 - level` inversion in `cover.py` is **correct for roller shutters/blinds** — a global flip would break them.

The reporter's device is an **awning (Markise)**, mounted the opposite way (retracted = motor up = `level` 0 = what they call "closed"), which is exactly the reported symptom. The gateway exposes no awning hint (both shutters and awnings are `Position`) and even has a per-device `Blinds Invert Output` firmware property — so direction is genuinely per-device.

## Fix

Add an **options flow** to flag inverted covers (e.g. awnings). A flagged cover uses an identity mapping instead of inverting; `_to_ha`/`_to_device` take an `inverted` flag (still the single inversion point). Changing the set reloads the entry (gated on an options snapshot so reauth's token-only update doesn't double-reload).

- `const`: `CONF_INVERTED_COVERS`
- `config_flow`: `JungHomeOptionsFlow` + `async_get_options_flow` + `_cover_choices`
- `cover`: thread `inverted` through position read + open/close/set_position
- `coordinator` + `__init__`: reload on host **or** options change
- `strings.json` / `en.json`: options step + `no_covers` abort (kept in sync)
- docs / CLAUDE.md / README: direction now **confirmed**; document the awning option

## Verification

`ruff check` · `ruff format --check` · `mypy --strict` · `pytest` — all green. **140 tests, 99.55 % coverage.** New tests cover the inverted read/commands, the options-driven reload, and the options flow (list/save, `no_covers` abort, offline-flag preservation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)