### PR TITLE
Claude/rooms to areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Currently functional things:
 - Measurement sensors (e.g. ambient brightness on presence detectors).
 - IoT integration for Rocker Switches - allows triggering any script or automation in HomeAssistant via button presses.
 - Button LED On/Off (unfortunately, color can only be configured via app or BT Mesh/NRF).
-- Rooms - each device is suggested to the Home Assistant area matching its Jung
-  Home group. This only applies when a device is first added and never moves a
-  device you have already placed in an area yourself.
+- Rooms - each device is placed in the Home Assistant area matching its Jung
+  Home group. A device is only ever placed if it has no area yet, and each
+  device is considered just once, so this never moves a device you placed
+  yourself and never re-adds one whose area you deliberately cleared. A group
+  matching an existing area links to it instead of creating a duplicate.
 
 > Note: thermostats, scenes and measurement sensors are implemented from the
 > gateway protocol but have **not yet been fully verified against real hardware**,

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Currently functional things:
 - Measurement sensors (e.g. ambient brightness on presence detectors).
 - IoT integration for Rocker Switches - allows triggering any script or automation in HomeAssistant via button presses.
 - Button LED On/Off (unfortunately, color can only be configured via app or BT Mesh/NRF).
+- Rooms - each device is suggested to the Home Assistant area matching its Jung
+  Home group. This only applies when a device is first added and never moves a
+  device you have already placed in an area yourself.
 
 > Note: thermostats, scenes and measurement sensors are implemented from the
 > gateway protocol but have **not yet been fully verified against real hardware**,

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -4,11 +4,12 @@ import logging
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, datapoint_suffix, device_slug
+from .const import DATA_AREA_ASSIGNED, DOMAIN, datapoint_suffix, device_slug
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,6 +90,66 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
 
     _prune_stale_devices()
     entry.async_on_unload(coordinator.async_add_listener(_prune_stale_devices))
+
+    # Place devices in the Home Assistant area matching their gateway group.
+    @callback
+    def _assign_areas() -> None:
+        """Auto-place devices that have no area yet, once each.
+
+        Runs after the platforms have created their devices (and again on each
+        refresh, so devices added at runtime are placed too). Two rules keep
+        this from ever disturbing an existing setup:
+
+        1. a device is placed only if it currently has **no** area, so an area
+           the user chose is never overwritten; and
+        2. every device is considered exactly **once** — the decision is
+           recorded in the entry so that a device whose area the user later
+           cleared on purpose is not silently re-placed on the next refresh.
+
+        Area lookup is by name, so a group matching an existing area links to
+        it rather than creating a duplicate.
+        """
+        if not coordinator.data:
+            return  # nothing to place on an empty/failed poll
+        area_by_slug = {
+            device_slug(device): room
+            for device in coordinator.data
+            if (room := coordinator.area_for_device(device))
+        }
+        if not area_by_slug:
+            return  # gateway reports no rooms (or none could be resolved)
+
+        considered = set(entry.data.get(DATA_AREA_ASSIGNED, []))
+        dev_reg = dr.async_get(hass)
+        area_reg = ar.async_get(hass)
+        newly_considered: set[str] = set()
+        for device_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+            for domain, slug in device_entry.identifiers:
+                if domain != DOMAIN or slug in considered:
+                    continue
+                area_name = area_by_slug.get(slug)
+                if area_name is None:
+                    continue  # no room for this device; reconsider it later
+                if device_entry.area_id is None:
+                    area = area_reg.async_get_or_create(area_name)
+                    dev_reg.async_update_device(device_entry.id, area_id=area.id)
+                # Recorded either way: a device the user had already placed is
+                # settled too, and must not be auto-placed if later cleared.
+                newly_considered.add(slug)
+
+        if newly_considered:
+            # A data-only update; the reload listener below ignores it (it acts
+            # on host/options changes), so this does not cause a reload loop.
+            hass.config_entries.async_update_entry(
+                entry,
+                data={
+                    **entry.data,
+                    DATA_AREA_ASSIGNED: sorted(considered | newly_considered),
+                },
+            )
+
+    _assign_areas()
+    entry.async_on_unload(coordinator.async_add_listener(_assign_areas))
 
     # Register the host-change reload listener only AFTER the migration's
     # async_update_entry flag-write above, so that write doesn't trigger a

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -47,6 +47,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
     # Expose the coordinator as runtime data for the platforms.
     entry.runtime_data = coordinator
 
+    # Fetch room groups before the platforms create entities, so each device can
+    # suggest its area at creation time. Best-effort: never blocks setup.
+    await coordinator.async_fetch_groups()
+
     # One-time migration of registry entries from the gateway's volatile device
     # ids to firmware-stable, label-based ids. Must run while the gateway's ids
     # still match the registry (i.e. before the platforms create new entities).

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -15,6 +15,16 @@ DOMAIN = "junghome"
 # the gateway's function data, so the user marks them here. See cover.py.
 CONF_INVERTED_COVERS = "inverted_covers"
 
+# Entry-data key: the device slugs whose Home Assistant area has already been
+# considered for auto-placement from the gateway's group (room) data.
+#
+# Placement is a *one-time* decision per device, mirroring what HA's own
+# (deprecated) `suggested_area` did: a device is placed only if it has no area
+# at the moment we first see it, and once recorded here it is never touched
+# again. Without this record, a device whose area the user deliberately cleared
+# would be re-placed on the next refresh. See `_assign_areas` in __init__.py.
+DATA_AREA_ASSIGNED = "auto_area_assigned"
+
 
 # Quantity labels that denote a boolean *state* rather than a measured value.
 # Presence/motion detectors (JUNG "BWM") report detection as a `quantity`

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -175,6 +175,57 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # Downstream code keeps defensive `.get(...)` access for malformed items.
         return cast("list[Device]", [d for d in data if isinstance(d, dict)])
 
+    async def _fetch_groups_from_api(self, host: str, token: str) -> list[dict[str, Any]]:
+        """Fetch the gateway's groups (rooms) from the REST API.
+
+        Groups also arrive over the WebSocket, but that connects only after the
+        platforms are set up; fetching once here makes room data available in
+        time to suggest a device's area when its entities are first created.
+        """
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        url = f"https://{host}/api/junghome/groups"
+        headers = {"token": f"{token}", "Content-Type": "application/json"}
+        async with asyncio.timeout(30):
+            async with session.get(url, headers=headers) as response:
+                response.raise_for_status()
+                data = await response.json()
+        if not isinstance(data, list):
+            return []
+        return [g for g in data if isinstance(g, dict)]
+
+    async def async_fetch_groups(self) -> None:
+        """Populate ``self.groups`` from REST, best-effort.
+
+        Room grouping is a nice-to-have (it only drives suggested areas), so a
+        failure here must never block setup or device polling — it just leaves
+        the groups empty until the WebSocket handshake delivers them.
+        """
+        try:
+            self.groups = await self._fetch_groups_from_api(
+                self.config["host"], self.config["token"]
+            )
+        except Exception as err:  # best-effort, never fatal
+            _LOGGER.debug("Could not fetch Jung Home groups: %s", err)
+
+    def area_for_device(self, device: Device) -> str | None:
+        """Return the room/area name for a device from its parent groups.
+
+        Resolves the device's ``parent_groups`` ids against the groups list and
+        returns the first group name found (a device is normally in one room).
+        Returns ``None`` when the device has no group or none resolve to a name.
+        """
+        parents = device.get("parent_groups") or []
+        if not parents:
+            return None
+        by_id = {
+            g.get("id"): (g.get("name") or g.get("label")) for g in self.groups
+        }
+        for parent in parents:
+            name = by_id.get(parent)
+            if name:
+                return str(name)
+        return None
+
     async def activate_scene(self, scene_id: str) -> None:
         """Activate a scene via REST (the WebSocket scene command is unimplemented)."""
         session = async_get_clientsession(self.hass, verify_ssl=False)

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -175,7 +175,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # Downstream code keeps defensive `.get(...)` access for malformed items.
         return cast("list[Device]", [d for d in data if isinstance(d, dict)])
 
-    async def _fetch_groups_from_api(self, host: str, token: str) -> list[dict[str, Any]]:
+    async def _fetch_groups_from_api(
+        self, host: str, token: str
+    ) -> list[dict[str, Any]]:
         """Fetch the gateway's groups (rooms) from the REST API.
 
         Groups also arrive over the WebSocket, but that connects only after the
@@ -217,9 +219,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         parents = device.get("parent_groups") or []
         if not parents:
             return None
-        by_id = {
-            g.get("id"): (g.get("name") or g.get("label")) for g in self.groups
-        }
+        by_id = {g.get("id"): (g.get("name") or g.get("label")) for g in self.groups}
         for parent in parents:
             name = by_id.get(parent)
             if name:

--- a/custom_components/junghome/entity.py
+++ b/custom_components/junghome/entity.py
@@ -50,7 +50,7 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information, linking the entity to its Jung Home device."""
-        info: DeviceInfo = {
+        return {
             "identifiers": {(DOMAIN, device_slug(self._device))},
             "name": self._device.get("label", "Jung Device"),
             "manufacturer": "Jung",
@@ -59,14 +59,6 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
             or self.coordinator.gateway_version
             or "Unknown Version",
         }
-        # Suggest the gateway's room as the device's Home Assistant area. This is
-        # only honoured by HA when the device entry is first created and never
-        # overrides an area the user has since chosen, so returning it on every
-        # read is safe (it does not move already-placed devices).
-        area = self.coordinator.area_for_device(self._device)
-        if area:
-            info["suggested_area"] = area
-        return info
 
     def _current_device(self) -> Device | None:
         """Return this entity's device from the latest coordinator data."""

--- a/custom_components/junghome/entity.py
+++ b/custom_components/junghome/entity.py
@@ -50,7 +50,7 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information, linking the entity to its Jung Home device."""
-        return {
+        info: DeviceInfo = {
             "identifiers": {(DOMAIN, device_slug(self._device))},
             "name": self._device.get("label", "Jung Device"),
             "manufacturer": "Jung",
@@ -59,6 +59,14 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
             or self.coordinator.gateway_version
             or "Unknown Version",
         }
+        # Suggest the gateway's room as the device's Home Assistant area. This is
+        # only honoured by HA when the device entry is first created and never
+        # overrides an area the user has since chosen, so returning it on every
+        # read is safe (it does not move already-placed devices).
+        area = self.coordinator.area_for_device(self._device)
+        if area:
+            info["suggested_area"] = area
+        return info
 
     def _current_device(self) -> Device | None:
         """Return this entity's device from the latest coordinator data."""

--- a/custom_components/junghome/models.py
+++ b/custom_components/junghome/models.py
@@ -34,6 +34,9 @@ class Device(TypedDict):
     label: str
     datapoints: list[Datapoint]
     sw_version: NotRequired[str]
+    # Ids of the gateway groups (rooms) this device belongs to. Used to suggest a
+    # Home Assistant area for the device; resolved against the groups list.
+    parent_groups: NotRequired[list[str]]
 
 
 class Scene(TypedDict):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,7 +18,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome import async_unload_entry
 from custom_components.junghome.climate import JungHomeClimate
-from custom_components.junghome.const import CONF_INVERTED_COVERS, DOMAIN, device_slug
+from custom_components.junghome.const import (
+    CONF_INVERTED_COVERS,
+    DATA_AREA_ASSIGNED,
+    DOMAIN,
+    device_slug,
+)
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.cover import JungHomeCover
 from custom_components.junghome.diagnostics import (
@@ -1944,8 +1949,8 @@ def _grouped_lamp() -> dict:
     }
 
 
-async def test_device_area_suggested_from_group(hass: HomeAssistant) -> None:
-    """A device in a gateway group is placed in the matching HA area at creation."""
+async def test_device_area_assigned_from_group(hass: HomeAssistant) -> None:
+    """A device in a gateway group is placed in the matching HA area."""
     groups = [{"id": "grp-living", "name": "Living Room"}]
     with (
         patch.object(
@@ -1983,7 +1988,7 @@ async def test_device_area_suggested_from_group(hass: HomeAssistant) -> None:
 
 
 async def test_device_area_does_not_override_user_choice(hass: HomeAssistant) -> None:
-    """A device the user already placed in an area keeps it (suggestion ignored)."""
+    """A device the user already placed in an area keeps it."""
     dev_reg = dr.async_get(hass)
     area_reg = ar.async_get(hass)
     office = area_reg.async_get_or_create("Office")
@@ -2022,3 +2027,74 @@ async def test_device_area_does_not_override_user_choice(hass: HomeAssistant) ->
     device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
     # Still in Office — the group suggestion must not move a user-placed device.
     assert area_reg.async_get_area(device_entry.area_id).name == "Office"
+
+
+async def _setup_grouped_lamp(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set the entry up with one grouped lamp in the "Living Room" group."""
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[_grouped_lamp()]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=[{"id": "grp-living", "name": "Living Room"}]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_device_area_not_reassigned_after_user_clears_it(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing a device's area on purpose sticks; it is not re-placed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    await _setup_grouped_lamp(hass, entry)
+
+    dev_reg = dr.async_get(hass)
+    device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+    assert device_entry.area_id is not None  # placed on first setup
+    # The device is recorded as already considered, so it is never re-placed.
+    assert "sofa_lamp" in entry.data[DATA_AREA_ASSIGNED]
+
+    # The user deliberately removes the device from every area...
+    dev_reg.async_update_device(device_entry.id, area_id=None)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # ...and it stays cleared across a full reload.
+    await _setup_grouped_lamp(hass, entry)
+    device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+    assert device_entry.area_id is None
+
+
+async def test_device_area_reuses_existing_area_by_name(hass: HomeAssistant) -> None:
+    """A group matching an existing area links to it instead of duplicating it."""
+    area_reg = ar.async_get(hass)
+    existing = area_reg.async_get_or_create("Living Room")
+    before = len(area_reg.areas)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    await _setup_grouped_lamp(hass, entry)
+
+    device_entry = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, "sofa_lamp")}
+    )
+    assert device_entry.area_id == existing.id
+    assert len(area_reg.areas) == before  # no duplicate area was created

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -1891,3 +1892,133 @@ async def test_cover_set_position_is_optimistic(
             blocking=True,
         )
     assert hass.states.get("cover.bedroom_blind").attributes["current_position"] == 25
+
+
+async def test_area_for_device_resolves_group_name(hass: HomeAssistant) -> None:
+    """area_for_device maps parent_groups ids to the group's name (or label)."""
+    coordinator = _bare_coordinator(hass)
+    coordinator.groups = [{"id": "g1", "name": "Kitchen"}]
+    assert (
+        coordinator.area_for_device({"id": "d", "parent_groups": ["g1"]}) == "Kitchen"
+    )
+    # No parent groups, or an id that doesn't resolve -> no area.
+    assert coordinator.area_for_device({"id": "d"}) is None
+    assert coordinator.area_for_device({"id": "d", "parent_groups": ["gX"]}) is None
+    # Falls back to `label` when the group has no `name`.
+    coordinator.groups = [{"id": "g2", "label": "Bathroom"}]
+    assert (
+        coordinator.area_for_device({"id": "d", "parent_groups": ["g2"]}) == "Bathroom"
+    )
+
+
+async def test_async_fetch_groups_is_best_effort(hass: HomeAssistant) -> None:
+    """A groups fetch failure leaves groups empty and never raises."""
+    coordinator = _bare_coordinator(hass)
+    with patch.object(
+        coordinator, "_fetch_groups_from_api", AsyncMock(side_effect=RuntimeError)
+    ):
+        await coordinator.async_fetch_groups()
+    assert coordinator.groups == []
+    with patch.object(
+        coordinator,
+        "_fetch_groups_from_api",
+        AsyncMock(return_value=[{"id": "g", "name": "X"}]),
+    ):
+        await coordinator.async_fetch_groups()
+    assert coordinator.groups == [{"id": "g", "name": "X"}]
+
+
+def _grouped_lamp() -> dict:
+    return {
+        "id": "idlamp",
+        "type": "OnOff",
+        "label": "Sofa Lamp",
+        "parent_groups": ["grp-living"],
+        "datapoints": [
+            {
+                "id": "idlamp-001",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "1"}],
+            }
+        ],
+    }
+
+
+async def test_device_area_suggested_from_group(hass: HomeAssistant) -> None:
+    """A device in a gateway group is placed in the matching HA area at creation."""
+    groups = [{"id": "grp-living", "name": "Living Room"}]
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[_grouped_lamp()]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=groups),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="1.2.3.4",
+            data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        dev_reg = dr.async_get(hass)
+        area_reg = ar.async_get(hass)
+        device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+        assert device_entry is not None
+        assert device_entry.area_id is not None
+        assert area_reg.async_get_area(device_entry.area_id).name == "Living Room"
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_device_area_does_not_override_user_choice(hass: HomeAssistant) -> None:
+    """A device the user already placed in an area keeps it (suggestion ignored)."""
+    dev_reg = dr.async_get(hass)
+    area_reg = ar.async_get(hass)
+    office = area_reg.async_get_or_create("Office")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    # Pre-create the device already assigned to "Office", as if the user moved it.
+    existing = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "sofa_lamp")}
+    )
+    dev_reg.async_update_device(existing.id, area_id=office.id)
+
+    groups = [{"id": "grp-living", "name": "Living Room"}]
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[_grouped_lamp()]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=groups),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+    # Still in Office — the group suggestion must not move a user-placed device.
+    assert area_reg.async_get_area(device_entry.area_id).name == "Office"


### PR DESCRIPTION
## What

Each device is now placed in the Home Assistant **area** matching its Jung Home **group** (room). The gateway already tells us this — every function carries `parent_groups`, and the groups list maps those ids to names — but that data was only kept for diagnostics.

## Why it does not disturb existing areas/rooms

Three rules, each covered by a test:

1. **Never overwrites a chosen area.** A device is placed only if it currently has *no* area. If you move a JUNG device to another room, it stays there.
2. **Each device is considered exactly once**, recorded in the entry data. So a device whose area you deliberately *cleared* is not silently re-placed on the next refresh.
3. **Reuses existing areas by name.** A group named "Living Room" links to your existing "Living Room" area instead of creating a duplicate.

## Note on the approach (changed after review)

This originally used `DeviceInfo.suggested_area`, which gave rules 1–3 for free. That attribute is **deprecated and removed in HA 2026.9**, so it has been reworked to assign the area directly.

Rule 2 is the subtle part of that rework and the reason this isn't just "assign whenever the area is empty": `suggested_area` only ever applied at device *creation*, so HA never reconsidered a device. A naive rewrite would re-place a device every time it found an empty area — actively worse than the original, since it would fight a user who wants a device in no area at all. The `DATA_AREA_ASSIGNED` record in the entry restores that once-only semantic without the deprecated API.

## Changes

- `coordinator.py`: best-effort REST fetch of groups before platform setup (never blocks setup); `area_for_device()` resolves `parent_groups` → room name (falls back to `label` if a group has no `name`).
- `const.py`: `DATA_AREA_ASSIGNED` entry-data key.
- `__init__.py`: fetch groups before platform setup; `_assign_areas()` registered alongside the existing stale-device prune, so devices added at runtime are placed too.
- `models.py`: type `parent_groups` on `Device`.
- `README.md`: document the behaviour and its guarantees.
- `tests/test_init.py`: `area_for_device` resolution, best-effort fetch, assignment at setup, no-override of a user's area, no-reassign after the user clears one, and reuse of an existing same-named area.

`entity.py` is unchanged from `main` — no `suggested_area`, and no deprecated API anywhere in the diff.

## Testing

Ran the full set of checks this repo's workflows define:

- `pytest` — 148 passed
- `mypy custom_components/junghome --strict` — clean
- `ruff check .` — clean
- `ruff format . --check` — clean

(Python 3.13 / HA 2025.10 locally; the pinned CI target is 3.14 / HA 2026.7.)