### PR TITLE
Cover presence binary_sensor edge branches

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2316,3 +2316,133 @@ async def test_presence_discovered_and_split_from_numeric_sensor(
 
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
+
+
+async def test_presence_binary_sensor_keeps_state_when_datapoint_gone(
+    hass: HomeAssistant,
+) -> None:
+    """A vanished datapoint holds the last state rather than resetting to off.
+
+    Unlike the switch/event platforms (which write unconditionally), presence
+    guards its write with ``if datapoint:`` — when the coordinator no longer
+    carries the datapoint, ``_handle_coordinator_update`` must return early,
+    leaving the previous reading untouched instead of writing ``None``/off.
+    """
+    coordinator = _bare_coordinator(hass)
+    device = _presence_device("1")
+    dp = device["datapoints"][0]
+    sensor = JungHomePresence(coordinator, device, dp, "Presence Detected")
+    assert sensor.is_on is True
+
+    coordinator.data = []  # device/datapoint dropped from the latest poll
+    with patch.object(sensor, "async_write_ha_state") as write_state:
+        sensor._handle_coordinator_update()  # must not raise
+    write_state.assert_not_called()
+    assert sensor.is_on is True  # last-known state preserved, not cleared
+
+
+async def test_presence_binary_sensor_discovered_on_any_device_type(
+    hass: HomeAssistant,
+) -> None:
+    """Presence discovery matches on the datapoint, not the device type.
+
+    ``binary_sensor.py`` is deliberately device-type-agnostic (every other
+    platform gates on ``device['type']``). A presence quantity riding on a
+    device whose type no other platform claims must still surface as an
+    occupancy binary_sensor — and never as a numeric sensor.
+    """
+    device = {
+        "id": "idbwm2",
+        "type": "BWM",  # not claimed by light/switch/sensor/event/cover/climate
+        "label": "Garage Detector",
+        "datapoints": [
+            {
+                "id": "idbwm2-001",
+                "type": "quantity",
+                "values": [
+                    {"key": "quantity", "value": "1"},
+                    {"key": "quantity_label", "value": "Occupancy"},
+                    {"key": "quantity_unit", "value": ""},
+                ],
+            }
+        ],
+    }
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[device]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="1.2.3.4",
+            data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        bs = hass.states.get("binary_sensor.garage_detector_occupancy")
+        assert bs is not None
+        assert bs.state == "on"
+        assert bs.attributes["device_class"] == "occupancy"
+        # The unusual device type must not spawn a numeric sensor for it.
+        assert hass.states.get("sensor.garage_detector_occupancy") is None
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_presence_binary_sensor_rediscovery_is_idempotent(
+    hass: HomeAssistant,
+) -> None:
+    """Re-running discovery for a known presence datapoint adds no duplicate.
+
+    The discovery callback is a coordinator listener and re-fires on every
+    update; a datapoint whose stable uid is already ``known`` must be skipped
+    (the ``if uid not in known`` guard), so a fresh poll of the same device
+    creates no second entity.
+    """
+    device = _presence_device("1")
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[device]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="1.2.3.4",
+            data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        registry = er.async_get(hass)
+
+        def _presence_entities() -> list:
+            return [
+                e
+                for e in er.async_entries_for_config_entry(registry, entry.entry_id)
+                if e.domain == "binary_sensor"
+            ]
+
+        assert len(_presence_entities()) == 1
+
+        # A REST poll re-runs discovery for the same (already-known) datapoint.
+        entry.runtime_data.async_set_updated_data([device])
+        await hass.async_block_till_done()
+
+        assert len(_presence_entities()) == 1  # dedup guard: no duplicate added
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
Follow-up to #112. That PR took `binary_sensor.py` to **100% statement** coverage, but two **branch** paths remained untested. These tests close them, locking the presence platform's deliberate — and deliberately *distinct* — behaviours against regression.

### What was uncovered (branch coverage on `binary_sensor.py`: 97% → 100%)

| Branch | Behaviour it guards |
| --- | --- |
| `106->exit` | `_handle_coordinator_update` guards its write with `if datapoint:`. Unlike the switch/event platforms (which write unconditionally), presence **does not write** when its datapoint disappears from coordinator data — it holds the last-known reading instead of resetting to off/unknown. |
| `59->49` | The discovery callback is a coordinator listener and re-fires on every update; a datapoint whose stable uid is already `known` must be skipped, so a re-poll of the same device adds no duplicate entity. |

### Tests added (all in `tests/test_init.py`)

- **`test_presence_binary_sensor_keeps_state_when_datapoint_gone`** — asserts the early return: `async_write_ha_state` is not called and `is_on` is preserved.
- **`test_presence_binary_sensor_discovered_on_any_device_type`** — presence discovery matches on the *datapoint*, not `device['type']` (every other platform gates on type). A presence quantity on an unclaimed device type still surfaces as an occupancy `binary_sensor` and never as a numeric `sensor`.
- **`test_presence_binary_sensor_rediscovery_is_idempotent`** — a second coordinator update for the same device creates no duplicate registry entry.

### Verification (matches CI)

- `pytest --cov` — **167 passed**, total coverage 99.20% (`binary_sensor.py` 100% statements, **100% branch**, 0 partials).
- `mypy custom_components/junghome --strict` — clean.
- `ruff check .` and `ruff format --check .` — clean.

Tests only; no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)