### PR TITLE
Fix Lint: ignore ruff CPY001 (missing copyright notice)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -13,6 +13,7 @@ ignore = [
     "D213", # multi-line-summary-second-line (we summarise on the first line)
     "COM812", # incompatible with formatter
     "ISC001", # incompatible with formatter
+    "CPY001", # missing copyright notice (Home Assistant ignores this too)
 
     # Families this (largely pre-existing) codebase does not follow; relaxed so
     # CI lint is green without rewriting working code.


### PR DESCRIPTION
## Problem

The **Lint / Ruff** check is failing on `main` and every open PR (e.g. #100), all reporting:

```
CPY001 Missing copyright notice at top of file
... (24 files)
Found 24 errors.
```

## Root cause

`.ruff.toml` uses `select = ["ALL"]`. Ruff **0.16.0** (merged in #103, `00c0bf1`) stabilised the `flake8-copyright` (`CPY`) family, so `CPY001` became active under `ALL` and now flags every file. This is unrelated to the dependency bumps in the affected PRs — it broke the moment ruff 0.16.0 landed on main.

## Fix

Ignore `CPY001` in `.ruff.toml`. Home Assistant's own `pyproject.toml` — which this config is explicitly based on — ignores it too.

Verified locally with `ruff==0.16.0`:

- `ruff check .` → `All checks passed!`
- `ruff format . --check` → `36 files already formatted`

Once this merges, the renovate/dependabot PRs (including #100) just need a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)