### PR TITLE
Gateway hub: link devices via_device; harden connectivity sensor

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -15,6 +15,7 @@ from .const import (
     datapoint_suffix,
     device_slug,
     gateway_device_id,
+    gateway_device_info,
 )
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
@@ -66,6 +67,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, "stable_ids_migrated": True}
             )
+
+    # Register the synthetic gateway (hub) device up front, before the platforms
+    # create the per-function devices that link to it via ``via_device``. Creating
+    # it here rather than lazily (via the connectivity sensor) guarantees it
+    # already exists when those devices reference it, so Home Assistant never
+    # takes its deprecated "non existing via_device" path.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **gateway_device_info(entry, coordinator.gateway_version),
+    )
 
     # Forward the setup to the appropriate platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/junghome/binary_sensor.py
+++ b/custom_components/junghome/binary_sensor.py
@@ -22,9 +22,9 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    DOMAIN,
     datapoint_value,
     gateway_device_id,
+    gateway_device_info,
     is_presence_quantity,
     stable_unique_id,
 )
@@ -160,8 +160,8 @@ class JungHomeGatewayConnectivity(
     ) -> None:
         """Initialize the gateway connectivity sensor."""
         super().__init__(coordinator)
-        self._gateway_id = gateway_device_id(entry)
-        self._attr_unique_id = f"{self._gateway_id}_connectivity"
+        self._entry = entry
+        self._attr_unique_id = f"{gateway_device_id(entry)}_connectivity"
 
     @property
     def available(self) -> bool:
@@ -180,10 +180,4 @@ class JungHomeGatewayConnectivity(
     @property
     def device_info(self) -> DeviceInfo:
         """Attach to the synthetic gateway (hub) device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._gateway_id)},
-            name="JUNG HOME Gateway",
-            manufacturer="Jung",
-            model="Gateway",
-            sw_version=self.coordinator.gateway_version,
-        )
+        return gateway_device_info(self._entry, self.coordinator.gateway_version)

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import slugify
 
 from .models import Datapoint, Device
@@ -10,6 +11,13 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
 DOMAIN = "junghome"
+
+# Presentation of the synthetic gateway (hub) device. Kept as constants so the
+# up-front registration in ``__init__`` and the connectivity sensor that lives on
+# the device describe it identically (see ``gateway_device_info``).
+GATEWAY_NAME = "JUNG HOME Gateway"
+GATEWAY_MANUFACTURER = "Jung"
+GATEWAY_MODEL = "Gateway"
 
 # Options-flow key: the stable unique_ids of covers whose position the gateway
 # reports inverted relative to Home Assistant's convention. The gateway's native
@@ -67,6 +75,23 @@ def gateway_device_id(entry: "ConfigEntry") -> str:
     avoid pruning this device (it never appears in the gateway's device list).
     """
     return f"gateway_{entry.unique_id or entry.entry_id}"
+
+
+def gateway_device_info(entry: "ConfigEntry", sw_version: str | None) -> DeviceInfo:
+    """Return the ``DeviceInfo`` for the synthetic gateway (hub) device.
+
+    Shared by the up-front registration in ``__init__`` (which creates the hub
+    before the platforms create the per-function devices that reference it via
+    ``via_device``) and by the connectivity sensor that lives on it, so both
+    describe the device identically.
+    """
+    return DeviceInfo(
+        identifiers={(DOMAIN, gateway_device_id(entry))},
+        name=GATEWAY_NAME,
+        manufacturer=GATEWAY_MANUFACTURER,
+        model=GATEWAY_MODEL,
+        sw_version=sw_version,
+    )
 
 
 def datapoint_value(datapoint: Datapoint | None, key: str) -> str | None:

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -349,10 +349,19 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             finally:
                 self.websocket = None
                 self.ws_connected = False
-                # Notify listeners so the gateway connectivity sensor flips to
-                # "off" immediately on a drop, rather than lagging until the next
-                # REST poll (the reconnect path already refreshes on connect).
-                self.async_update_listeners()
+                self._notify_websocket_closed()
+
+    def _notify_websocket_closed(self) -> None:
+        """Push the WebSocket-down state to listeners after a live drop.
+
+        Flips the gateway connectivity sensor to "off" immediately rather than
+        lagging until the next REST poll (the reconnect path already refreshes on
+        connect). Skipped while ``stop()`` is tearing the entry down: there the
+        platforms are already being removed, so notifying would only run the
+        prune/area listeners for no benefit.
+        """
+        if not self._closing:
+            self.async_update_listeners()
 
     def _log_ws_frame(self, raw: str) -> None:
         """Record a raw WebSocket frame for diagnostics.

--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -82,6 +82,10 @@ async def async_get_config_entry_diagnostics(
             "title": entry.title,
         },
         "gateway_version": coordinator.gateway_version,
+        # Whether the live push link is currently up (mirrors the gateway
+        # connectivity binary_sensor); a dump taken while it is False explains
+        # why state looks stale (it has fallen back to 1-minute REST polling).
+        "ws_connected": coordinator.ws_connected,
         # Quick map of what the gateway exposes vs what we implement — the first
         # thing to check when matching real hardware against our support.
         "support_summary": _support_summary(devices),

--- a/custom_components/junghome/entity.py
+++ b/custom_components/junghome/entity.py
@@ -5,18 +5,18 @@ repeated the same ``device_info``, ``available`` and coordinator-data lookups.
 This base centralises them. The scene platform is intentionally *not* based on
 it — scenes have no backing device.
 
-Behaviour preserved exactly: ``device_info`` produces the same dict as before,
-``available`` keys off the same ``ws_connected or last_update_success`` signal,
-and the lookup helpers return the same objects the inline ``next(...)`` calls
-did. Subclasses keep their own ``unique_id``/naming and their own
-``_handle_coordinator_update`` write logic (which intentionally differs between
-platforms).
+``available`` keys off the ``ws_connected or last_update_success`` signal, and
+the lookup helpers return the same objects the inline ``next(...)`` calls did.
+``device_info`` additionally links each device to the synthetic gateway (hub)
+device via ``via_device``. Subclasses keep their own ``unique_id``/naming and
+their own ``_handle_coordinator_update`` write logic (which intentionally
+differs between platforms).
 """
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, device_slug
+from .const import DOMAIN, device_slug, gateway_device_id
 from .coordinator import JungHomeDataUpdateCoordinator
 from .models import Datapoint, Device
 
@@ -49,8 +49,14 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device information, linking the entity to its Jung Home device."""
-        return {
+        """Return device information, linking the entity to its Jung Home device.
+
+        Every device is hung off the synthetic gateway (hub) device via
+        ``via_device`` so the registry reflects the real "devices reached
+        through the gateway" topology (the hub is registered up front in
+        ``async_setup_entry``, so this reference always resolves).
+        """
+        info: DeviceInfo = {
             "identifiers": {(DOMAIN, device_slug(self._device))},
             "name": self._device.get("label", "Jung Device"),
             "manufacturer": "Jung",
@@ -59,6 +65,10 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
             or self.coordinator.gateway_version
             or "Unknown Version",
         }
+        entry = self.coordinator.config_entry
+        if entry is not None:
+            info["via_device"] = (DOMAIN, gateway_device_id(entry))
+        return info
 
     def _current_device(self) -> Device | None:
         """Return this entity's device from the latest coordinator data."""

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -94,7 +94,7 @@
   },
   "entity": {
     "binary_sensor": {
-      "gateway_connectivity": { "name": "Gateway connection" }
+      "gateway_connectivity": { "name": "Connection" }
     },
     "climate": {
       "thermostat": {

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -94,7 +94,7 @@
   },
   "entity": {
     "binary_sensor": {
-      "gateway_connectivity": { "name": "Gateway connection" }
+      "gateway_connectivity": { "name": "Connection" }
     },
     "climate": {
       "thermostat": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -566,6 +566,8 @@ async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
     diag = await async_get_config_entry_diagnostics(hass, init_integration)
     assert diag["device_count"] == len(DEVICES)
     assert diag["gateway_version"] == "1.5.0"
+    # The live-link flag is surfaced so a dump explains stale-looking state.
+    assert diag["ws_connected"] is True
     assert diag["entry"]["data"][CONF_TOKEN] == "**REDACTED**"
     assert diag["entry"]["data"][CONF_HOST] == "**REDACTED**"
     # Scenes are a separate coordinator data category, surfaced for debugging.
@@ -2275,6 +2277,34 @@ async def test_gateway_device_not_pruned(hass: HomeAssistant, init_integration) 
     device = dev_reg.async_get_device(identifiers={(DOMAIN, "gateway_1.2.3.4")})
     assert device is not None
     assert device.name == "JUNG HOME Gateway"
+
+
+async def test_devices_linked_to_gateway_hub(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Every function device hangs off the synthetic gateway (hub) via via_device."""
+    dev_reg = dr.async_get(hass)
+    hub = dev_reg.async_get_device(identifiers={(DOMAIN, "gateway_1.2.3.4")})
+    assert hub is not None
+    light = dev_reg.async_get_device(identifiers={(DOMAIN, "hall_light")})
+    assert light is not None
+    assert light.via_device_id == hub.id
+
+
+async def test_notify_websocket_closed_skips_during_teardown(
+    hass: HomeAssistant,
+) -> None:
+    """The disconnect notify fires on a live drop but is muted while stopping."""
+    coordinator = _bare_coordinator(hass)
+    with patch.object(coordinator, "async_update_listeners") as notify:
+        # A genuine drop notifies listeners so the connectivity sensor flips off.
+        coordinator._notify_websocket_closed()
+        assert notify.call_count == 1
+        # During stop()/unload the platforms are already going away, so the
+        # guard suppresses the redundant notification.
+        coordinator._closing = True
+        coordinator._notify_websocket_closed()
+        assert notify.call_count == 1
 
 
 def _presence_device(value: str) -> dict:


### PR DESCRIPTION
Follow-up to #104 (gateway connectivity binary sensor), which I reviewed and merged. #104 is solid — correct always-available connectivity semantics, prompt flip-to-off on WS drop, a synthetic hub device with prune protection, and full test coverage. This PR completes the hub model it introduced and polishes a few edges. No behavioural regressions; every touched file stays at 100% test coverage.

## What #104 left on the table

**The gateway device was an island.** #104 created a synthetic "JUNG HOME Gateway" device to give gateway-level entities a home, but the per-function devices (lights, covers, …) weren't linked to it. A platinum hub integration should model the real topology so the device page shows *"N devices connected via this hub."*

- **`entity.py`** — every device-backed entity now sets `via_device=(DOMAIN, gateway_device_id(entry))`.
- **`__init__.py`** — the hub device is now registered **up front** in `async_setup_entry`, before the platforms create the devices that reference it. This matters: HA's `async_get_or_create` logs a deprecation for referencing a `via_device` that doesn't exist yet (`breaks_in_ha_version="2025.12.0"`). Because platforms are forwarded concurrently and `BINARY_SENSOR` (which lazily created the hub in #104) runs *after* `LIGHT`/`SWITCH`/`SENSOR`, lazy creation couldn't guarantee the ordering — explicit up-front registration does.
- **`const.py`** — `gateway_device_info()` helper + `GATEWAY_NAME`/`GATEWAY_MANUFACTURER`/`GATEWAY_MODEL` constants, shared by the registration and the connectivity sensor so the hub is described in exactly one place.

## Hardening & polish

- **`coordinator.py`** — the on-drop `async_update_listeners()` (added in #104 so the sensor flips off promptly) also fired during `stop()`/unload, because the cancelling `CancelledError` runs the same `finally`. At that point the platforms are already unloaded, so the notify only re-runs the prune/area listeners for no benefit. Extracted to `_notify_websocket_closed()`, guarded on `not self._closing`.
- **`strings.json` / `translations/en.json`** — the entity name "Gateway connection" on the "JUNG HOME Gateway" device rendered as "JUNG HOME Gateway **Gateway** connection". Renamed to just **"Connection"**.
- **`diagnostics.py`** — added `ws_connected`, so a diagnostics dump taken during an outage explains why state looks stale (the link has fallen back to 1-minute REST polling).

## Tests

- `test_devices_linked_to_gateway_hub` — a function device's `via_device_id` points at the hub device.
- `test_notify_websocket_closed_skips_during_teardown` — the notify fires on a live drop but is muted once `_closing` is set.
- `test_diagnostics` — asserts the new `ws_connected` field.

All 169 tests pass; `ruff check`, `ruff format --check`, and `mypy --strict` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)