### PR TITLE
Add a gateway connectivity binary sensor

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -9,7 +9,13 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_AREA_ASSIGNED, DOMAIN, datapoint_suffix, device_slug
+from .const import (
+    DATA_AREA_ASSIGNED,
+    DOMAIN,
+    datapoint_suffix,
+    device_slug,
+    gateway_device_id,
+)
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,6 +82,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
         if not coordinator.data:
             return  # don't prune on an empty/failed poll
         current = {device_slug(d) for d in coordinator.data}
+        # The synthetic gateway (hub) device never appears in the device list, so
+        # keep it in the live set or it would be pruned on every refresh.
+        current.add(gateway_device_id(entry))
         dev_reg = dr.async_get(hass)
         for device_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
             slugs = {

--- a/custom_components/junghome/binary_sensor.py
+++ b/custom_components/junghome/binary_sensor.py
@@ -15,10 +15,19 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import datapoint_value, is_presence_quantity, stable_unique_id
+from .const import (
+    DOMAIN,
+    datapoint_value,
+    gateway_device_id,
+    is_presence_quantity,
+    stable_unique_id,
+)
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 from .entity import JungHomeEntity
 from .models import Datapoint, Device
@@ -37,6 +46,11 @@ async def async_setup_entry(
     """Set up Jung Home binary sensors from a config entry."""
     coordinator = entry.runtime_data
     known: set[str] = set()
+
+    # One gateway-level connectivity sensor per entry. Added once at setup (not a
+    # per-device discovery) so the hub always exposes a reachability entity even
+    # before any device is discovered.
+    async_add_entities([JungHomeGatewayConnectivity(coordinator, entry)])
 
     @callback
     def _discover_binary_sensors() -> None:
@@ -122,3 +136,54 @@ class JungHomePresence(JungHomeEntity, BinarySensorEntity):
         except (TypeError, ValueError):
             return None
         return numeric != 0 if math.isfinite(numeric) else None
+
+
+class JungHomeGatewayConnectivity(
+    CoordinatorEntity[JungHomeDataUpdateCoordinator], BinarySensorEntity
+):
+    """Reports whether the gateway's live WebSocket link is up.
+
+    This is a hub-level diagnostic entity, not backed by a JUNG *function*, so it
+    is attached to a synthetic gateway device (shared by any future gateway-level
+    entities) rather than to ``JungHomeEntity``.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "gateway_connectivity"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: JungHomeDataUpdateCoordinator,
+        entry: JungHomeConfigEntry,
+    ) -> None:
+        """Initialize the gateway connectivity sensor."""
+        super().__init__(coordinator)
+        self._gateway_id = gateway_device_id(entry)
+        self._attr_unique_id = f"{self._gateway_id}_connectivity"
+
+    @property
+    def available(self) -> bool:
+        """Always available.
+
+        A connectivity sensor that went unavailable when the gateway dropped
+        would be useless — it must stay available to report ``off`` (offline).
+        """
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while the gateway WebSocket is connected."""
+        return self.coordinator.ws_connected
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the synthetic gateway (hub) device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._gateway_id)},
+            name="JUNG HOME Gateway",
+            manufacturer="Jung",
+            model="Gateway",
+            sw_version=self.coordinator.gateway_version,
+        )

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -1,8 +1,13 @@
 """Constants and firmware-stable identity helpers for Jung Home."""
 
+from typing import TYPE_CHECKING
+
 from homeassistant.util import slugify
 
 from .models import Datapoint, Device
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
 
 DOMAIN = "junghome"
 
@@ -47,6 +52,21 @@ def is_presence_quantity(label: str | None) -> bool:
         return False
     text = label.strip().lower()
     return any(keyword in text for keyword in _PRESENCE_LABEL_KEYWORDS)
+
+
+def gateway_device_id(entry: "ConfigEntry") -> str:
+    """Return the stable identifier for the synthetic gateway (hub) device.
+
+    The gateway itself is not one of the gateway's *functions*, so it has no
+    device slug from the device list. Give it a fixed, per-entry identifier so
+    gateway-level entities (e.g. the connectivity sensor) can share one hub
+    device. Anchored on the entry's ``unique_id`` (the host/mDNS hostname, which
+    survives reconfigure) and falling back to the entry id.
+
+    The ``gateway_`` prefix is what ``__init__._prune_stale_devices`` keys off to
+    avoid pruning this device (it never appears in the gateway's device list).
+    """
+    return f"gateway_{entry.unique_id or entry.entry_id}"
 
 
 def datapoint_value(datapoint: Datapoint | None, key: str) -> str | None:

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -349,6 +349,10 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             finally:
                 self.websocket = None
                 self.ws_connected = False
+                # Notify listeners so the gateway connectivity sensor flips to
+                # "off" immediately on a drop, rather than lagging until the next
+                # REST poll (the reconnect path already refreshes on connect).
+                self.async_update_listeners()
 
     def _log_ws_frame(self, raw: str) -> None:
         """Record a raw WebSocket frame for diagnostics.

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -93,6 +93,9 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "gateway_connectivity": { "name": "Gateway connection" }
+    },
     "climate": {
       "thermostat": {
         "state_attributes": {

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -93,6 +93,9 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "gateway_connectivity": { "name": "Gateway connection" }
+    },
     "climate": {
       "thermostat": {
         "state_attributes": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2227,3 +2227,49 @@ async def test_device_area_self_heals_when_groups_arrive_later(
 
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
+
+
+async def test_gateway_connectivity_sensor(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The gateway connectivity sensor is on while the WebSocket is connected."""
+    coordinator = init_integration.runtime_data
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "gateway_1.2.3.4_connectivity"
+    )
+    assert entity_id is not None
+    # The real _run_websocket refreshes the coordinator right after connecting
+    # (the test's fake socket only parks), so drive one update to mirror that.
+    assert coordinator.ws_connected is True
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+    assert state.attributes["device_class"] == "connectivity"
+
+
+async def test_gateway_connectivity_reflects_disconnect(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """On a WebSocket drop the sensor reads off but stays available."""
+    coordinator = init_integration.runtime_data
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "gateway_1.2.3.4_connectivity"
+    )
+    coordinator.ws_connected = False
+    # REST poll still succeeds, so the entity must not go unavailable — it must
+    # report the disconnect as "off".
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == "off"
+
+
+async def test_gateway_device_not_pruned(hass: HomeAssistant, init_integration) -> None:
+    """The synthetic gateway device survives the stale-device prune."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "gateway_1.2.3.4")})
+    assert device is not None
+    assert device.name == "JUNG HOME Gateway"


### PR DESCRIPTION
Expose whether the gateway's live WebSocket link is up as a hub-level diagnostic binary_sensor (device_class connectivity). It is attached to a new synthetic "JUNG HOME Gateway" device so gateway-level entities have a home of their own, and it stays available even when the gateway drops — a connectivity sensor that went unavailable on disconnect would be useless.

- const.py: gateway_device_id() helper for the synthetic hub device id.
- binary_sensor.py: JungHomeGatewayConnectivity, added once per entry.
- coordinator.py: notify listeners on WebSocket drop so the sensor flips to off promptly instead of lagging until the next REST poll.
- __init__.py: keep the gateway device out of the stale-device prune.
- strings.json / translations/en.json: entity name.