### PR TITLE
Enable branch coverage in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,13 @@
 # by tests/. Only never-executed TYPE_CHECKING import blocks are excluded here;
 # for a genuinely unreachable line, add a scoped `# pragma: no cover` on that
 # line rather than a package-wide regex.
+#
+# branch = true measures BOTH sides of each of those defensive guards, not just
+# that the line ran — so an untested early-return (`if x: ...` never falling
+# through) shows up as a partial branch. This is read by coverage.py directly,
+# so `pytest --cov` picks it up with no `--cov-branch` flag needed in CI.
 [run]
+branch = true
 source = custom_components/junghome
 
 [report]


### PR DESCRIPTION
Follow-up to #112 / #115. While closing the presence sensor's untested branches I noticed the coverage gate measures **statement** coverage only (`--cov` without `--cov-branch`), so an untested early-return still reads as 100%. This turns branch coverage on.

### Why

`.coveragerc` already states its intent — *"the reported figure should reflect REACHABLE code, so we do NOT broadly exclude defensive branches (bad-value guards, missing-datapoint fallbacks…)"*. But statement coverage only proves each guard **line ran**, not that **both sides** were taken. Branch coverage is what actually enforces that stated intent.

### Change

One line in `.coveragerc`:

```ini
[run]
branch = true
```

coverage.py reads this directly, so the **existing** CI command (`pytest -q --cov=custom_components/junghome --cov-report=term-missing`) picks it up — no workflow edit, no `--cov-branch` flag needed. No test or production code touched.

### Effect (verified locally against current `main`, HA 2026.7.4 / py3.14)

- Reported total: **99.22% (statement) → 98.02% (statement + branch)** — still above the **95%** `fail_under`, so CI stays green.
- The report now shows `Branch` / `BrPart` columns, surfacing previously-hidden untested edges, e.g.:

```
binary_sensor.py   ... 73->63, 120->exit   (closed by #115)
coordinator.py     ... 259->exit, 306->350, ...
config_flow.py     ... (93% combined)
```

These partials don't fail the build (the gate is on the 95% total); they're now **visible** so future PRs can close them deliberately instead of them hiding behind 100% statement coverage.

The `fail_under` threshold is intentionally left at 95 — raising it is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)