### PR TITLE
Claude/register by password

### DIFF
--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -171,9 +171,16 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     return await self.async_step_register()
 
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors
-        )
+        # Re-shown after an error (e.g. a rejected password): keep the host the
+        # user already typed rather than making them enter it again. The password
+        # is deliberately not suggested back — it is a credential, and the retry
+        # is usually *because* it was wrong.
+        schema = STEP_USER_SCHEMA
+        if user_input is not None:
+            schema = self.add_suggested_values_to_schema(
+                STEP_USER_SCHEMA, {CONF_HOST: user_input.get(CONF_HOST)}
+            )
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     async def async_step_register(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -9,7 +9,7 @@ import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TOKEN
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -26,7 +26,20 @@ _LOGGER = logging.getLogger(__name__)
 REGISTER_TIMEOUT = 190
 REGISTER_USER_NAME = "Home Assistant"
 
+# Host-only schema, reused by the reconfigure step.
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+
+# The user step also offers an optional password: supplying the gateway's
+# network-key password registers instantly via /register/by-password instead of
+# waiting for in-app approval.
+STEP_USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Optional(CONF_PASSWORD): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
+    }
+)
 
 
 class CannotRegister(Exception):
@@ -145,10 +158,21 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.context["title_placeholders"] = {"host": self._host}
                 await self.async_set_unique_id(self._host)
                 self._abort_if_unique_id_configured()
-                return await self.async_step_register()
+                password = user_input.get(CONF_PASSWORD)
+                if password:
+                    # Instant path: exchange the network-key password for a token
+                    # right away instead of waiting for in-app approval.
+                    try:
+                        self._token = await self._async_register_by_password(password)
+                    except CannotRegister:
+                        errors["base"] = self._error
+                    else:
+                        return await self.async_step_finish()
+                else:
+                    return await self.async_step_register()
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user", data_schema=STEP_USER_SCHEMA, errors=errors
         )
 
     async def async_step_register(
@@ -331,6 +355,39 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             async with session.post(
                 url, json={"user_name": REGISTER_USER_NAME}, timeout=timeout
             ) as response:
+                if response.status != 200:
+                    self._error = "register_failed"
+                    raise CannotRegister(f"HTTP {response.status}")
+                data = await response.json()
+        except (TimeoutError, aiohttp.ClientError) as err:
+            self._error = "cannot_connect"
+            raise CannotRegister(str(err)) from err
+
+        token = data.get("token") if isinstance(data, dict) else None
+        if not token:
+            self._error = "register_failed"
+            raise CannotRegister("No token in response")
+        return str(token)
+
+    async def _async_register_by_password(self, password: str) -> str:
+        """Exchange the gateway's network-key password for a token immediately.
+
+        Unlike ``_async_register`` this does not block on in-app approval: the
+        gateway's ``register/by-password`` endpoint returns a token right away,
+        or ``401`` if the password is wrong.
+        """
+        # Shared HA session; verify_ssl=False tolerates the gateway's self-signed
+        # cert without building an SSL context on the event loop.
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        url = f"https://{self._host}/api/junghome/register/by-password"
+        try:
+            async with (
+                asyncio.timeout(30),
+                session.post(url, json={"password": password}) as response,
+            ):
+                if response.status == 401:
+                    self._error = "invalid_auth"
+                    raise CannotRegister("Wrong password")
                 if response.status != 200:
                     self._error = "register_failed"
                     raise CannotRegister(f"HTTP {response.status}")

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -8,12 +8,14 @@
       },
       "user": {
         "title": "Connect to Jung Home",
-        "description": "Enter the address of your Jung Home gateway. After you continue, approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests.",
+        "description": "Enter the address of your Jung Home gateway. Leave the password empty to approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests. Alternatively, enter the gateway network-key password to connect immediately.",
         "data": {
-          "host": "Host"
+          "host": "Host",
+          "password": "Network-key password (optional)"
         },
         "data_description": {
-          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local)."
+          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local).",
+          "password": "The Jung Home gateway network-key password. Leave empty to approve the request in the app instead."
         }
       },
       "register_failed": {
@@ -45,6 +47,7 @@
     "error": {
       "invalid_host": "The host is not valid.",
       "cannot_connect": "Failed to connect to the gateway.",
+      "invalid_auth": "The gateway rejected the network-key password.",
       "register_failed": "Registration was not completed. Make sure you approve the request in the app."
     },
     "abort": {

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -8,12 +8,14 @@
       },
       "user": {
         "title": "Connect to Jung Home",
-        "description": "Enter the address of your Jung Home gateway. After you continue, approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests.",
+        "description": "Enter the address of your Jung Home gateway. Leave the password empty to approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests. Alternatively, enter the gateway network-key password to connect immediately.",
         "data": {
-          "host": "Host"
+          "host": "Host",
+          "password": "Network-key password (optional)"
         },
         "data_description": {
-          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local)."
+          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local).",
+          "password": "The Jung Home gateway network-key password. Leave empty to approve the request in the app instead."
         }
       },
       "register_failed": {
@@ -45,6 +47,7 @@
     "error": {
       "invalid_host": "The host is not valid.",
       "cannot_connect": "Failed to connect to the gateway.",
+      "invalid_auth": "The gateway rejected the network-key password.",
       "register_failed": "Registration was not completed. Make sure you approve the request in the app."
     },
     "abort": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -326,6 +326,10 @@ async def test_user_flow_password_rejected(hass: HomeAssistant) -> None:
         )
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
+    # The host the user already typed is kept so they don't retype it on retry;
+    # the password is not suggested back (it's a credential, and it was wrong).
+    host_key = next(k for k in result["data_schema"].schema if k == CONF_HOST)
+    assert host_key.description == {"suggested_value": "1.2.3.4"}
 
 
 async def test_async_register_by_password_returns_token(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -289,6 +289,64 @@ async def test_async_register_connection_error(
     assert flow._error == "cannot_connect"
 
 
+_REGISTER_PW = (
+    "custom_components.junghome.config_flow."
+    "JungHomeConfigFlow._async_register_by_password"
+)
+
+
+async def test_user_flow_password_success(hass: HomeAssistant) -> None:
+    """Supplying a password registers instantly (no waiting-for-approval step)."""
+    fetch, run_ws = _no_network()
+    with patch(_REGISTER_PW, AsyncMock(return_value="pw-tok")), fetch, run_ws:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", "password": "secret"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_TOKEN: "pw-tok"}
+        await hass.async_block_till_done()
+
+
+async def test_user_flow_password_rejected(hass: HomeAssistant) -> None:
+    """A wrong password re-shows the form with the invalid_auth error."""
+
+    async def _reject(self, password):
+        self._error = "invalid_auth"
+        raise CannotRegister("Wrong password")
+
+    with patch(_REGISTER_PW, _reject):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", "password": "bad"}
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_async_register_by_password_returns_token(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    aioclient_mock.post(
+        "https://gw/api/junghome/register/by-password", json={"token": "abc"}
+    )
+    assert await _flow(hass)._async_register_by_password("pw") == "abc"
+
+
+async def test_async_register_by_password_wrong_password(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    aioclient_mock.post("https://gw/api/junghome/register/by-password", status=401)
+    flow = _flow(hass)
+    with pytest.raises(CannotRegister):
+        await flow._async_register_by_password("pw")
+    assert flow._error == "invalid_auth"
+
+
 async def test_reconfigure_invalid_host(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN, unique_id="1.2.3.4", data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"}


### PR DESCRIPTION
## What

Adds an **optional password field** to the setup step. Leave it empty for the existing app-approval flow; enter the gateway's network-key password to register **instantly** via `POST /register/by-password`.

## Why

The only registration path today is app approval, which blocks for up to ~180 s while the user approves the request in the Jung Home app. The gateway also supports instant, password-based registration (`docs/gateway-rest-api.md` §B) — this exposes it without changing the default flow.

## Changes

- `config_flow.py`:
  - optional `password` on the `user` step (host-only reconfigure schema is unchanged);
  - new `_async_register_by_password()` that exchanges the password for a token, mapping `401` → `invalid_auth`;
  - the re-shown form now suggests the **host back**, so a rejected password no longer forces the user to retype an address they already entered correctly. The password is deliberately *not* suggested back — it's a credential, and the retry is usually because it was wrong.
- `strings.json` / `translations/en.json`: password field label/description and the `invalid_auth` error.
- `tests/test_config_flow.py`: instant-success, wrong-password (form re-shown with `invalid_auth` **and** the host retained), and unit tests for the new method (token on 200, `invalid_auth` on 401).

## Notes

- Password path is scoped to initial setup; reauth/zeroconf keep the app-approval flow.
- The password is only used to obtain the token; it is never stored (only `host` + `token` are persisted, same as before).

## Testing

Ran the full set of checks this repo's workflows define:

- `pytest` — 146 passed
- `mypy custom_components/junghome --strict` — clean
- `ruff check .` — clean
- `ruff format . --check` — clean

(Python 3.13 / HA 2025.10 locally; the pinned CI target is 3.14 / HA 2026.7.)