### PR TITLE
Give awnings the awning cover device class

### DIFF
--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -118,12 +118,11 @@ async def async_setup_entry(
 
 
 class JungHomeCover(JungHomeEntity, CoverEntity):
-    """Representation of a Jung Home cover (blind / shutter)."""
+    """Representation of a Jung Home cover (blind / shutter / awning)."""
 
     # The cover is the device's main feature, so it adopts the device name
     # (entity_id `cover.<device>`).
     _attr_name = None
-    _attr_device_class = CoverDeviceClass.BLIND
 
     def __init__(
         self,
@@ -139,6 +138,15 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
         self._level_datapoint_id = level_datapoint["id"]
         # Awning-style cover whose level is reported percent-open, not -closed.
         self._inverted = inverted
+        # An inverted cover is, by the gateway's own reasoning (see the module
+        # docstring), a Markise/awning: the motor's "extended" is what the user
+        # calls open. Reflect that in the device class so the UI shows an awning
+        # icon and the correct open/close semantics; every other cover stays a
+        # blind. (This is the same per-device flag users already set for the
+        # position inversion, so no extra configuration is introduced.)
+        self._attr_device_class = (
+            CoverDeviceClass.AWNING if inverted else CoverDeviceClass.BLIND
+        )
         self._angle_datapoint = next(
             (dp for dp in device.get("datapoints", []) if dp.get("type") == "angle"),
             None,

--- a/custom_components/junghome/quality_scale.yaml
+++ b/custom_components/junghome/quality_scale.yaml
@@ -28,9 +28,7 @@ rules:
     status: exempt
     comment: The integration registers no service actions.
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: exempt
-    comment: The integration has no options to configure.
+  docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.components.cover import CoverEntityFeature
+from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -1220,10 +1220,21 @@ async def test_cover_inverted_awning_position(hass: HomeAssistant) -> None:
     retracted = _awning("0")
     assert retracted.current_cover_position == 0
     assert retracted.is_closed is True
+    # An inverted cover is treated as an awning, not a blind (see cover.py).
+    assert retracted.device_class == CoverDeviceClass.AWNING
 
     extended = _awning("100")
     assert extended.current_cover_position == 100
     assert extended.is_closed is False
+
+
+async def test_cover_normal_device_class_is_blind(hass: HomeAssistant) -> None:
+    """A non-inverted cover keeps the blind device class."""
+    coordinator = _bare_coordinator(hass)
+    dps = [{"id": "b-1", "type": "level", "values": [{"key": "level", "value": "0"}]}]
+    device = {"id": "b", "type": "Position", "label": "Shutter", "datapoints": dps}
+    cover = JungHomeCover(coordinator, device, dps[0])
+    assert cover.device_class == CoverDeviceClass.BLIND
 
 
 async def test_cover_inverted_commands_pass_through(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Inverted covers are, by the integration's own reasoning, Markise/awnings: the motor's "extended" is what the user calls open, which is exactly why their position is read straight through instead of inverted. Reflect that in the cover device class (AWNING for inverted covers, BLIND otherwise) so the UI shows the correct icon and open/close semantics. This reuses the existing per-cover inverted flag, so no new configuration is introduced.

Also correct the quality_scale docs-configuration-parameters entry: it was marked exempt with "no options to configure", but the integration does have the inverted-covers option (documented in the README), so it is now "done".