### PR TITLE
Release 1.3.0b2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,18 @@ When working on anything that touches the gateway protocol, consult
   (`{"user_name": ...}`), which blocks up to 180 s until the user approves the
   request in the JUNG HOME app (Settings → Gateway → Access Permissions → Open
   Requests).
+- **Capabilities follow datapoints, and can change at runtime.** Each platform
+  freezes an entity's supported features at construction from the datapoints
+  present (cover tilt ← `angle`, light brightness/colour ← `brightness`/
+  `color_temperature`, climate off ← `switch`), and `_discover_*` is add-only, so
+  a live entity never re-derives them. The gateway *can* add or drop a datapoint
+  for an existing device (a firmware update re-enumerates and datapoints arrive
+  over several polls; the slat channel is toggled in the app — see the tilt note
+  in [docs/gateway-websocket.md](docs/gateway-websocket.md)). `__init__.py`'s
+  `_register_capability_reload` reloads the entry when a device's datapoint-type
+  set changes so features are rebuilt — the reason the tilt-lost-after-update
+  regression can't recur. Keep capabilities gated on datapoint *presence*, not
+  the function-type name.
 
 ## Conventions
 

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     gateway_device_info,
 )
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
+from .models import Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +32,80 @@ PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
     Platform.SCENE,
 ]
+
+
+def _capability_signature(device: Device) -> tuple[str | None, frozenset[str]]:
+    """Fingerprint a device's capabilities: its function type + datapoint types.
+
+    The platforms freeze an entity's supported features from the datapoints
+    present when it is first built (a cover's tilt, a light's brightness/colour,
+    a thermostat's off mode), and ``_discover_*`` is add-only — it never revisits
+    a device it has already created. So this fingerprint changing on an existing
+    device means its entities now carry a stale feature set, and the entry must be
+    reloaded to rebuild them. Only the datapoint *types* matter here (not their
+    values), so a normal value push never changes the signature.
+    """
+    return (
+        device.get("type"),
+        frozenset(
+            dp_type
+            for dp in device.get("datapoints", [])
+            if (dp_type := dp.get("type"))
+        ),
+    )
+
+
+def _register_capability_reload(
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    coordinator: JungHomeDataUpdateCoordinator,
+) -> None:
+    """Reload the entry when an existing device's capability fingerprint changes.
+
+    The platforms compute supported features once, from the datapoints present at
+    entity construction, and discovery never revisits a device it has already
+    created — so if the gateway later starts or stops exposing a datapoint for an
+    existing device, the live entity keeps its stale features. This happens when a
+    firmware update re-enumerates a device and its datapoints arrive across
+    several polls, or when a channel like a blind's slat tilt is toggled visible
+    in the JUNG HOME app: the gateway then reports the cover as PositionAndAngle
+    with an ``angle`` datapoint (rather than Position), but a cover entity built
+    moments earlier without it stays position-only until reloaded. A reload
+    rebuilds every entity from the current datapoint set. See
+    ``_capability_signature`` for what counts as a change (datapoint types, not
+    their values, so a routine value push never triggers a reload).
+    """
+    capability_signatures: dict[str, tuple[str | None, frozenset[str]]] = {}
+    reload_scheduled = False
+
+    @callback
+    def _reload_on_capability_change() -> None:
+        nonlocal reload_scheduled
+        if reload_scheduled or not coordinator.data:
+            return
+        changed = False
+        for device in coordinator.data:
+            slug = device_slug(device)
+            signature = _capability_signature(device)
+            previous = capability_signatures.get(slug)
+            capability_signatures[slug] = signature
+            # A brand-new device is picked up by the platforms' own discovery and
+            # a vanished one by the stale-device prune; only a change to a device
+            # already fingerprinted leaves an entity with stale features.
+            if previous is not None and previous != signature:
+                changed = True
+        if changed:
+            reload_scheduled = True
+            _LOGGER.info(
+                "Jung Home: a device's datapoint set changed; reloading the entry "
+                "to rebuild entity capabilities (e.g. cover tilt, light colour)"
+            )
+            hass.config_entries.async_schedule_reload(entry.entry_id)
+
+    # Seed the baseline from the current devices (the first pass never reloads),
+    # then watch for changes on subsequent refreshes.
+    _reload_on_capability_change()
+    entry.async_on_unload(coordinator.async_add_listener(_reload_on_capability_change))
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -170,6 +245,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
 
     _assign_areas()
     entry.async_on_unload(coordinator.async_add_listener(_assign_areas))
+
+    _register_capability_reload(hass, entry, coordinator)
 
     # Register the host-change reload listener only AFTER the migration's
     # async_update_entry flag-write above, so that write doesn't trigger a

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.3.0b1",
+  "version": "1.3.0b2",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -137,6 +137,20 @@ Common `values` keys by device type:
 > in its options flow, which switches that cover to an identity mapping. The
 > inversion lives in one place (`cover.py` `_to_ha`/`_to_device`).
 
+> **Whether a cover exposes slat tilt is per-device and can change.** In
+> `function_helper_methods.js` a `WindowCover` is reported as **`PositionAndAngle`
+> with an `angle` datapoint** only when its angle state is visible
+> (`device.states.angle?.profile.visible === true`); otherwise it is reported as
+> **`Position`** with just a `level` datapoint and no tilt. `level` and `angle`
+> are the *same* BT-Mesh model (Generic Level `0x1002`) — only the datapoint
+> `type` string (`"level"` vs `"angle"`) distinguishes them. So the presence of
+> the `angle` datapoint is the single source of truth for tilt, and it can appear
+> or disappear across firmware updates (which re-enumerate devices, their
+> datapoints sometimes arriving over several polls) or when the slat channel is
+> toggled in the JUNG HOME app. The integration gates HA's tilt features on that
+> datapoint and reloads the entry when a device's datapoint set changes so the
+> capability is rebuilt (see `_register_capability_reload` in `__init__.py`).
+
 ### Other command types
 
 | `type` | Behaviour |

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -258,6 +258,27 @@ async def test_zeroconf_aborts_when_already_configured(hass: HomeAssistant) -> N
     assert result["reason"] == "already_configured"
 
 
+async def test_zeroconf_aborts_when_host_added_manually(hass: HomeAssistant) -> None:
+    """A gateway already added manually (under a different unique_id) is skipped.
+
+    Discovery assigns the mDNS hostname as the unique_id, which does not match the
+    manual entry keyed on the host, so the unique_id abort does not fire; the
+    host-based fallback check must still abort so the gateway is not offered twice.
+    """
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    ).add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=_zeroconf_info("junghome-abc.local."),
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 async def test_user_flow_success(hass: HomeAssistant) -> None:
     """Menu -> app approval -> host -> approved registration creates the entry."""
     fetch, run_ws = _no_network()
@@ -441,6 +462,56 @@ async def test_async_register_by_password_wrong_password(
     with pytest.raises(CannotRegister):
         await flow._async_register_by_password("pw")
     assert flow._error == "invalid_auth"
+
+
+async def test_async_register_by_password_http_error(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A non-200/401 status maps to register_failed."""
+    aioclient_mock.post("https://gw/api/junghome/register/by-password", status=500)
+    flow = _flow(hass)
+    with pytest.raises(CannotRegister):
+        await flow._async_register_by_password("pw")
+    assert flow._error == "register_failed"
+
+
+async def test_async_register_by_password_connection_error(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A transport error maps to cannot_connect."""
+    aioclient_mock.post(
+        "https://gw/api/junghome/register/by-password", exc=aiohttp.ClientError()
+    )
+    flow = _flow(hass)
+    with pytest.raises(CannotRegister):
+        await flow._async_register_by_password("pw")
+    assert flow._error == "cannot_connect"
+
+
+async def test_async_register_by_password_missing_token(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A 200 with no token is treated as a failed registration."""
+    aioclient_mock.post("https://gw/api/junghome/register/by-password", json={})
+    with pytest.raises(CannotRegister):
+        await _flow(hass)._async_register_by_password("pw")
+
+
+async def test_password_flow_invalid_host(hass: HomeAssistant) -> None:
+    """An empty/invalid host in the password step re-shows the form with an error.
+
+    The host is validated before any network call, so no gateway is contacted.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await _choose(hass, result, "password")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "   ", "password": "secret"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "password"
+    assert result["errors"] == {"base": "invalid_host"}
 
 
 async def test_reconfigure_invalid_host(hass: HomeAssistant) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 """Integration setup / entity / lifecycle tests for Jung Home."""
 
 import asyncio
+import copy
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
@@ -731,6 +732,103 @@ async def test_token_only_change_no_reload(
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_TOKEN: "newtok"}
         )
+        await hass.async_block_till_done()
+    reload.assert_not_called()
+
+
+async def test_datapoint_set_change_reloads_entry(hass: HomeAssistant) -> None:
+    """A cover that gains a slat `angle` datapoint after creation reloads the entry.
+
+    Regression guard for the reporter who lost tilt on 1.2.2: a cover's tilt
+    support is frozen at construction and discovery is add-only, so when the
+    gateway re-enumerates the device and its `angle` datapoint appears on a later
+    poll (function type flips Position -> PositionAndAngle), the entry must reload
+    to rebuild the entity with tilt instead of leaving it position-only forever.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    position_only = {
+        "id": "idcov",
+        "type": "Position",
+        "label": "Rolladen",
+        "datapoints": [
+            {
+                "id": "idcov-1",
+                "type": "level",
+                "values": [{"key": "level", "value": "30"}],
+            },
+        ],
+    }
+    with_angle = {
+        "id": "idcov",
+        "type": "PositionAndAngle",
+        "label": "Rolladen",
+        "datapoints": [
+            {
+                "id": "idcov-1",
+                "type": "level",
+                "values": [{"key": "level", "value": "30"}],
+            },
+            {
+                "id": "idcov-2",
+                "type": "angle",
+                "values": [{"key": "angle", "value": "40"}],
+            },
+        ],
+    }
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[position_only]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        # Built without a slat datapoint: position-only, no tilt exposed.
+        state = hass.states.get("cover.rolladen")
+        assert state is not None
+        assert not (
+            state.attributes["supported_features"]
+            & CoverEntityFeature.SET_TILT_POSITION
+        )
+
+        # The gateway now re-enumerates the same cover WITH a slat angle datapoint;
+        # the capability fingerprint changes, so a reload is scheduled to rebuild it.
+        with patch.object(hass.config_entries, "async_schedule_reload") as reload:
+            coordinator.async_set_updated_data([with_angle])
+            await hass.async_block_till_done()
+        reload.assert_called_once_with(entry.entry_id)
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_value_only_change_does_not_reload_entry(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A normal value push (same datapoint *types*) must never reload the entry.
+
+    The capability fingerprint keys on datapoint types, not values, so routine
+    state updates don't trip the capability-change reload into a reload storm.
+    """
+    coordinator = init_integration.runtime_data
+    devices = copy.deepcopy(coordinator.data)
+    # Change only a value on the blind's level datapoint (types unchanged).
+    for device in devices:
+        if device["id"] == "idblind1":
+            device["datapoints"][0]["values"][0]["value"] = "80"
+    with patch.object(hass.config_entries, "async_schedule_reload") as reload:
+        coordinator.async_set_updated_data(devices)
         await hass.async_block_till_done()
     reload.assert_not_called()
 
@@ -2506,10 +2604,13 @@ async def test_presence_binary_sensor_rediscovery_is_idempotent(
         registry = er.async_get(hass)
 
         def _presence_entities() -> list:
+            # Filter to occupancy sensors: the entry also has a gateway
+            # connectivity binary_sensor, which is not a presence entity.
             return [
                 e
                 for e in er.async_entries_for_config_entry(registry, entry.entry_id)
                 if e.domain == "binary_sensor"
+                and e.original_device_class == BinarySensorDeviceClass.OCCUPANCY
             ]
 
         assert len(_presence_entities()) == 1


### PR DESCRIPTION
## Release 1.3.0b2

Second beta of 1.3.0. Headline change is a fix for **cover slat tilt disappearing after a gateway firmware update**, plus a fix for a test that `main` is currently red on, plus config-flow coverage. Rebased onto current `main` (includes #115/#116/#117).

---

### The fix — restore cover slat tilt

A user reported their blinds dropped to `supported_features: 15` (open/close/set_position/stop) with the tilt slider gone after updating to gateway FW 2.1.3.

**Root cause (integration side, not the tilt-reading logic).** The gateway only reports a cover as `PositionAndAngle` with an `angle` datapoint while its slat channel is visible (`device.states.angle.profile.visible` in the gateway middleware); otherwise it reports `Position` with no `angle`. The integration correctly gates HA's tilt features on the presence of that `angle` datapoint — that logic is unchanged since the cover platform was first added. But two compounding gaps made a transient loss permanent:

1. `supported_features` is computed **once** at entity construction.
2. `_discover_*` is **add-only** — it never revisits a device it has already created.

A firmware update re-enumerates devices and their datapoints can arrive across several polls, so the cover entity gets built in a window where `angle` is momentarily absent, locks in `supported_features: 15`, and never regains tilt without a reload.

**Fix.** A coordinator listener (`__init__._register_capability_reload`) reloads the entry when an already-seen device's capability fingerprint — `(function type, set of datapoint *types*)` — changes, rebuilding the entities. This also closes the **same latent gap** for lights (brightness/colour) and climate (off mode). The fingerprint keys on datapoint *types*, not values, so routine state pushes never trigger a reload (guarded by a dedicated test).

Docs added: the gateway's `angle.profile.visible → PositionAndAngle` mechanism (`docs/gateway-websocket.md`) and the capability-reload behaviour (`CLAUDE.md`).

### Also fixes a currently-red `main`

`test_presence_binary_sensor_rediscovery_is_idempotent` (added in #115) counts **all** `binary_sensor` entities and expects 1, but #117 added a per-entry gateway-connectivity binary_sensor — so it now counts 2 and fails on `main`. #117 merged after #115 without re-running against it. This PR narrows that test's filter to occupancy sensors so the connectivity sensor isn't miscounted.

---

### Comprehensive review of the 1.3.0 changes (`v1.2.2..main`)

Reviewed every non-dependency source change in 1.3.0:

| Area | Verdict |
|---|---|
| `config_flow.py` — connection-method menu, network-key **password** registration, host prefill, reconfigure, zeroconf dedup | **Solid.** Password is exchanged for a token and never stored; host normalization is sound; unique_id/abort handling correct across discovered/manual/reauth/reconfigure. |
| `coordinator.py` — REST groups fetch + `area_for_device` | **Solid.** Best-effort (never blocks setup), defensive JSON, `activate_scene` percent-encodes the untrusted id. |
| `__init__.py` — rooms→areas placement, synthetic gateway (hub) device (#117) | **Solid.** One-time per device, never overwrites a user's area. |
| `binary_sensor.py` — gateway connectivity sensor (#117) + presence | **Solid**; presence/numeric split via `is_presence_quantity`. |
| `cover.py` — awning device class | **Solid.** |
| `strings.json` / `translations/en.json` | **Complete and byte-identical**; no `<...>` markup. |

**Interaction check:** the new capability-reload can't be tripped spuriously — the WS `groups` broadcast doesn't fire coordinator listeners, and datapoint value-merges don't change the type fingerprint; the synthetic gateway device isn't in `coordinator.data` so it's never fingerprinted.

**Coverage added:** the new `_async_register_by_password` error branches (non-200 / transport / missing token) and the password-step host-error + zeroconf manual-dedup branches. `config_flow.py` 93% → 97% (remaining 4 lines are the pre-existing register/reauth `show_progress`-not-done branches, non-deterministic to unit-test).

---

### Validation (Python 3.14 / homeassistant 2026.7.4, matches CI)

- `pytest` (branch coverage on): **179 passed**, total **98.71%** (gate 95%).
- `mypy --strict`: clean. `ruff check` + `ruff format --check`: clean.
- All JSON valid; `strings.json` == `translations/en.json`.

hassfest + HACS validation run in CI.

---

### Releasing

After merge, tag the merge commit to trigger `release.yml` (marks it a pre-release from the `b2` suffix):

```sh
git tag v1.3.0b2 && git push origin v1.3.0b2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
