### PR TITLE
Release 1.3.0

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.3.0b2",
+  "version": "1.3.0",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
## Release 1.3.0 (stable)

Promotes `1.3.0b2` to a **stable** release. Manifest-only bump — no code change since b2 (already validated and CI-green on `main`).

Tagging `v1.3.0` (no pre-release suffix) publishes a full GitHub release, so HACS offers it to all users.

### Since 1.2.2
- **Config flow rework** — connection-method selection with mDNS discovery preserved and the host pre-filled; new **instant setup** via the gateway network-key password, no in-app approval (#107, #110).
- **Rooms → areas** — devices auto-placed into the HA area matching their gateway group (#106).
- **Awnings** — awning cover device class + per-cover inversion option (#105).
- **Gateway hub** — synthetic hub device with a connectivity binary_sensor (#117).
- **Fix** — roller-shutter/blind slat tilt could disappear after a firmware update; the entry now reloads to rebuild entity capabilities when a device's datapoint set changes (#118).

### After merge
```sh
git tag v1.3.0 && git push origin v1.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)