### PR TITLE
Harden rooms-to-areas tests; fix setup-time network call under CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,13 @@ reconnects automatically with backoff. No cloud and no account are involved.
 
 # Known limitations
 
-- **Groups** defined in the JUNG app aren't exposed; use Home Assistant areas
-  instead. (Scenes *are* exposed — see [Scenes](#scenes).)
+- **Room → area placement is one-time per device.** Each device is placed in the
+  Home Assistant area matching its JUNG app group only the first time it's seen,
+  and never moved again. This is deliberate: it can't tell "the user moved this
+  in Home Assistant" from "the room changed in the app", so it never overrides
+  your choice — but it also means **re-grouping a device in the JUNG app later
+  won't move it** in Home Assistant. Move it yourself in HA if you need to.
+  (Scenes are exposed too — see [Scenes](#scenes).)
 - **Thermostats, scenes and measurement sensors are not yet fully verified
   against real hardware** — they're implemented from the gateway protocol but I
   don't own those devices. Feedback welcome. Cover position direction is

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -181,8 +181,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         """Fetch the gateway's groups (rooms) from the REST API.
 
         Groups also arrive over the WebSocket, but that connects only after the
-        platforms are set up; fetching once here makes room data available in
-        time to suggest a device's area when its entities are first created.
+        platforms are set up; fetching once here lets the first area-assignment
+        pass at the end of setup place devices straight away, instead of waiting
+        for the WebSocket handshake to deliver the groups a moment later.
         """
         session = async_get_clientsession(self.hass, verify_ssl=False)
         url = f"https://{host}/api/junghome/groups"
@@ -198,9 +199,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     async def async_fetch_groups(self) -> None:
         """Populate ``self.groups`` from REST, best-effort.
 
-        Room grouping is a nice-to-have (it only drives suggested areas), so a
-        failure here must never block setup or device polling — it just leaves
-        the groups empty until the WebSocket handshake delivers them.
+        Room grouping is a nice-to-have (it only drives placing a device in the
+        matching area), so a failure here must never block setup or device
+        polling — it just leaves the groups empty until the WebSocket handshake
+        delivers them, at which point the next refresh places any device that
+        was waiting on its room.
         """
         try:
             self.groups = await self._fetch_groups_from_api(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,46 @@
 """Shared fixtures for the Jung Home test suite."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
+
+from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "real_groups_fetch: let the test run the real _fetch_groups_from_api "
+        "(pair with aioclient_mock); by default it is stubbed to avoid a socket.",
+    )
 
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable loading the junghome custom integration in every test."""
     return
+
+
+@pytest.fixture(autouse=True)
+def mock_groups_fetch(request):
+    """Keep the setup-time REST groups fetch off the network.
+
+    ``async_setup_entry`` fetches the gateway's room groups over REST (see
+    ``async_fetch_groups``) before the platforms are set up. Entity/lifecycle
+    tests don't stub that call, so without this fixture they would open a real
+    socket, which the Home Assistant test harness rejects. Default it to an
+    empty list. Tests that assert on room -> area behaviour patch
+    ``_fetch_groups_from_api`` themselves (that inner patch wins inside its
+    ``with`` block), and the tests that cover the REST body opt out with
+    ``@pytest.mark.real_groups_fetch``.
+    """
+    if request.node.get_closest_marker("real_groups_fetch") is not None:
+        yield
+        return
+    with patch.object(
+        JungHomeDataUpdateCoordinator,
+        "_fetch_groups_from_api",
+        AsyncMock(return_value=[]),
+    ):
+        yield

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2109,3 +2109,121 @@ async def test_device_area_reuses_existing_area_by_name(hass: HomeAssistant) -> 
     )
     assert device_entry.area_id == existing.id
     assert len(area_reg.areas) == before  # no duplicate area was created
+
+
+def _ungrouped_lamp() -> dict:
+    """A lamp the gateway reports in no room (empty ``parent_groups``)."""
+    return {
+        "id": "idlamp2",
+        "type": "OnOff",
+        "label": "Hall Lamp",
+        "parent_groups": [],
+        "datapoints": [
+            {
+                "id": "idlamp2-001",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "1"}],
+            }
+        ],
+    }
+
+
+async def test_ungrouped_device_is_left_unplaced_and_reconsidered(
+    hass: HomeAssistant,
+) -> None:
+    """A device with no resolvable room is not placed, and stays reconsiderable.
+
+    It must not be recorded as considered: a room could still arrive later (over
+    the WebSocket), and only then should the device be placed.
+    """
+    groups = [{"id": "grp-living", "name": "Living Room"}]
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[_grouped_lamp(), _ungrouped_lamp()]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=groups),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="1.2.3.4",
+            data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        dev_reg = dr.async_get(hass)
+        grouped = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+        ungrouped = dev_reg.async_get_device(identifiers={(DOMAIN, "hall_lamp")})
+        assert grouped.area_id is not None  # placed in its room
+        assert ungrouped.area_id is None  # no room -> not placed
+
+        # The grouped device is settled; the ungrouped one is NOT recorded, so a
+        # room arriving later still gets a chance to place it.
+        assigned = entry.data[DATA_AREA_ASSIGNED]
+        assert "sofa_lamp" in assigned
+        assert "hall_lamp" not in assigned
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_device_area_self_heals_when_groups_arrive_later(
+    hass: HomeAssistant,
+) -> None:
+    """If the REST groups fetch yields nothing, a later WebSocket delivery of the
+    groups still places the device on the next refresh."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[_grouped_lamp()]),
+        ),
+        # The pre-setup REST groups fetch comes back empty (e.g. it failed).
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        dev_reg = dr.async_get(hass)
+        device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+        assert device_entry.area_id is None  # no rooms known yet -> not placed
+        assert "sofa_lamp" not in entry.data.get(DATA_AREA_ASSIGNED, [])
+
+        # The WebSocket handshake later delivers the groups; the next coordinator
+        # update runs the placement again and now resolves the room.
+        coordinator = entry.runtime_data
+        coordinator.groups = [{"id": "grp-living", "name": "Living Room"}]
+        coordinator.async_set_updated_data([_grouped_lamp()])
+        await hass.async_block_till_done()
+
+        device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+        assert device_entry.area_id is not None
+        area_reg = ar.async_get(hass)
+        assert area_reg.async_get_area(device_entry.area_id).name == "Living Room"
+        assert "sofa_lamp" in entry.data[DATA_AREA_ASSIGNED]
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -217,6 +217,28 @@ async def test_fetch_devices_from_api(hass: HomeAssistant, aioclient_mock) -> No
     assert data == [{"id": "x", "datapoints": []}]
 
 
+@pytest.mark.real_groups_fetch
+async def test_fetch_groups_from_api(hass: HomeAssistant, aioclient_mock) -> None:
+    aioclient_mock.get(
+        "https://gw/api/junghome/groups",
+        json=[{"id": "g1", "name": "Kitchen"}, "not-a-dict"],
+    )
+    coordinator = _coordinator(hass)
+    # Dict groups are kept; non-dict entries in the array are dropped.
+    data = await coordinator._fetch_groups_from_api("gw", "tok")
+    assert data == [{"id": "g1", "name": "Kitchen"}]
+
+
+@pytest.mark.real_groups_fetch
+async def test_fetch_groups_from_api_ignores_non_list(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    # A non-list response (e.g. an error object) yields no groups, never raises.
+    aioclient_mock.get("https://gw/api/junghome/groups", json={"error": "boom"})
+    coordinator = _coordinator(hass)
+    assert await coordinator._fetch_groups_from_api("gw", "tok") == []
+
+
 async def test_update_data_returns_empty_on_none(hass: HomeAssistant) -> None:
     coordinator = _coordinator(hass)
     with patch.object(


### PR DESCRIPTION
## What

Follow-up to #106 (rooms → areas). That PR shipped correct behaviour, but its tests fail on this repo's CI target and leave the new code paths partly uncovered. This restores green CI and brings the new code to full coverage — no production logic change.

## The problem #106 left on `main`

#106 added a REST groups fetch into `async_setup_entry` (`async_fetch_groups` → `_fetch_groups_from_api`). It's best-effort in production, but **44 existing setup tests don't stub it**, so under the pinned CI target (Python 3.14 / HA 2026.7.x) `pytest-socket` rejects the network attempt and reports those tests as **errors**. The author's older local stack (HA 2025.10 / py3.13) masked it, which is why #106 looked green locally but its `pytest` check failed on GitHub.

## Changes

- **`tests/conftest.py`** — autouse `mock_groups_fetch` fixture stubs the setup-time groups fetch to `[]` by default (the idiomatic HA approach), with a `real_groups_fetch` marker so the two tests that exercise the real REST body opt back in.
- **`tests/test_websocket.py`** — cover the real `_fetch_groups_from_api` (dict filtering + the non-list guard) via `aioclient_mock`, mirroring the existing `_fetch_devices_from_api` tests.
- **`tests/test_init.py`** — cover the two guarantees that carry the design: an **ungrouped device is left unplaced and *not* recorded** (so a room arriving later still places it), and the **self-heal path** where the WebSocket delivers groups after setup and the next refresh places the device.
- **`coordinator.py`** — correct two docstrings that still described the abandoned `suggested_area`-at-creation approach (no logic change).
- **`README.md`** — the Known-limitations list still said groups aren't exposed, which now contradicts the feature; document the real **one-time-placement** limitation instead.

## Verification (exact CI commands, HA 2026.7.4)

- `pytest` — **153 passed** (was 148 passed + 44 errors)
- coverage — **100%** on `__init__.py`, `coordinator.py`, `const.py`, `models.py`
- `mypy custom_components/junghome --strict` — clean
- `ruff check .` and `ruff format . --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)