### PR TITLE
Don't add a discovered gateway twice when its host is typed manually

### DIFF
--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TOKEN, Platform
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -246,6 +247,15 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         host = _normalize_host(raw_host)
         if not host:
             return "invalid_host"
+        # unique_id alone does not catch every duplicate: a gateway discovered
+        # over mDNS is keyed by its *hostname*, so typing that same gateway's IP
+        # here would claim a different unique_id and add it a second time. Match
+        # on the stored host too — the same check `async_step_zeroconf` and
+        # `async_step_reconfigure` already apply from the other direction.
+        if any(
+            entry.data.get(CONF_HOST) == host for entry in self._async_current_entries()
+        ):
+            raise AbortFlow("already_configured")
         self._host = host
         # Populate the {host} flow_title placeholder for later steps.
         self.context["title_placeholders"] = {"host": host}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -165,6 +165,77 @@ async def test_user_flow_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
+async def test_manual_host_aborts_when_gateway_discovered_under_hostname(
+    hass: HomeAssistant,
+) -> None:
+    """Typing a discovered gateway's IP must not add it a second time.
+
+    A zeroconf-discovered entry is keyed by its mDNS *hostname*, so the manual
+    flow's `async_set_unique_id(host)` claims a different id for the same
+    gateway and nothing aborts on unique_id alone.
+    """
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="junghome-abc.local",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await _choose(hass, result, "app_approval")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "1.2.3.4"}
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_manual_password_host_aborts_when_discovered_under_hostname(
+    hass: HomeAssistant,
+) -> None:
+    """The password step is the other `_async_apply_host` caller."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="junghome-abc.local",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await _choose(hass, result, "password")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "1.2.3.4", "password": "secret"}
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_manual_host_proceeds_when_no_entry_uses_it(
+    hass: HomeAssistant,
+) -> None:
+    """A different host must still be accepted (the guard must not over-abort)."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="junghome-abc.local",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await _choose(hass, result, "app_approval")
+    fetch, run_ws = _no_network()
+    with patch(_REGISTER, AsyncMock(return_value="tok")), fetch, run_ws:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "5.6.7.8"}
+        )
+        result = await _advance_progress(hass, result)
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == "5.6.7.8"
+
+
 def _zeroconf_info(hostname: str = "junghome-abc.local.") -> ZeroconfServiceInfo:
     return ZeroconfServiceInfo(
         ip_address="1.2.3.4",


### PR DESCRIPTION
## The bug

`_async_apply_host` claimed a unique_id but never cross-checked the host against existing entries:

```python
if not self._discovered:
    await self.async_set_unique_id(host)
    self._abort_if_unique_id_configured()
```

A gateway discovered over mDNS is keyed by its **hostname** (`async_step_zeroconf` sets `unique_id = junghome-abc.local`). Typing that same gateway's **IP** into the manual flow claims a *different* unique_id, so `_abort_if_unique_id_configured()` finds no match and the gateway is added a second time — duplicate config entries and a duplicate set of entities for every device behind it.

The other two paths already guard against this from the opposite direction: `async_step_zeroconf` skips gateways added manually, and `async_step_reconfigure` rejects a host another entry already uses. The manual path was the remaining hole.

## The fix

Match on the stored host as well, mirroring those two checks:

```python
if any(entry.data.get(CONF_HOST) == host
       for entry in self._async_current_entries()):
    raise AbortFlow("already_configured")
```

`AbortFlow` propagates out of the step exactly like the `_abort_if_unique_id_configured()` call already in the same helper, so both callers (`app_approval` and `password`) abort cleanly with the existing `already_configured` reason. No new strings, so no translation changes.

Reauth is unaffected — it sets `self._host` from entry data and never routes through this helper.

## Tests

Three added to `tests/test_config_flow.py`:

- discovered-under-hostname gateway, IP typed in the **app_approval** step → aborts
- same via the **password** step (the other caller)
- a genuinely new host still creates the entry — guards against over-aborting

The first two **fail on `main`** and pass here, so they pin the regression:

```
FAILED test_manual_host_aborts_when_gateway_discovered_under_hostname
FAILED test_manual_password_host_aborts_when_discovered_under_hostname
```

Verified: `mypy --strict` clean, ruff clean, 192 tests pass, coverage 98.31%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoLaQY1DE3kFH4ze4NtBAL