### PR TITLE
Add occupancy binary_sensor for presence detectors (BWM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,22 @@ JUNG HOME Gateway over its REST API and WebSocket.
     app-approval registration.
   - `const.py` — `DOMAIN` and the stable-ID helpers (`device_slug`,
     `datapoint_suffix`, `stable_unique_id`).
-  - `light.py`, `switch.py`, `sensor.py`, `event.py`, `cover.py`, `climate.py`,
-    `scene.py` — platforms (each does live discovery of devices added at
-    runtime). `event.py` exposes RockerSwitch buttons; the gateway only reports
-    raw `pressed` / `depressed` edges (no native single/double/hold) and
-    alternates a button between its `up_request` and `down_request` events on
-    consecutive presses. Function-type → platform map:
+  - `light.py`, `switch.py`, `sensor.py`, `binary_sensor.py`, `event.py`,
+    `cover.py`, `climate.py`, `scene.py` — platforms (each does live discovery of
+    devices added at runtime). `event.py` exposes RockerSwitch buttons; the
+    gateway only reports raw `pressed` / `depressed` edges (no native
+    single/double/hold) and alternates a button between its `up_request` and
+    `down_request` events on consecutive presses. Function-type → platform map:
     `OnOff`/`DimmerLight`/`ColorLight` → light (capabilities follow the
     datapoints present, not the type name); `Socket` → switch + sensor;
-    `Measurement` → sensor; `Position`/`PositionAndAngle` → cover;
-    `Thermostat` → climate; `RockerSwitch` → event + switch (status LED).
+    `Measurement` → sensor + binary_sensor; `Position`/`PositionAndAngle` →
+    cover; `Thermostat` → climate; `RockerSwitch` → event + switch (status LED).
+    Datapoint mapping is not purely by function/datapoint *type*: a `quantity`
+    datapoint whose label denotes presence/occupancy (empty unit, 0/1 value, e.g.
+    a "BWM" detector's `Presence Detected`) becomes an **occupancy
+    binary_sensor**, while other `quantity` datapoints become numeric sensors.
+    `is_presence_quantity` (in `const.py`) is the single split point: the
+    binary_sensor platform claims those labels and `sensor.py` skips them.
     Scenes come from the WebSocket `scenes` broadcast and recall over REST
     (`POST /scenes/{id}`; the WebSocket `scene` command is unimplemented).
     **Cover position convention is confirmed against gateway firmware** — a

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -17,6 +17,7 @@ PLATFORMS: list[Platform] = [
     Platform.LIGHT,
     Platform.SWITCH,
     Platform.SENSOR,
+    Platform.BINARY_SENSOR,
     Platform.EVENT,
     Platform.COVER,
     Platform.CLIMATE,

--- a/custom_components/junghome/binary_sensor.py
+++ b/custom_components/junghome/binary_sensor.py
@@ -1,0 +1,124 @@
+"""Binary sensor platform for Jung Home (presence / occupancy detectors).
+
+JUNG presence/motion detectors ("BWM") are ``Measurement`` functions that, next
+to their ambient ``Present Illuminance`` (lux) reading, expose detection as a
+``quantity`` datapoint with an **empty unit** and a ``0``/``1`` value (label
+``Presence Detected``). That is a boolean state, not a measurement, so it surfaces
+here as an occupancy ``binary_sensor`` rather than a numeric sensor — the numeric
+``sensor`` platform deliberately skips it (see ``is_presence_quantity``).
+"""
+
+import logging
+import math
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import datapoint_value, is_presence_quantity, stable_unique_id
+from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .entity import JungHomeEntity
+from .models import Datapoint, Device
+
+_LOGGER = logging.getLogger(__name__)
+
+# Read-only platform; no update serialisation needed.
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Jung Home binary sensors from a config entry."""
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _discover_binary_sensors() -> None:
+        """Add entities for any presence sensors not yet created (handles late adds)."""
+        new_entities: list[JungHomePresence] = []
+        for device in coordinator.data or []:
+            # Presence/occupancy is reported as a quantity datapoint (with an
+            # empty unit); it can ride on a Measurement detector or, in
+            # principle, any device, so match on the datapoint, not the type.
+            for datapoint in device.get("datapoints", []):
+                if datapoint.get("type") != "quantity":
+                    continue
+                raw_label = datapoint_value(datapoint, "quantity_label")
+                if raw_label is None or not is_presence_quantity(raw_label):
+                    continue
+                label = raw_label.strip()
+                uid = stable_unique_id(
+                    device, datapoint, label.replace(" ", "_").lower()
+                )
+                if uid not in known:
+                    known.add(uid)
+                    new_entities.append(
+                        JungHomePresence(coordinator, device, datapoint, label)
+                    )
+        if new_entities:
+            async_add_entities(new_entities, update_before_add=True)
+
+    _discover_binary_sensors()
+    entry.async_on_unload(coordinator.async_add_listener(_discover_binary_sensors))
+
+
+class JungHomePresence(JungHomeEntity, BinarySensorEntity):
+    """A Jung Home presence/occupancy detection (boolean quantity)."""
+
+    # Secondary entity on the device (the detector also has a lux sensor), so HA
+    # prepends the device name: entity_id `binary_sensor.<device>_presence_detected`.
+    _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
+
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        device: Device,
+        datapoint: Datapoint,
+        label: str,
+    ) -> None:
+        """Initialize the presence sensor."""
+        super().__init__(coordinator, device)
+        self._datapoint = datapoint
+        self._datapoint_id = datapoint["id"]
+        self._attr_name = label
+        self._name = f"{device.get('label', 'Jung Device')} {label}"  # for logging
+        # Firmware-stable id derived from the label, not the volatile device id.
+        self._attr_unique_id = stable_unique_id(
+            device, datapoint, label.replace(" ", "_").lower()
+        )
+        self._is_on = self._get_state_from_datapoint(datapoint)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if presence is detected (None if unknown)."""
+        return self._is_on
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        datapoint = self._find_datapoint(self._datapoint_id)
+        if datapoint:
+            self._is_on = self._get_state_from_datapoint(datapoint)
+            self.async_write_ha_state()
+
+    def _get_state_from_datapoint(self, datapoint: Datapoint | None) -> bool | None:
+        """Extract the boolean presence state from a quantity datapoint.
+
+        The value is a numeric string (``"0"``/``"1"``); anything non-finite
+        (e.g. an uninitialised ``"NaN"``) reads as unknown rather than ``True``
+        (``float("NaN") != 0`` is misleadingly truthy).
+        """
+        value = datapoint_value(datapoint, "quantity")
+        if value is None:
+            return None
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return None
+        return numeric != 0 if math.isfinite(numeric) else None

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -16,6 +16,29 @@ DOMAIN = "junghome"
 CONF_INVERTED_COVERS = "inverted_covers"
 
 
+# Quantity labels that denote a boolean *state* rather than a measured value.
+# Presence/motion detectors (JUNG "BWM") report detection as a `quantity`
+# datapoint with an empty `quantity_unit` and a 0/1 `quantity` value, so it is
+# surfaced as an occupancy binary_sensor, not a numeric sensor. Matched as
+# case-insensitive substrings of the (English) label the gateway reports, e.g.
+# "Presence Detected". ("Present Illuminance" has unit "lux" and the substring
+# "present", not "presence", so it stays a numeric illuminance sensor.)
+_PRESENCE_LABEL_KEYWORDS = ("presence", "occupancy", "motion")
+
+
+def is_presence_quantity(label: str | None) -> bool:
+    """Whether a quantity datapoint's label denotes presence/occupancy (boolean).
+
+    The binary_sensor platform claims such datapoints and the numeric sensor
+    platform skips them, so the two never double-expose the same datapoint (see
+    ``binary_sensor.py`` / ``sensor.py``).
+    """
+    if not label:
+        return False
+    text = label.strip().lower()
+    return any(keyword in text for keyword in _PRESENCE_LABEL_KEYWORDS)
+
+
 def datapoint_value(datapoint: Datapoint | None, key: str) -> str | None:
     """Return the value for ``key`` in a datapoint's ``values``, or ``None``.
 

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import datapoint_value, stable_unique_id
+from .const import datapoint_value, is_presence_quantity, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 from .entity import JungHomeEntity
 from .models import Datapoint, Device
@@ -79,6 +79,11 @@ async def async_setup_entry(
                 for datapoint in device.get("datapoints", []):
                     if datapoint.get("type") == "quantity":
                         raw_label = datapoint_value(datapoint, "quantity_label")
+                        # Presence/occupancy is a boolean state, owned by the
+                        # binary_sensor platform — skip it here so the two never
+                        # double-expose the same datapoint.
+                        if is_presence_quantity(raw_label):
+                            continue
                         label = raw_label.strip() if raw_label else None
                         unit = datapoint_value(datapoint, "quantity_unit")
                         if label and unit:

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -8,6 +8,7 @@ device id.
 from custom_components.junghome.const import (
     datapoint_suffix,
     device_slug,
+    is_presence_quantity,
     stable_unique_id,
 )
 
@@ -88,3 +89,20 @@ def test_stable_unique_id_is_independent_of_the_gateway_device_id():
     before = {"id": "idAAAA1111-010"}
     after = {"id": "idBBBB2222-010"}
     assert stable_unique_id(device, before) == stable_unique_id(device, after)
+
+
+def test_is_presence_quantity_matches_presence_labels():
+    """Presence/occupancy/motion labels are boolean states (binary_sensor)."""
+    # Trailing space mirrors the real gateway label "Presence Detected ".
+    assert is_presence_quantity("Presence Detected ") is True
+    assert is_presence_quantity("Occupancy") is True
+    assert is_presence_quantity("Motion Detected") is True
+
+
+def test_is_presence_quantity_rejects_measurement_labels():
+    """ "Present Illuminance" must NOT match (substring "present", not "presence"),
+    so it stays a numeric sensor; other measurements and empty/None too."""
+    assert is_presence_quantity("Present Illuminance ") is False
+    assert is_presence_quantity("Present Device Input Power ") is False
+    assert is_presence_quantity("") is False
+    assert is_presence_quantity(None) is False


### PR DESCRIPTION
## Summary

JUNG presence/motion detectors (`Measurement` "BWM" functions) report detection as a `quantity` datapoint with an **empty unit** and a `0`/`1` value (label `Presence Detected`). `sensor.py` only surfaces quantities that have a unit, so presence — the whole point of a motion sensor — was silently dropped. The diagnostics "unhandled types" check can't catch this because `Measurement`/`quantity` are both already-handled types; it was only visible in the raw WebSocket frames (spotted in a shared diagnostics dump).

## Changes

- **`binary_sensor.py`** (new) — discovers any `quantity` datapoint whose label denotes presence and exposes it as `BinarySensorDeviceClass.OCCUPANCY`. `on` when the value is non-zero; `None` for a non-finite value (a bare `NaN != 0` is misleadingly truthy, so it's guarded).
- **`const.py`** — `is_presence_quantity()` is the single split point (matches `presence`/`occupancy`/`motion`; deliberately not `Present Illuminance`).
- **`sensor.py`** — skips presence quantities so the two platforms never double-expose the same datapoint.
- **`__init__.py`** — registers `Platform.BINARY_SENSOR`.
- **`CLAUDE.md`** + tests updated; bump manifest to **1.2.2**.

Device-class note: chose `OCCUPANCY` (label is "Presence Detected"; these hold state while occupied) over `MOTION` (instantaneous pulses).

## Validation

- 142 tests pass (2 new for `is_presence_quantity`); `ruff check`/`format` clean; `mypy` clean.
- Simulated against the real diagnostics data: 3 new occupancy binary sensors discovered, the 3 illuminance sensors preserved, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)