### PR TITLE
Thermostat: stop mapping the RTR switch datapoint to hvac_mode (fixes #121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,14 @@ JUNG HOME Gateway over its REST API and WebSocket.
     binary_sensor**, while other `quantity` datapoints become numeric sensors.
     `is_presence_quantity` (in `const.py`) is the single split point: the
     binary_sensor platform claims those labels and `sensor.py` skips them.
+    Likewise a **`Thermostat`'s `switch` datapoint is not an on/off**: the gateway
+    re-labels the RTR's `automatic_mode` state as type `switch`, and in the field
+    it tracks the regulator's momentary heating output — it flips on its own
+    several times an hour. A room regulator has no on/off at all, so the climate
+    entity is permanently `HVACMode.HEAT` (`hvac_modes = [HEAT]`) and that
+    datapoint only feeds `hvac_action` (heating/idle); never map it to
+    `hvac_mode` again (issue #121, evidence in
+    [docs/gateway-websocket.md](docs/gateway-websocket.md)).
     Scenes come from the WebSocket `scenes` broadcast and recall over REST
     (`POST /scenes/{id}`; the WebSocket `scene` command is unimplemented).
     **Cover position convention is confirmed against gateway firmware** — a

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Currently functional things:
 - Sockets - On/Off, energy statistics, etc.
 - Blinds / shutters (covers) - open/close/stop, position, and slat tilt. Awnings,
   which report position inverted, can be flagged in the integration's options.
-- Thermostats (room temperature regulators) - target temperature and presets.
+- Thermostats (room temperature regulators) - target temperature, presets, and
+  heating activity (`hvac_action`). The gateway offers no on/off for a regulator,
+  so these entities are heat-only; the **frost protection** preset is the closest
+  thing to "off".
 - Scenes - recall any Jung Home scene from Home Assistant.
 - Measurement sensors (e.g. ambient brightness on presence detectors).
 - IoT integration for Rocker Switches - allows triggering any script or automation in HomeAssistant via button presses.

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -48,10 +48,10 @@ def _capability_signature(device: Device) -> tuple[str | None, frozenset[str]]:
 
     The platforms freeze an entity's supported features from the datapoints
     present when it is first built (a cover's tilt, a light's brightness/colour,
-    a thermostat's off mode), and ``_discover_*`` is add-only — it never revisits
-    a device it has already created. So this fingerprint changing on an existing
-    device means its entities now carry a stale feature set, and the entry must be
-    reloaded to rebuild them. Only the datapoint *types* matter here (not their
+    a thermostat's heating action), and ``_discover_*`` is add-only — it never
+    revisits a device it has already created. So this fingerprint changing on an
+    existing device means its entities now carry a stale feature set, and the entry
+    must be reloaded to rebuild them. Only the datapoint *types* matter here (not their
     values), so a normal value push never changes the signature.
     """
     return (

--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -3,12 +3,25 @@
 A ``Thermostat`` function exposes three datapoints (see
 ``cdb_types_datapoints.json`` / ``cdb_types_functions.json``):
 
-- ``switch`` — on/off (``0`` / ``1``), mapped to HVAC mode OFF / HEAT.
 - ``temperature_ctrl`` — the target temperature in °C (range 5..30) plus a
   ``temperature_ctrl_preset`` key (``none`` / ``frost`` / ``eco`` / ``comfort``).
 - ``quantity`` — the room temperature reading, surfaced here as
   ``current_temperature``. (Sensor discovery does not turn a Thermostat's
   quantity into a standalone sensor entity; it is only the ambient reading.)
+- ``switch`` — despite the datapoint *type* name, **not** the thermostat's
+  on/off. It is the room regulator's momentary activity, surfaced here as
+  ``hvac_action`` (heating / idle), never as ``hvac_mode``.
+
+**The regulator has no on/off, so the entity is permanently ``HVACMode.HEAT``.**
+The gateway builds a Thermostat from exactly three device *states* — setpoint,
+ambient temperature and ``automatic_mode`` (``JungHome_Thermostat`` in
+``jung-home-device.js``) — and re-labels the third as a ``switch`` datapoint on
+the way to the API (``datapoint_helper_methods.js``). None of them turns the
+regulator off; the closest equivalent is the ``frost`` preset. Reading that
+datapoint as an off/on mode is what made every thermostat flip between ``off``
+and ``heat`` several times an hour while its configuration never changed (issue
+#121) — the value tracks the device's momentary heating output. Full firmware
+evidence is in the Thermostat note in ``docs/gateway-websocket.md``.
 """
 
 import logging
@@ -21,6 +34,7 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_NONE,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, Platform, UnitOfTemperature
@@ -52,6 +66,11 @@ _HA_TO_DEVICE_PRESET = {
     PRESET_COMFORT: "comfort",
 }
 _DEVICE_TO_HA_PRESET = {v: k for k, v in _HA_TO_DEVICE_PRESET.items()}
+
+# The Thermostat's ``switch`` datapoint value -> momentary HVAC action. Any other
+# value (notably the ``"NaN"`` the gateway sends for an offline device) leaves the
+# action unknown rather than asserting the regulator is heating.
+_SWITCH_TO_HVAC_ACTION = {"1": HVACAction.HEATING, "0": HVACAction.IDLE}
 
 
 async def async_setup_entry(
@@ -109,6 +128,11 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
     )
+    # A room regulator is heat-only and cannot be switched off through the
+    # gateway (see the module docstring), so the mode is a constant. HA requires
+    # a non-empty hvac_modes list, and validates set_hvac_mode against it.
+    _attr_hvac_modes = [HVACMode.HEAT]
+    _attr_hvac_mode = HVACMode.HEAT
 
     def __init__(
         self,
@@ -122,20 +146,15 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self._ctrl_datapoint_id = ctrl_datapoint["id"]
         self._name = device.get("label", "Jung Thermostat")
         self._attr_unique_id = stable_unique_id(device, ctrl_datapoint)
-        # The Thermostat function carries a `switch` datapoint for on/off; map it
-        # to HVAC OFF/HEAT. A thermostat without one (defensive) stays HEAT-only,
-        # and HA requires a non-empty hvac_modes list either way.
+        # The Thermostat function's `switch` datapoint is the regulator's
+        # momentary activity, not an on/off — it drives hvac_action only. A
+        # thermostat that doesn't report one leaves the action unknown.
         switch_dp = next(
             (dp for dp in device.get("datapoints", []) if dp.get("type") == "switch"),
             None,
         )
         self._switch_datapoint_id = switch_dp.get("id") if switch_dp else None
-        self._attr_hvac_modes = (
-            [HVACMode.OFF, HVACMode.HEAT]
-            if self._switch_datapoint_id is not None
-            else [HVACMode.HEAT]
-        )
-        self._attr_hvac_mode = self._get_hvac_mode_from_datapoint(switch_dp)
+        self._attr_hvac_action = self._get_hvac_action_from_datapoint(switch_dp)
         self._target_temperature = self._get_target_from_datapoint(ctrl_datapoint)
         self._preset_mode = self._get_preset_from_datapoint(ctrl_datapoint)
         self._current_temperature = self._get_current_temperature(device)
@@ -177,15 +196,15 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Turn the thermostat on (HEAT) or off via its switch datapoint."""
-        if self._switch_datapoint_id is None:
-            return  # no on/off control on this thermostat
-        if hvac_mode == HVACMode.OFF:
-            await self.coordinator.turn_off_switch(self._switch_datapoint_id)
-        else:
-            await self.coordinator.turn_on_switch(self._switch_datapoint_id)
-        self._attr_hvac_mode = hvac_mode
-        self.async_write_ha_state()
+        """Accept HEAT, the mode the regulator is permanently in.
+
+        There is nothing to send: the gateway exposes no on/off for a room
+        regulator (see the module docstring). HA validates the requested mode
+        against ``hvac_modes`` before calling this, so only HEAT ever arrives —
+        but the override still has to exist, or a card/automation re-asserting
+        "heat" would hit ``ClimateEntity``'s ``NotImplementedError``.
+        """
+        _LOGGER.debug("Thermostat %s is heat-only; ignoring set_hvac_mode", self._name)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -205,7 +224,7 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         if self._switch_datapoint_id is not None and self._should_refresh(
             self._switch_datapoint_id
         ):
-            self._attr_hvac_mode = self._get_hvac_mode_from_datapoint(
+            self._attr_hvac_action = self._get_hvac_action_from_datapoint(
                 self._find_datapoint(self._switch_datapoint_id)
             )
         # The ambient reading is read-only (never set optimistically), so always
@@ -213,11 +232,22 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self._current_temperature = self._get_current_temperature(device)
         self.async_write_ha_state()
 
-    def _get_hvac_mode_from_datapoint(self, datapoint: Datapoint | None) -> HVACMode:
-        """Map the switch datapoint to an HVAC mode (OFF only when explicitly off)."""
-        if datapoint is not None and datapoint_value(datapoint, "switch") == "0":
-            return HVACMode.OFF
-        return HVACMode.HEAT
+    def _get_hvac_action_from_datapoint(
+        self, datapoint: Datapoint | None
+    ) -> HVACAction | None:
+        """Map the ``switch`` datapoint to the regulator's momentary action.
+
+        ``1`` reads as HEATING and ``0`` as IDLE; a missing datapoint or any other
+        value (e.g. ``"NaN"`` for an offline device) leaves the action unknown.
+        Unlike ``hvac_mode`` this is an attribute, so the device's own heating
+        cycle no longer rewrites the entity *state* every few minutes.
+        """
+        if datapoint is None:
+            return None
+        value = datapoint_value(datapoint, "switch")
+        if value is None:
+            return None
+        return _SWITCH_TO_HVAC_ACTION.get(value)
 
     def _get_target_from_datapoint(self, datapoint: Datapoint | None) -> float | None:
         value = datapoint_value(datapoint, "temperature_ctrl")

--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.3.2b1",
+  "version": "1.3.2b2",
   "zeroconf": ["_junghome._tcp.local."]
 }

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -151,6 +151,30 @@ Common `values` keys by device type:
 > datapoint and reloads the entry when a device's datapoint set changes so the
 > capability is rebuilt (see `_register_capability_reload` in `__init__.py`).
 
+> **A Thermostat's `switch` datapoint is *not* the regulator's on/off — and a room
+> regulator has no on/off at all.** The middleware builds a `Thermostat` from
+> exactly three device states — `SetPoint`, `sensor_ambient_temperature` and
+> `AutomaticMode` (`jung-home-device.js`, `JungHome_Thermostat`) — and
+> `datapoint_helper_methods.js` re-labels the third one on the way out
+> (`case StateType.AutomaticMode: return DatapointType.Switch`), so it reaches the
+> API as an ordinary `switch` = `"0"` / `"1"` datapoint with nothing to
+> distinguish it from a light's or a socket's. Internally it is a Generic OnOff
+> `0x1000` server state the gateway reads as `"manu"` (0) / `"auto"` (1)
+> (`btmesh_get_datapoint_service.js`), and the RTR scheduler property
+> `LBC_PROP_RTR_SCHEDULER_ENABLE_ID` writes into that *same* state
+> (`handleThermostatAutomaticMode` in `btmesh_device_property_service.js`) — two
+> sources feeding one value. In the field it flips on its own several times an
+> hour, tracking the regulator's momentary heating output (these RTRs drive
+> heating with a ~15-minute PWM cycle) while setpoint, preset and ambient
+> temperature stay unchanged — see
+> [issue #121](https://github.com/ernetas/junghome/issues/121). Nothing in the
+> state set switches a regulator off, either: `Property_RTR_SensorHVAC_Mode`
+> exists in the middleware but is commented out and never exposed, so the `frost`
+> preset is the closest equivalent. The integration therefore reads this datapoint
+> as HA's `hvac_action` (`heating` / `idle`) only, holds `hvac_mode` at `heat`, and
+> never writes it. Treating it as an on/off is what made every thermostat entity
+> flap between `off` and `heat`.
+
 ### Other command types
 
 | `type` | Behaviour |

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2,9 +2,11 @@
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.components.climate.const import HVACMode
+import pytest
+from homeassistant.components.climate.const import HVACAction, HVACMode
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome.climate import JungHomeClimate
@@ -69,15 +71,32 @@ async def test_climate_created(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes["preset_mode"] == "comfort"
     # Current temperature read from the sibling °C quantity datapoint.
     assert state.attributes["current_temperature"] == 20.0
-    # The switch datapoint (value "1") maps to HVAC HEAT, with OFF available.
+    # A room regulator is heat-only: HEAT is the only mode, and the switch
+    # datapoint (value "1") shows up as the momentary action instead.
     assert state.state == "heat"
-    assert set(state.attributes["hvac_modes"]) == {"off", "heat"}
+    assert state.attributes["hvac_modes"] == ["heat"]
+    assert state.attributes["hvac_action"] == "heating"
 
 
-async def test_climate_hvac_on_off(hass: HomeAssistant, init_integration) -> None:
-    """HVAC OFF / HEAT drives the thermostat's switch datapoint."""
-    coordinator = init_integration.runtime_data
+async def test_climate_hvac_off_is_rejected(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The thermostat advertises no OFF mode, so HA rejects a request for one."""
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": "climate.living_room", "hvac_mode": "off"},
+            blocking=True,
+        )
     assert hass.states.get("climate.living_room").state == "heat"
+
+
+async def test_climate_set_hvac_mode_heat_sends_nothing(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Re-asserting HEAT is accepted but never writes the switch datapoint."""
+    coordinator = init_integration.runtime_data
     with (
         patch.object(coordinator, "turn_off_switch", AsyncMock()) as off,
         patch.object(coordinator, "turn_on_switch", AsyncMock()) as on,
@@ -85,37 +104,49 @@ async def test_climate_hvac_on_off(hass: HomeAssistant, init_integration) -> Non
         await hass.services.async_call(
             "climate",
             "set_hvac_mode",
-            {"entity_id": "climate.living_room", "hvac_mode": "off"},
-            blocking=True,
-        )
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
             {"entity_id": "climate.living_room", "hvac_mode": "heat"},
             blocking=True,
         )
-    off.assert_called_once_with("idrtr1-000")
-    on.assert_called_once_with("idrtr1-000")
+    off.assert_not_called()
+    on.assert_not_called()
+    assert hass.states.get("climate.living_room").state == "heat"
 
 
-async def test_climate_hvac_mode_follows_switch_echo(
+async def test_switch_echo_moves_hvac_action_not_state(
     hass: HomeAssistant, init_integration
 ) -> None:
-    """A switch=0 echo flips the thermostat to OFF without touching target/preset."""
+    """Regression for #121: the regulator's own cycling must not change the state.
+
+    The gateway's Thermostat `switch` datapoint tracks momentary heating activity
+    (it flips several times an hour on its own), so it may only move
+    ``hvac_action`` — mapping it to ``hvac_mode`` flooded the logbook and fired
+    every ``climate.*`` state automation.
+    """
     coordinator = init_integration.runtime_data
-    assert hass.states.get("climate.living_room").state == "heat"
-    coordinator._handle_websocket_message(
-        {
-            "type": "datapoint",
-            "data": {"id": "idrtr1-000", "values": [{"key": "switch", "value": "0"}]},
-        }
-    )
-    await hass.async_block_till_done()
     state = hass.states.get("climate.living_room")
-    assert state.state == "off"
-    # Target temperature/preset unchanged by the switch echo.
-    assert state.attributes["temperature"] == 21.5
-    assert state.attributes["preset_mode"] == "comfort"
+    assert (state.state, state.attributes["hvac_action"]) == ("heat", "heating")
+    last_changed = state.last_changed
+
+    for value, action in (("0", "idle"), ("1", "heating"), ("0", "idle")):
+        coordinator._handle_websocket_message(
+            {
+                "type": "datapoint",
+                "data": {
+                    "id": "idrtr1-000",
+                    "values": [{"key": "switch", "value": value}],
+                },
+            }
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get("climate.living_room")
+        assert state.state == "heat"
+        assert state.attributes["hvac_action"] == action
+        # An attribute-only change leaves last_changed alone, which is exactly
+        # what keeps the logbook (and state triggers) quiet.
+        assert state.last_changed == last_changed
+        # Target temperature/preset unchanged by the switch echo.
+        assert state.attributes["temperature"] == 21.5
+        assert state.attributes["preset_mode"] == "comfort"
 
 
 async def test_climate_commands(hass: HomeAssistant, init_integration) -> None:
@@ -140,17 +171,22 @@ async def test_climate_commands(hass: HomeAssistant, init_integration) -> None:
     assert sp.call_args.args[1] == "eco"
 
 
-async def test_climate_hvac_mode_from_switch_value(hass: HomeAssistant) -> None:
-    """Switch 1/0 maps to HEAT/OFF; a thermostat without a switch stays HEAT-only."""
+async def test_climate_hvac_action_from_switch_value(hass: HomeAssistant) -> None:
+    """Switch 1/0 maps to HEATING/IDLE; anything else leaves the action unknown."""
     coord = _bare_coordinator(hass)
-    on = _climate(coord, switch="1")
-    assert on._attr_hvac_mode == HVACMode.HEAT
-    assert set(on._attr_hvac_modes) == {HVACMode.OFF, HVACMode.HEAT}
-    off = _climate(coord, switch="0")
-    assert off._attr_hvac_mode == HVACMode.OFF
-    none = _climate(coord)  # no switch datapoint
+    heating = _climate(coord, switch="1")
+    assert heating.hvac_action == HVACAction.HEATING
+    assert heating.hvac_mode == HVACMode.HEAT
+    assert heating.hvac_modes == [HVACMode.HEAT]
+    assert _climate(coord, switch="0").hvac_action == HVACAction.IDLE
+    # The gateway reports "NaN" for an offline device: unknown, not heating.
+    assert _climate(coord, switch="NaN").hvac_action is None
+    none = _climate(coord)  # no switch datapoint at all
     assert none._switch_datapoint_id is None
-    assert none._attr_hvac_modes == [HVACMode.HEAT]
+    assert none.hvac_action is None
+    assert none.hvac_mode == HVACMode.HEAT
+    # A switch datapoint with no `switch` key is unknown too.
+    assert none._get_hvac_action_from_datapoint({"id": "x", "values": []}) is None
 
 
 async def test_climate_extractors_defensive(hass: HomeAssistant) -> None:
@@ -236,13 +272,31 @@ async def test_climate_unknown_preset_noops(hass: HomeAssistant) -> None:
     sp.assert_not_called()
 
 
-async def test_switchless_thermostat_hvac_mode_is_noop(hass: HomeAssistant) -> None:
-    """A thermostat without a switch datapoint accepts set_hvac_mode but sends nothing."""
+async def test_set_hvac_mode_never_writes_the_switch_datapoint(
+    hass: HomeAssistant,
+) -> None:
+    """set_hvac_mode is inert: the regulator has no on/off to command."""
     coordinator = _bare_coordinator(hass)
-    climate = _climate(coordinator)  # no switch datapoint
+    climate = _climate(coordinator, switch="1")
     with patch.object(coordinator, "send_websocket_message", AsyncMock()) as send:
         await climate.async_set_hvac_mode(HVACMode.HEAT)  # must not raise
     send.assert_not_called()
+    assert climate.hvac_action == HVACAction.HEATING
+
+
+async def test_climate_poll_refreshes_hvac_action(hass: HomeAssistant) -> None:
+    """A REST poll (no pushed datapoint) re-reads the action from the device data."""
+    coordinator = _bare_coordinator(hass)
+    climate = _climate(coordinator, switch="1")
+    coordinator.data = [climate._device]
+    assert climate.hvac_action == HVACAction.HEATING
+    switch_dp = next(
+        dp for dp in climate._device["datapoints"] if dp["type"] == "switch"
+    )
+    switch_dp["values"] = [{"key": "switch", "value": "0"}]
+    with patch.object(climate, "async_write_ha_state"):
+        climate._handle_coordinator_update()
+    assert climate.hvac_action == HVACAction.IDLE
 
 
 async def test_climate_handle_update_missing_device_noops(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## The bug

Every thermostat entity flipped between `heat` and `off` on its own, cycles as short as ~40 s, across all of the reporter's 10 room regulators — flooding the logbook/recorder and firing every automation keyed on `climate.*` state. Reported in #121 with a very good debug trace: only the `switch` datapoint moved, while setpoint (18 °C), preset (`eco`) and ambient temperature (22.5 °C — i.e. no heating demand) never changed.

## Why

The `switch` datapoint the gateway reports for a `Thermostat` is **not** an on/off. From the gateway middleware:

- `JungHome_Thermostat` (`models/jung-home-device.js`) has exactly three states: `SetPoint`, `sensor_ambient_temperature`, `AutomaticMode`.
- `util/datapoint_helper_methods.js` re-labels the third on the way to the API: `case StateType.AutomaticMode: return DatapointType.Switch` — so it arrives as a plain `switch` = `"0"`/`"1"`, indistinguishable from a light's or a socket's.
- Internally it is a Generic OnOff `0x1000` **server** state that the gateway interprets as `"manu"` (0) / `"auto"` (1) (`services/btmesh_get_datapoint_service.js`), and the RTR scheduler property `LBC_PROP_RTR_SCHEDULER_ENABLE_ID` writes into that *same* state (`handleThermostatAutomaticMode`) — two sources feeding one value.
- Nothing in the state set switches a regulator off. `Property_RTR_SensorHVAC_Mode` exists in the middleware but is commented out and never exposed.

Empirically (#121) the value tracks the regulator's **momentary heating output** — these RTRs drive heating with a ~15-minute PWM cycle — not any configuration. Either way it must not drive the entity state.

## The change

- `hvac_modes` is now `[heat]` and `hvac_mode` a constant → **the flapping is gone**. `frost` remains the preset that stands in for "off".
- The datapoint feeds **`hvac_action`** instead (`heating` / `idle`; unknown for the `"NaN"` the gateway sends for an offline device). It's an attribute, so a heating cycle no longer rewrites the state, keeps the logbook clean and leaves `to:`/`from:` state automations alone.
- `set_hvac_mode` writes nothing; HA rejects `off` up front rather than writing a datapoint that never meant "off".
- Firmware evidence written up in `docs/gateway-websocket.md` alongside the cover-position and slat-tilt notes; `CLAUDE.md` gained a "never map this to hvac_mode again" note.

## Behaviour change for users

Thermostats that currently read `off` will read `heat` after upgrading, and `climate.set_hvac_mode: off` on a JUNG regulator now raises a validation error instead of silently doing the wrong thing. Use the **frost protection** preset (or a low setpoint) for "off".

## Tests

- Regression test for #121: three consecutive `switch` echoes move `hvac_action` only, state stays `heat`, target/preset untouched.
- `off` is rejected; `set_hvac_mode: heat` sends nothing; `1`/`0`/`NaN`/absent → `heating`/`idle`/unknown/unknown; REST-poll refresh path.
- Full suite green (189 tests), `mypy --strict` clean, ruff clean, branch coverage unchanged (climate.py 99%, same two pre-existing partials).

## Open question for the reporter

@kfyjb74sg6-png — the beta reads `1` as **heating** and `0` as **idle**, following your observation. Since the gateway's own name for the state is "automatic mode", could you confirm on `v1.3.2b2` that `hvac_action` matches when your radiators actually run? If it turns out to track the scheduler instead, that mapping is the one thing left to adjust.

Ships as pre-release **1.3.2b2**.

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)