### PR TITLE
Release 1.3.0b1

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.2",
+  "version": "1.3.0b1",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
Bumps the manifest to **1.3.0b1** (first beta of 1.3.0). Merging this, then pushing the `v1.3.0b1` tag, triggers the Release workflow to publish a GitHub **pre-release** (HACS treats it as a beta and won't auto-update everyone).

### Changes since 1.2.2
- **Network-key password setup** — connect instantly without in-app approval (#107).
- **Config-flow rework** — connection-method selection, mDNS discovery preserved, host pre-filled (#110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)