### PR TITLE
Config flow: choose connection method (app approval vs network-key password)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,32 @@ Copy `custom_components/junghome/` into your Home Assistant `config/custom_compo
 
 # Setup
 
-Adding the integration is now a two-step, app-driven flow — you no longer need to
-fetch a token by hand:
+You no longer need to fetch a token by hand. In most cases the gateway is
+**discovered automatically** over mDNS and appears under
+**Settings → Devices & Services** as a discovered device — just click
+**Configure**. If it isn't discovered, go to **Add Integration → Jung Home** to
+start setup manually.
 
-1. In Home Assistant, go to **Settings → Devices & Services → Add Integration**
-   and pick **Jung Home**.
-2. Enter your gateway address — the IP (e.g. `192.168.1.50`) or `junghome.local`.
-3. Home Assistant requests access from the gateway and waits. Open the **Jung
-   Home mobile app** and approve the request under
-   **Settings → Gateway → Access Permissions → Open Requests**.
-4. Once you approve (within ~3 minutes), setup completes automatically and your
-   devices appear. If it times out, just submit again and re-approve.
+Either way you then pick **how to connect**:
 
-Behind the scenes this calls the gateway's `POST /api/junghome/register`
-endpoint; the issued token is stored in the config entry. Devices added or
-removed in the Jung Home app afterwards are picked up automatically.
+- **Approve the connection in the Jung Home app.** Home Assistant asks the
+  gateway for access and waits; open the **Jung Home app** and approve the
+  request under **Settings → Gateway → Access Permissions → Open Requests**.
+  Setup finishes automatically once you approve (within ~3 minutes) — if it times
+  out, submit again and re-approve. (Uses `POST /api/junghome/register`.)
+- **Enter the gateway network-key password.** Connects immediately, with no app
+  approval, by exchanging the gateway's network-key password for a token (uses
+  `POST /api/junghome/register/by-password`). You can find the password in the
+  Jung Home app.
+
+The gateway address is filled in for you when it was discovered; otherwise it
+defaults to `junghome.local` (which works on many networks) and you can change it
+to your gateway's IP (e.g. `192.168.1.50`) if that name doesn't resolve.
+
+The issued token is stored in the config entry. Devices added or removed in the
+Jung Home app afterwards are picked up automatically. If the gateway's IP later
+changes, discovery updates it automatically, or you can **Reconfigure** the entry
+to point at the new address.
 
 # Button automations (rocker switches)
 

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -26,19 +26,21 @@ _LOGGER = logging.getLogger(__name__)
 REGISTER_TIMEOUT = 190
 REGISTER_USER_NAME = "Home Assistant"
 
-# Host-only schema, reused by the reconfigure step.
-STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+# The gateway's generic mDNS hostname (also its TLS certificate CN). Offered as
+# the default host so most users need not look up the gateway's IP. It only
+# resolves if the network maps it; the reliable name is the per-device mDNS
+# hostname (junghome-<mac>.local) that discovery supplies, and an IP always works.
+MDNS_DEFAULT_HOST = "junghome.local"
 
-# The user step also offers an optional password: supplying the gateway's
-# network-key password registers instantly via /register/by-password instead of
-# waiting for in-app approval.
-STEP_USER_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): str,
-        vol.Optional(CONF_PASSWORD): selector.TextSelector(
-            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-        ),
-    }
+_PASSWORD_SELECTOR = selector.TextSelector(
+    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+)
+
+# Host-only schema, reused by the app-approval and reconfigure steps.
+STEP_HOST_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+# Host + network-key password, for instant setup.
+STEP_HOST_PASSWORD_SCHEMA = vol.Schema(
+    {vol.Required(CONF_HOST): str, vol.Required(CONF_PASSWORD): _PASSWORD_SELECTOR}
 )
 
 
@@ -143,44 +145,121 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._token: str | None = None
         self._error: str = "register_failed"
         self._register_task: asyncio.Task[str] | None = None
+        # True once the host is known from discovery, so the method steps skip
+        # asking for it again.
+        self._discovered: bool = False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Collect the gateway host, then start registration."""
+        """Let the user pick how to connect to the gateway.
+
+        Gateways are normally found automatically (mDNS) and shown on the
+        Integrations page. This menu is the manual fallback and offers the two
+        ways to obtain a token: approving the request in the app, or entering the
+        gateway's network-key password for an instant connection.
+        """
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["app_approval", "password"],
+        )
+
+    async def async_step_app_approval(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Connect by approving the access request in the Jung Home app.
+
+        Shows the host field (pre-filled with the discovered address when the
+        gateway was found automatically) so the user can confirm or edit it.
+        """
         errors: dict[str, str] = {}
         if user_input is not None:
-            self._host = _normalize_host(user_input[CONF_HOST])
-            if not self._host:
-                errors["base"] = "invalid_host"
-            else:
-                # Populate the {host} flow_title placeholder for later steps.
-                self.context["title_placeholders"] = {"host": self._host}
-                await self.async_set_unique_id(self._host)
-                self._abort_if_unique_id_configured()
-                password = user_input.get(CONF_PASSWORD)
-                if password:
-                    # Instant path: exchange the network-key password for a token
-                    # right away instead of waiting for in-app approval.
-                    try:
-                        self._token = await self._async_register_by_password(password)
-                    except CannotRegister:
-                        errors["base"] = self._error
-                    else:
-                        return await self.async_step_finish()
-                else:
-                    return await self.async_step_register()
+            error = await self._async_apply_host(user_input[CONF_HOST])
+            if error is None:
+                return await self.async_step_register()
+            errors["base"] = error
 
-        # Re-shown after an error (e.g. a rejected password): keep the host the
-        # user already typed rather than making them enter it again. The password
-        # is deliberately not suggested back — it is a credential, and the retry
-        # is usually *because* it was wrong.
-        schema = STEP_USER_SCHEMA
+        return self.async_show_form(
+            step_id="app_approval",
+            data_schema=self._host_schema(user_input),
+            errors=errors,
+        )
+
+    async def async_step_password(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Connect instantly using the gateway's network-key password.
+
+        Shows the host field (pre-filled with the discovered address when the
+        gateway was found automatically) alongside the password.
+        """
+        errors: dict[str, str] = {}
         if user_input is not None:
-            schema = self.add_suggested_values_to_schema(
-                STEP_USER_SCHEMA, {CONF_HOST: user_input.get(CONF_HOST)}
-            )
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+            error = await self._async_apply_host(user_input[CONF_HOST])
+            if error is not None:
+                errors["base"] = error
+            else:
+                try:
+                    self._token = await self._async_register_by_password(
+                        user_input[CONF_PASSWORD]
+                    )
+                except CannotRegister:
+                    errors["base"] = self._error
+                else:
+                    return await self.async_step_finish()
+
+        return self.async_show_form(
+            step_id="password",
+            data_schema=self._password_schema(user_input),
+            errors=errors,
+        )
+
+    async def _async_apply_host(self, raw_host: str) -> str | None:
+        """Normalise the host from a form and claim identity where needed.
+
+        Returns an error key to show, or None on success. A discovered gateway
+        already set its unique_id to the stable mDNS hostname during discovery, so
+        we keep that and only record the confirmed (or edited) host; a manually
+        entered host becomes the unique_id and aborts if already configured.
+        """
+        host = _normalize_host(raw_host)
+        if not host:
+            return "invalid_host"
+        self._host = host
+        # Populate the {host} flow_title placeholder for later steps.
+        self.context["title_placeholders"] = {"host": host}
+        if not self._discovered:
+            await self.async_set_unique_id(host)
+            self._abort_if_unique_id_configured()
+        return None
+
+    def _host_default(self, user_input: dict[str, Any] | None) -> str:
+        """Return the host to pre-fill: retyped value, else discovered, else mDNS.
+
+        Order: a value the user just typed (kept across a retry), then the
+        discovered address, then the generic mDNS default.
+        """
+        if user_input and user_input.get(CONF_HOST):
+            return str(user_input[CONF_HOST])
+        if self._discovered and self._host:
+            return self._host
+        return MDNS_DEFAULT_HOST
+
+    def _host_schema(self, user_input: dict[str, Any] | None) -> vol.Schema:
+        """Host-only form with the host pre-filled."""
+        return self.add_suggested_values_to_schema(
+            STEP_HOST_SCHEMA, {CONF_HOST: self._host_default(user_input)}
+        )
+
+    def _password_schema(self, user_input: dict[str, Any] | None) -> vol.Schema:
+        """Host + password form with the host pre-filled.
+
+        The password is never suggested back — it is a credential, and a retry is
+        usually *because* it was wrong.
+        """
+        return self.add_suggested_values_to_schema(
+            STEP_HOST_PASSWORD_SCHEMA, {CONF_HOST: self._host_default(user_input)}
+        )
 
     async def async_step_register(
         self, user_input: dict[str, Any] | None = None
@@ -313,7 +392,7 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, {CONF_HOST: entry.data.get(CONF_HOST)}
+                STEP_HOST_SCHEMA, {CONF_HOST: entry.data.get(CONF_HOST)}
             ),
             errors=errors,
         )
@@ -323,6 +402,7 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a gateway discovered via mDNS (_junghome._tcp)."""
         self._host = discovery_info.host
+        self._discovered = True
         hostname = (discovery_info.hostname or "").rstrip(".") or self._host
         # Stable per-gateway id; update the stored host if its IP changed.
         await self.async_set_unique_id(hostname)
@@ -339,13 +419,12 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Confirm setup of a discovered gateway, then register."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="zeroconf_confirm",
-                description_placeholders={"host": self._host or ""},
-            )
-        return await self.async_step_register()
+        """Let the user choose how to connect to the discovered gateway."""
+        return self.async_show_menu(
+            step_id="zeroconf_confirm",
+            menu_options=["app_approval", "password"],
+            description_placeholders={"host": self._host or ""},
+        )
 
     async def _async_register(self) -> str:
         """POST the registration request and return the issued token.

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -4,18 +4,40 @@
     "step": {
       "zeroconf_confirm": {
         "title": "Jung Home gateway discovered",
-        "description": "Set up the Jung Home gateway at {host}? After you continue, approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+        "description": "A Jung Home gateway was found at {host}. Choose how to connect.",
+        "menu_options": {
+          "app_approval": "Approve the connection in the Jung Home app",
+          "password": "Enter the gateway network-key password (connects instantly)"
+        }
       },
       "user": {
         "title": "Connect to Jung Home",
-        "description": "Enter the address of your Jung Home gateway. Leave the password empty to approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests. Alternatively, enter the gateway network-key password to connect immediately.",
+        "description": "Your gateway is usually found automatically and shown on the Integrations page. If it was not, choose how to connect below.",
+        "menu_options": {
+          "app_approval": "Approve the connection in the Jung Home app",
+          "password": "Enter the gateway network-key password (connects instantly)"
+        }
+      },
+      "app_approval": {
+        "title": "Connect to Jung Home",
+        "description": "Confirm or enter the address of your Jung Home gateway. After you continue, approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests.",
         "data": {
-          "host": "Host",
-          "password": "Network-key password (optional)"
+          "host": "Host"
         },
         "data_description": {
-          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local).",
-          "password": "The Jung Home gateway network-key password. Leave empty to approve the request in the app instead."
+          "host": "IP address or hostname of the Jung Home gateway. It is filled in automatically when the gateway is discovered; otherwise the default junghome.local works on many networks, or use the IP address (for example 192.168.1.50)."
+        }
+      },
+      "password": {
+        "title": "Connect to Jung Home",
+        "description": "Confirm the gateway address and enter its network-key password to connect immediately, without approving a request in the app. You can find the password in the Jung Home app.",
+        "data": {
+          "host": "Host",
+          "password": "Network-key password"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the Jung Home gateway. It is filled in automatically when the gateway is discovered; otherwise the default junghome.local works on many networks, or use the IP address (for example 192.168.1.50).",
+          "password": "The Jung Home gateway network-key password."
         }
       },
       "register_failed": {

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -4,18 +4,40 @@
     "step": {
       "zeroconf_confirm": {
         "title": "Jung Home gateway discovered",
-        "description": "Set up the Jung Home gateway at {host}? After you continue, approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests."
+        "description": "A Jung Home gateway was found at {host}. Choose how to connect.",
+        "menu_options": {
+          "app_approval": "Approve the connection in the Jung Home app",
+          "password": "Enter the gateway network-key password (connects instantly)"
+        }
       },
       "user": {
         "title": "Connect to Jung Home",
-        "description": "Enter the address of your Jung Home gateway. Leave the password empty to approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests. Alternatively, enter the gateway network-key password to connect immediately.",
+        "description": "Your gateway is usually found automatically and shown on the Integrations page. If it was not, choose how to connect below.",
+        "menu_options": {
+          "app_approval": "Approve the connection in the Jung Home app",
+          "password": "Enter the gateway network-key password (connects instantly)"
+        }
+      },
+      "app_approval": {
+        "title": "Connect to Jung Home",
+        "description": "Confirm or enter the address of your Jung Home gateway. After you continue, approve the access request in the Jung Home app under Settings, Gateway, Access Permissions, Open Requests.",
         "data": {
-          "host": "Host",
-          "password": "Network-key password (optional)"
+          "host": "Host"
         },
         "data_description": {
-          "host": "IP address or hostname of the Jung Home gateway (for example 192.168.1.50 or junghome.local).",
-          "password": "The Jung Home gateway network-key password. Leave empty to approve the request in the app instead."
+          "host": "IP address or hostname of the Jung Home gateway. It is filled in automatically when the gateway is discovered; otherwise the default junghome.local works on many networks, or use the IP address (for example 192.168.1.50)."
+        }
+      },
+      "password": {
+        "title": "Connect to Jung Home",
+        "description": "Confirm the gateway address and enter its network-key password to connect immediately, without approving a request in the app. You can find the password in the Jung Home app.",
+        "data": {
+          "host": "Host",
+          "password": "Network-key password"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the Jung Home gateway. It is filled in automatically when the gateway is discovered; otherwise the default junghome.local works on many networks, or use the IP address (for example 192.168.1.50).",
+          "password": "The Jung Home gateway network-key password."
         }
       },
       "register_failed": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -96,11 +96,47 @@ def test_normalize_host_strips_scheme_whitespace_and_slash():
         assert _normalize_host(raw) == expected
 
 
+async def _choose(hass: HomeAssistant, result: dict, option: str) -> dict:
+    """Pick an option from a menu step."""
+    assert result["type"] == FlowResultType.MENU
+    return await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": option}
+    )
+
+
+def _host_suggested(result: dict) -> str | None:
+    """Return the suggested_value pre-filled into a form's host field."""
+    host_key = next(k for k in result["data_schema"].schema if k == CONF_HOST)
+    return (host_key.description or {}).get("suggested_value")
+
+
+async def test_user_menu_lists_both_methods(hass: HomeAssistant) -> None:
+    """The user step is a menu offering both connection methods."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "user"
+    assert set(result["menu_options"]) == {"app_approval", "password"}
+
+
+async def test_user_flow_defaults_host_to_mdns(hass: HomeAssistant) -> None:
+    """The manual host field is pre-filled with the mDNS default."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await _choose(hass, result, "app_approval")
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "app_approval"
+    assert _host_suggested(result) == "junghome.local"
+
+
 async def test_user_flow_invalid_host(hass: HomeAssistant) -> None:
     """A blank host is rejected with an error and re-shows the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    result = await _choose(hass, result, "app_approval")
     assert result["type"] == FlowResultType.FORM
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_HOST: "   "}
@@ -120,6 +156,7 @@ async def test_user_flow_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    result = await _choose(hass, result, "app_approval")
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_HOST: "1.2.3.4"}
     )
@@ -127,22 +164,75 @@ async def test_user_flow_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_discovery_starts_confirm(hass: HomeAssistant) -> None:
-    """A discovered gateway pre-fills the host and asks to confirm."""
-    info = ZeroconfServiceInfo(
+def _zeroconf_info(hostname: str = "junghome-abc.local.") -> ZeroconfServiceInfo:
+    return ZeroconfServiceInfo(
         ip_address="1.2.3.4",
         ip_addresses=["1.2.3.4"],
         port=443,
-        hostname="junghome.local.",
+        hostname=hostname,
         type="_junghome._tcp.local.",
         name="junghome._junghome._tcp.local.",
         properties={},
     )
+
+
+async def test_zeroconf_discovery_starts_confirm(hass: HomeAssistant) -> None:
+    """A discovered gateway offers a menu of connection methods."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "zeroconf"}, data=info
+        DOMAIN, context={"source": "zeroconf"}, data=_zeroconf_info()
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] == FlowResultType.MENU
     assert result["step_id"] == "zeroconf_confirm"
+    assert set(result["menu_options"]) == {"app_approval", "password"}
+
+
+async def test_zeroconf_confirm_app_approval_prefills_host(
+    hass: HomeAssistant,
+) -> None:
+    """Discovered + approve-in-app: the host is pre-filled (not hidden) and the
+    entry keeps the stable mDNS-hostname unique_id.
+    """
+    fetch, run_ws = _no_network()
+    with patch(_REGISTER, AsyncMock(return_value="tok-z")), fetch, run_ws:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "zeroconf"}, data=_zeroconf_info()
+        )
+        result = await _choose(hass, result, "app_approval")
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "app_approval"
+        assert _host_suggested(result) == "1.2.3.4"  # discovered address, editable
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4"}
+        )
+        result = await _advance_progress(hass, result)
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok-z"}
+        await hass.async_block_till_done()
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.unique_id == "junghome-abc.local"
+
+
+async def test_zeroconf_confirm_password_prefills_host(hass: HomeAssistant) -> None:
+    """Discovered + network-key password: the host is pre-filled and setup is
+    instant.
+    """
+    fetch, run_ws = _no_network()
+    with patch(_REGISTER_PW, AsyncMock(return_value="pw-z")), fetch, run_ws:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "zeroconf"}, data=_zeroconf_info()
+        )
+        result = await _choose(hass, result, "password")
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "password"
+        assert _host_suggested(result) == "1.2.3.4"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", "password": "secret"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_TOKEN: "pw-z"}
+        await hass.async_block_till_done()
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.unique_id == "junghome-abc.local"
 
 
 async def test_zeroconf_aborts_when_already_configured(hass: HomeAssistant) -> None:
@@ -169,12 +259,13 @@ async def test_zeroconf_aborts_when_already_configured(hass: HomeAssistant) -> N
 
 
 async def test_user_flow_success(hass: HomeAssistant) -> None:
-    """Host + approved registration creates and sets up the entry."""
+    """Menu -> app approval -> host -> approved registration creates the entry."""
     fetch, run_ws = _no_network()
     with patch(_REGISTER, AsyncMock(return_value="tok-123")), fetch, run_ws:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
+        result = await _choose(hass, result, "app_approval")
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_HOST: "1.2.3.4"}
         )
@@ -296,12 +387,13 @@ _REGISTER_PW = (
 
 
 async def test_user_flow_password_success(hass: HomeAssistant) -> None:
-    """Supplying a password registers instantly (no waiting-for-approval step)."""
+    """Menu -> password -> host + password registers instantly."""
     fetch, run_ws = _no_network()
     with patch(_REGISTER_PW, AsyncMock(return_value="pw-tok")), fetch, run_ws:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
+        result = await _choose(hass, result, "password")
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_HOST: "1.2.3.4", "password": "secret"}
         )
@@ -321,6 +413,7 @@ async def test_user_flow_password_rejected(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
+        result = await _choose(hass, result, "password")
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_HOST: "1.2.3.4", "password": "bad"}
         )
@@ -328,8 +421,7 @@ async def test_user_flow_password_rejected(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "invalid_auth"}
     # The host the user already typed is kept so they don't retype it on retry;
     # the password is not suggested back (it's a credential, and it was wrong).
-    host_key = next(k for k in result["data_schema"].schema if k == CONF_HOST)
-    assert host_key.description == {"suggested_value": "1.2.3.4"}
+    assert _host_suggested(result) == "1.2.3.4"
 
 
 async def test_async_register_by_password_returns_token(


### PR DESCRIPTION
## What & why

Reworks the setup UX from one combined form into a clear **selection flow**, per the proposed workflow, while keeping the integration at its existing Platinum bar.

### The flow now

1. **Automatic discovery (autodetect).** Unchanged and still primary — the gateway advertises `_junghome._tcp.local.` (confirmed in firmware: avahi `junghome-<mac>.local`, port 443, TXT `mac`/`serial`), so it appears as a *Discovered* device automatically.
2. **Method menu.** Both the manual (`user`) step and the discovered (`zeroconf_confirm`) step are now menus offering the two ways to get a token:
   - **Approve in the Jung Home app** — `POST /api/junghome/register` (blocks on in-app approval).
   - **Enter the gateway network-key password** — instant, `POST /api/junghome/register/by-password` (validated against the firmware; see #107).
3. **Host is always shown and prefilled** — the discovered address when found automatically (editable, never hidden — per review feedback), otherwise the mDNS default `junghome.local`.

### Does a dedicated "autodetect" button make sense?

No — and this PR deliberately omits one. HA already autodetects via the zeroconf manifest + `async_step_zeroconf` (zero clicks, learns the real name + IP). An active in-flow "scan" would duplicate that with flaky mDNS timing code. The menu is therefore *method* selection; discovery stays the autodetect. The valuable, non-redundant wins are: discovery now also offers the password method, and the manual host prefills a sensible mDNS default.

### mDNS default caveat

The gateway's real A-record is per-device (`junghome-<mac>.local`); there's no publisher for a generic `junghome.local` (that name is the TLS cert CN / documented alias). So `junghome.local` is offered as a *default suggestion* that works on many networks — discovery provides the reliable name, and an IP always works. The field help text explains this.

### Identity

Discovered entries keep their stable mDNS-hostname `unique_id` even when the host is confirmed/edited; manual entries continue to key on the host. Reauth, reconfigure, and duplicate-guarding are preserved.

## Quality (Platinum)

- `ruff check .` — clean
- `ruff format . --check` — clean
- `mypy custom_components/junghome --strict` — clean
- `pytest` — 161 passed (config-flow tests updated for the menu; new coverage for discovered → app-approval and discovered → password with host prefilled + unique_id assertions)
- `strings.json` / `translations/en.json` kept in sync; README setup section rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)