### PR TITLE
Add device triggers for rocker buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,12 @@ to point at the new address.
 # Button automations (rocker switches)
 
 Rocker buttons show up as Home Assistant **event entities** (one per up/down
-side). The gateway only reports raw press/release, so single/double/hold gestures
-are derived in an automation — a ready-made **blueprint** does this for you:
+side), and each button also offers **device triggers** — open the button's device
+page, add an automation, and pick e.g. *"Up button pressed"*. That's the quickest
+route for a simple "press this, do that" automation.
+
+The gateway only reports raw press/release, so single/double/hold gestures are
+derived in an automation — a ready-made **blueprint** does this for you:
 
 - Blueprint: [`blueprints/automation/junghome/button_gestures.yaml`](blueprints/automation/junghome/button_gestures.yaml)
 - Full guide + copy-paste recipes: [`docs/example-button-automation.md`](docs/example-button-automation.md)

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -17,6 +17,31 @@ DOMAIN = "junghome"
 # registered description always matches the event actually fired.
 EVENT_SCENE_RECALLED = f"{DOMAIN}_scene_recalled"
 
+# Fired on every genuine rocker-button edge the gateway pushes. The event
+# entities already expose those edges, but a device trigger has to attach to
+# something on the *bus* (this is how HA's own button integrations do it — see
+# Shelly and Hue), so the button platform re-emits each edge here and
+# ``device_trigger`` matches on it.
+EVENT_BUTTON_ACTION = f"{DOMAIN}_button_action"
+
+# Device-trigger vocabulary.
+#
+# ``type`` is which side of the rocker fired and ``subtype`` is the raw edge.
+# The gateway reports only press/release — it has no native single/double/hold —
+# so those two edges are all a device trigger can honestly offer; gestures are
+# still derived in an automation (see the shipped blueprint).
+CONF_SUBTYPE = "subtype"
+
+# Rocker datapoint type -> button side. Also drives the event entities'
+# translation keys, so both surfaces name a given side identically.
+BUTTON_DATAPOINT_TYPES = {
+    "up_request": "up",
+    "down_request": "down",
+    "trigger_request": "press",
+}
+BUTTON_TRIGGER_TYPES = set(BUTTON_DATAPOINT_TYPES.values())
+BUTTON_TRIGGER_SUBTYPES = {"pressed", "depressed"}
+
 # Presentation of the synthetic gateway (hub) device. Kept as constants so the
 # up-front registration in ``__init__`` and the connectivity sensor that lives on
 # the device describe it identically (see ``gateway_device_info``).

--- a/custom_components/junghome/device_trigger.py
+++ b/custom_components/junghome/device_trigger.py
@@ -1,0 +1,169 @@
+"""Device triggers for Jung Home rocker buttons.
+
+Rocker buttons are already exposed as ``event`` entities, but those only show up
+in the *entity* automation picker. Device triggers put "Button A — up pressed"
+directly in the device's automation UI, which is where users look first for a
+wall switch.
+
+A device trigger can only attach to something on the Home Assistant bus, so the
+event platform re-emits every genuine edge as ``EVENT_BUTTON_ACTION`` and the
+triggers here are thin wrappers that match it (the same shape HA's own button
+integrations use). The gateway reports only press/release — there is no native
+single/double/hold — so those two edges are all that is offered here; gestures
+are still derived in an automation via the shipped blueprint.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_EVENT_DATA,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.helpers import device_registry as dr
+
+from .const import (
+    BUTTON_DATAPOINT_TYPES,
+    BUTTON_TRIGGER_SUBTYPES,
+    BUTTON_TRIGGER_TYPES,
+    CONF_SUBTYPE,
+    DOMAIN,
+    EVENT_BUTTON_ACTION,
+    device_slug,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+    from homeassistant.helpers.typing import ConfigType
+
+    from .coordinator import JungHomeDataUpdateCoordinator
+    from .models import Device
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(BUTTON_TRIGGER_TYPES),
+        vol.Required(CONF_SUBTYPE): vol.In(BUTTON_TRIGGER_SUBTYPES),
+    }
+)
+
+
+def _gateway_device(hass: HomeAssistant, device_id: str) -> Device | None:
+    """Return the gateway device backing a Home Assistant device id.
+
+    Device identity is label-derived (see ``device_slug``), so the registry entry
+    is matched back to the coordinator's device list by slug rather than by the
+    gateway's volatile id.
+    """
+    device_entry = dr.async_get(hass).async_get(device_id)
+    if device_entry is None:
+        return None
+    slugs = {
+        identifier
+        for domain, identifier in device_entry.identifiers
+        if domain == DOMAIN
+    }
+    if not slugs:
+        return None
+    for entry_id in device_entry.config_entries:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            continue
+        # `runtime_data` is only set while the entry is loaded.
+        coordinator: JungHomeDataUpdateCoordinator | None = getattr(
+            entry, "runtime_data", None
+        )
+        if coordinator is None:
+            continue
+        devices: list[Device] = coordinator.data or []
+        for device in devices:
+            if device_slug(device) in slugs:
+                return device
+    return None
+
+
+def _button_types(device: Device) -> list[str]:
+    """Return the button sides a device exposes, in a stable order."""
+    present = {
+        side
+        for datapoint in device.get("datapoints", [])
+        if (side := BUTTON_DATAPOINT_TYPES.get(datapoint.get("type", ""))) is not None
+    }
+    # Order by the canonical map rather than set iteration, so the automation UI
+    # lists a device's buttons the same way every time.
+    return [side for side in BUTTON_DATAPOINT_TYPES.values() if side in present]
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, Any]]:
+    """List the triggers a Jung Home device offers."""
+    device = _gateway_device(hass, device_id)
+    if device is None or device.get("type") != "RockerSwitch":
+        return []
+    return [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: button_type,
+            CONF_SUBTYPE: subtype,
+        }
+        for button_type in _button_types(device)
+        # Sorted so the two edges are always offered in the same order.
+        for subtype in sorted(BUTTON_TRIGGER_SUBTYPES)
+    ]
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate a trigger against what the device actually exposes."""
+    config = TRIGGER_SCHEMA(config)
+    device = _gateway_device(hass, config[CONF_DEVICE_ID])
+    # An unavailable device (gateway offline, entry not loaded) can't be checked;
+    # accept the config rather than break an existing automation on a restart.
+    if device is None:
+        return config
+    if config[CONF_TYPE] not in _button_types(device):
+        raise InvalidDeviceAutomationConfig(
+            translation_domain=DOMAIN,
+            translation_key="invalid_trigger",
+            translation_placeholders={
+                "trigger": f"{config[CONF_TYPE]} {config[CONF_SUBTYPE]}"
+            },
+        )
+    return config
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger by listening for the matching button event."""
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: EVENT_BUTTON_ACTION,
+            CONF_EVENT_DATA: {
+                CONF_DEVICE_ID: config[CONF_DEVICE_ID],
+                CONF_TYPE: config[CONF_TYPE],
+                CONF_SUBTYPE: config[CONF_SUBTYPE],
+            },
+        }
+    )
+    return await event_trigger.async_attach_trigger(
+        hass, event_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -3,11 +3,17 @@
 import logging
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
-from homeassistant.const import Platform
+from homeassistant.const import CONF_DEVICE_ID, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import datapoint_value, stable_unique_id
+from .const import (
+    BUTTON_DATAPOINT_TYPES,
+    CONF_SUBTYPE,
+    EVENT_BUTTON_ACTION,
+    datapoint_value,
+    stable_unique_id,
+)
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 from .entity import JungHomeEntity, claim_new_entity
 from .models import Datapoint, Device
@@ -20,12 +26,9 @@ PARALLEL_UPDATES = 0
 # Translation keys per rocker datapoint type. With `_attr_has_entity_name`, HA
 # prepends the device name; the entity name itself comes from the
 # `entity.event.*` translations (strings.json), so it's localisable rather than
-# hardcoded.
-_EVENT_TRANSLATION_KEYS = {
-    "up_request": "up",
-    "down_request": "down",
-    "trigger_request": "press",
-}
+# hardcoded. Shared with `device_trigger` (see BUTTON_DATAPOINT_TYPES) so a
+# button side is named the same in both surfaces.
+_EVENT_TRANSLATION_KEYS = BUTTON_DATAPOINT_TYPES
 
 
 async def async_setup_entry(
@@ -114,7 +117,33 @@ class JungHomeEventEntity(JungHomeEntity, EventEntity):
                 )
                 _LOGGER.debug("Triggering %s event for %s", event_type, self.entity_id)
                 self._trigger_event(event_type)
+                self._fire_bus_event(event_type)
         self.async_write_ha_state()
+
+    @callback
+    def _fire_bus_event(self, event_type: str) -> None:
+        """Re-emit this edge on the Home Assistant bus for device triggers.
+
+        Device triggers can only attach to a bus event, not to an entity, so the
+        edge is published a second time here (this mirrors how HA's own button
+        integrations do it). Skipped for a datapoint type with no button side, and
+        when the entity is not yet in the device registry — a device trigger is
+        keyed on the device id, so an event without one would match nothing.
+        """
+        button_type = _EVENT_TRANSLATION_KEYS.get(self._datapoint.get("type", ""))
+        device_entry = self.device_entry
+        if button_type is None or device_entry is None:
+            return
+        self.hass.bus.async_fire(
+            EVENT_BUTTON_ACTION,
+            {
+                CONF_DEVICE_ID: device_entry.id,
+                CONF_TYPE: button_type,
+                CONF_SUBTYPE: event_type,
+                "entity_id": self.entity_id,
+                "device_name": device_entry.name_by_user or device_entry.name,
+            },
+        )
 
     def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
         """Extract state from datapoint values. Returns True if pressed.

--- a/custom_components/junghome/strings.json
+++ b/custom_components/junghome/strings.json
@@ -92,9 +92,22 @@
       "no_covers": "No covers were found on this gateway, so there is nothing to configure."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Up button {subtype}",
+      "down": "Down button {subtype}",
+      "press": "Button {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "pressed",
+      "depressed": "released"
+    }
+  },
   "entity": {
     "binary_sensor": {
-      "gateway_connectivity": { "name": "Connection" }
+      "gateway_connectivity": {
+        "name": "Connection"
+      }
     },
     "climate": {
       "thermostat": {
@@ -108,12 +121,20 @@
       }
     },
     "event": {
-      "up": { "name": "Up" },
-      "down": { "name": "Down" },
-      "press": { "name": "Press" }
+      "up": {
+        "name": "Up"
+      },
+      "down": {
+        "name": "Down"
+      },
+      "press": {
+        "name": "Press"
+      }
     },
     "switch": {
-      "status_led": { "name": "Status LED" }
+      "status_led": {
+        "name": "Status LED"
+      }
     }
   },
   "exceptions": {
@@ -131,6 +152,9 @@
     },
     "scene_not_found": {
       "message": "The Jung Home scene {label} is no longer available on the gateway."
+    },
+    "invalid_trigger": {
+      "message": "The Jung Home device does not support the trigger {trigger}."
     }
   }
 }

--- a/custom_components/junghome/translations/en.json
+++ b/custom_components/junghome/translations/en.json
@@ -92,9 +92,22 @@
       "no_covers": "No covers were found on this gateway, so there is nothing to configure."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Up button {subtype}",
+      "down": "Down button {subtype}",
+      "press": "Button {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "pressed",
+      "depressed": "released"
+    }
+  },
   "entity": {
     "binary_sensor": {
-      "gateway_connectivity": { "name": "Connection" }
+      "gateway_connectivity": {
+        "name": "Connection"
+      }
     },
     "climate": {
       "thermostat": {
@@ -108,12 +121,20 @@
       }
     },
     "event": {
-      "up": { "name": "Up" },
-      "down": { "name": "Down" },
-      "press": { "name": "Press" }
+      "up": {
+        "name": "Up"
+      },
+      "down": {
+        "name": "Down"
+      },
+      "press": {
+        "name": "Press"
+      }
     },
     "switch": {
-      "status_led": { "name": "Status LED" }
+      "status_led": {
+        "name": "Status LED"
+      }
     }
   },
   "exceptions": {
@@ -131,6 +152,9 @@
     },
     "scene_not_found": {
       "message": "The Jung Home scene {label} is no longer available on the gateway."
+    },
+    "invalid_trigger": {
+      "message": "The Jung Home device does not support the trigger {trigger}."
     }
   }
 }

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -1,0 +1,142 @@
+"""Device-trigger tests for Jung Home rocker buttons."""
+
+import pytest
+from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_get_device_automations
+
+from custom_components.junghome.const import CONF_SUBTYPE, DOMAIN
+from custom_components.junghome.device_trigger import async_validate_trigger_config
+
+
+def _device_id(hass: HomeAssistant, slug: str) -> str:
+    """Return the HA device id for a Jung Home device slug."""
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, slug)})
+    assert device is not None
+    return device.id
+
+
+def _press(coordinator, value: str = "1") -> None:
+    """Push an up_request edge for the fixture's rocker (Button A)."""
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idrock1-00c",
+                "values": [{"key": "up_request", "value": value}],
+            },
+        }
+    )
+
+
+async def test_get_triggers_lists_each_button_side_and_edge(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A rocker offers both its sides, each with a pressed/released edge."""
+    device_id = _device_id(hass, "button_a")
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_id
+    )
+    ours = [t for t in triggers if t.get(CONF_DOMAIN) == DOMAIN]
+    # The fixture's Button A exposes up_request + down_request (and a status LED,
+    # which is not a button), so: 2 sides x 2 edges.
+    assert {(t[CONF_TYPE], t[CONF_SUBTYPE]) for t in ours} == {
+        ("up", "pressed"),
+        ("up", "depressed"),
+        ("down", "pressed"),
+        ("down", "depressed"),
+    }
+
+
+async def test_non_button_device_offers_no_triggers(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A device that is not a RockerSwitch contributes no button triggers."""
+    device_id = _device_id(hass, "hall_light")
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_id
+    )
+    assert [t for t in triggers if t.get(CONF_DOMAIN) == DOMAIN] == []
+
+
+async def test_trigger_fires_on_matching_press(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """An automation using the device trigger runs when that edge is pushed."""
+    device_id = _device_id(hass, "button_a")
+    fired: list[str] = []
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_id,
+                        CONF_TYPE: "up",
+                        CONF_SUBTYPE: "pressed",
+                    },
+                    "action": {
+                        "event": "junghome_test_fired",
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.bus.async_listen("junghome_test_fired", lambda e: fired.append("x"))
+
+    coordinator = init_integration.runtime_data
+    _press(coordinator, "1")
+    await hass.async_block_till_done()
+    assert len(fired) == 1
+
+    # The opposite edge must NOT run this automation.
+    _press(coordinator, "0")
+    await hass.async_block_till_done()
+    assert len(fired) == 1
+
+
+async def test_invalid_trigger_is_rejected(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A button side the device does not expose fails validation."""
+    device_id = _device_id(hass, "button_a")
+    # The fixture's rocker has no `trigger_request` datapoint, so "press" is not
+    # a valid side for it.
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await async_validate_trigger_config(
+            hass,
+            {
+                CONF_PLATFORM: "device",
+                CONF_DOMAIN: DOMAIN,
+                CONF_DEVICE_ID: device_id,
+                CONF_TYPE: "press",
+                CONF_SUBTYPE: "pressed",
+            },
+        )
+
+
+async def test_validate_accepts_config_for_unknown_device(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """An unresolvable device is accepted, so a restart can't break automations."""
+    config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DOMAIN,
+        CONF_DEVICE_ID: "does-not-exist",
+        CONF_TYPE: "up",
+        CONF_SUBTYPE: "pressed",
+    }
+    assert await async_validate_trigger_config(hass, config) == config


### PR DESCRIPTION
Rocker buttons were only reachable from the *entity* automation picker, via their event entities. Device triggers put "Button A — up pressed" directly on the device's automation page, which is where users look first for a wall switch, and remove the need to know that event entities exist.

A device trigger can only attach to something on the bus, so the event platform re-emits each genuine press/release edge as a junghome_button_action event and the triggers are thin wrappers matching it. This is the same shape Home Assistant's own button integrations use (Shelly, Hue), and it mirrors the existing junghome_scene_recalled event.

Only press/release are offered, because that is all the gateway reports — it has no native single/double/hold. Gestures are still derived in an automation via the shipped blueprint, which is unchanged.

- const.py: EVENT_BUTTON_ACTION plus the shared trigger vocabulary. The datapoint-type -> button-side map moves here so the event entities' names and the trigger types cannot drift apart.
- event.py: re-emit each edge on the bus. Skipped when the entity has no device-registry entry yet, since a trigger keyed on device id would never match such an event.
- device_trigger.py: enumerate, validate and attach. A device whose entry is unloaded validates as OK rather than raising, so a restart cannot break an existing automation.
- strings.json / translations/en.json: trigger names and the invalid_trigger message.
- README: document the new route.