### PR TITLE
Verify the gateway is reachable before committing a reconfigured host

### DIFF
--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -27,6 +27,11 @@ _LOGGER = logging.getLogger(__name__)
 REGISTER_TIMEOUT = 190
 REGISTER_USER_NAME = "Home Assistant"
 
+# Reachability check on the reconfigure form. Kept short: the user is sitting in
+# front of the dialog, and an unreachable host should fail fast enough that
+# retyping it feels immediate.
+PROBE_TIMEOUT = 10
+
 # The gateway's generic mDNS hostname (also its TLS certificate CN). Offered as
 # the default host so most users need not look up the gateway's IP. It only
 # resolves if the network maps it; the reliable name is the per-device mDNS
@@ -385,6 +390,10 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         The existing token still works for the same gateway at a new address; if
         it points at a different gateway, the next refresh triggers reauth.
+
+        The new address is probed before it is stored (connect-then-commit): a
+        typo used to be accepted silently and only surfaced later as a confusing
+        connect/reauth failure, with nothing tying it back to this edit.
         """
         entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
@@ -397,6 +406,10 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 for other in self._async_current_entries()
             ):
                 return self.async_abort(reason="already_configured")
+            elif probe_error := await self._async_probe_host(
+                host, entry.data.get(CONF_TOKEN, "")
+            ):
+                errors["base"] = probe_error
             else:
                 # Update the stored host and let the `add_update_listener` reload
                 # the entry exactly once (the host change makes its guard pass).
@@ -446,6 +459,35 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             menu_options=["app_approval", "password"],
             description_placeholders={"host": self._host or ""},
         )
+
+    async def _async_probe_host(self, host: str, token: str) -> str | None:
+        """Check that a Jung Home gateway answers at ``host``.
+
+        Returns an error key to show, or None when the address is usable.
+
+        This deliberately tests **reachability only**: any HTTP reply proves a
+        gateway is listening and the address is typed correctly, so a 401/403 is
+        accepted here. A rejected token means the address now points at a
+        different gateway (or the token was revoked), which the reauth flow
+        already handles on the next refresh — failing the form for it would just
+        strand the user on a screen that cannot fix it.
+        """
+        # Shared HA session; verify_ssl=False tolerates the gateway's self-signed
+        # cert without building an SSL context on the event loop.
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        url = f"https://{host}/api/junghome/functions"
+        headers = {"token": token, "Content-Type": "application/json"}
+        try:
+            async with (
+                asyncio.timeout(PROBE_TIMEOUT),
+                session.get(url, headers=headers),
+            ):
+                # No raise_for_status(): a status-based failure still means the
+                # host is reachable, which is all this probe asserts.
+                return None
+        except (TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.debug("Jung Home gateway probe failed for %s: %s", host, err)
+            return "cannot_connect"
 
     async def _async_register(self) -> str:
         """POST the registration request and return the issued token.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -315,7 +315,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
     assert entry.data[CONF_TOKEN] == "new-tok"
 
 
-async def test_reconfigure_flow(hass: HomeAssistant) -> None:
+async def test_reconfigure_flow(hass: HomeAssistant, aioclient_mock) -> None:
     """Reconfigure updates the gateway host in place."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -323,6 +323,7 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"},
     )
     entry.add_to_hass(hass)
+    aioclient_mock.get("https://5.6.7.8/api/junghome/functions", json=[])
     fetch, run_ws = _no_network()
     with fetch, run_ws:
         result = await entry.start_reconfigure_flow(hass)
@@ -337,7 +338,7 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
 
 
 async def test_reconfigure_reloads_once_and_keeps_unique_id(
-    hass: HomeAssistant,
+    hass: HomeAssistant, aioclient_mock
 ) -> None:
     """A reconfigure host change reloads exactly once and preserves unique_id.
 
@@ -351,6 +352,7 @@ async def test_reconfigure_reloads_once_and_keeps_unique_id(
         data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"},
     )
     entry.add_to_hass(hass)
+    aioclient_mock.get("https://5.6.7.8/api/junghome/functions", json=[])
     fetch, run_ws = _no_network()
     with fetch, run_ws:
         await hass.config_entries.async_setup(entry.entry_id)
@@ -542,6 +544,79 @@ async def test_reconfigure_host_collision(hass: HomeAssistant) -> None:
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_reconfigure_rejects_unreachable_host(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A typo'd address must be caught on the form, not committed.
+
+    Before connect-then-commit the new host was stored unverified and the
+    mistake only surfaced later as a connect/reauth failure.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="1.2.3.4", data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get(
+        "https://5.6.7.9/api/junghome/functions", exc=aiohttp.ClientError
+    )
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "5.6.7.9"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    # The typo must not have been persisted.
+    assert entry.data[CONF_HOST] == "1.2.3.4"
+
+
+async def test_reconfigure_accepts_host_that_rejects_the_token(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A 401 still proves a gateway is reachable at the new address.
+
+    The probe asserts reachability only: a rejected token means the address now
+    points at a different gateway (or the token was revoked), which the reauth
+    flow handles. Failing the form for it would strand the user on a screen that
+    cannot fix it.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="1.2.3.4", data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get("https://5.6.7.8/api/junghome/functions", status=401)
+
+    fetch, run_ws = _no_network()
+    with fetch, run_ws:
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "5.6.7.8"}
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_HOST] == "5.6.7.8"
+
+
+async def test_reconfigure_rejects_host_that_times_out(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A hanging address fails the form rather than blocking the commit."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="1.2.3.4", data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get("https://5.6.7.9/api/junghome/functions", exc=TimeoutError)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "5.6.7.9"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert entry.data[CONF_HOST] == "1.2.3.4"
 
 
 async def test_register_step_captures_failure(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Problem

`async_step_reconfigure` wrote the new host straight into the entry with no connection attempt:

```python
self.hass.config_entries.async_update_entry(
    entry, data={**entry.data, CONF_HOST: host}
)
return self.async_abort(reason="reconfigure_successful")
```

A typo was accepted, the dialog reported success, and the mistake only surfaced later as a connect or reauth failure with nothing tying it back to the edit. The user is then debugging a "broken integration" rather than a form they just filled in wrong.

## Fix

Connect-then-commit: probe the address with the entry's existing token before storing it. On failure the form is re-shown with `cannot_connect` and the stored host is left untouched.

The probe deliberately tests **reachability only** — any HTTP reply, including `401`/`403`, proves a gateway is listening and the address was typed correctly. A rejected token means the address now points at a different gateway (or the token was revoked), which the reauth flow already handles on the next refresh; failing the form for it would strand the user on a screen that cannot fix it. This keeps the behaviour the step's docstring already promised.

`PROBE_TIMEOUT = 10` rather than the coordinator's 30s: the user is sitting in front of the dialog, so an unreachable host should fail fast enough that retyping feels immediate.

Reuses the existing `cannot_connect` error key, so **no new strings and no translation churn**.

## Tests

Added to `tests/test_config_flow.py`, all driving the real probe through `aioclient_mock`:

- unreachable host (`aiohttp.ClientError`) → form re-shown with `cannot_connect`, `entry.data[CONF_HOST]` **unchanged**
- host that times out → same
- host returning `401` → still accepted and committed (reachability-only contract)

The two rejection tests **fail on `main`**:

```
FAILED test_reconfigure_rejects_unreachable_host
FAILED test_reconfigure_rejects_host_that_times_out
```

The two existing reconfigure success tests now stub the probe endpoint via `aioclient_mock`, so they exercise the real code path rather than bypassing it.

Verified: `mypy --strict` clean, ruff clean, 192 tests pass, coverage 98.32%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoLaQY1DE3kFH4ze4NtBAL