### PR TITLE
Narrow the best-effort except handlers so real bugs surface

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -41,6 +42,24 @@ PLATFORMS: list[Platform] = [
 # re-create them under whatever label the next poll reports, losing the user's
 # entity_id/customisations. Requiring persistence rides out a transient blip.
 STALE_DEVICE_PRUNE_MISSES = 3
+
+# Failures the stable-id migration can realistically hit, and therefore the only
+# ones it treats as "this item didn't migrate, carry on":
+#   * malformed gateway JSON — a device without an ``id``, or a value of an
+#     unexpected type, reaching the slug/prefix construction (KeyError,
+#     TypeError, AttributeError);
+#   * Home Assistant refusing a registry write because the target unique_id or
+#     identifier is already claimed (ValueError, HomeAssistantError).
+# Anything else is a bug in the migration itself. Catching it here would record
+# it as a routine skipped item and hide it behind a log line, so it is left to
+# propagate and fail setup loudly instead.
+_MIGRATION_ERRORS = (
+    KeyError,
+    TypeError,
+    AttributeError,
+    ValueError,
+    HomeAssistantError,
+)
 
 
 def _capability_signature(device: Device) -> tuple[str | None, frozenset[str]]:
@@ -373,7 +392,7 @@ def _migrate_to_stable_ids(
                 else:
                     ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
                 migrated += 1
-            except Exception:
+            except _MIGRATION_ERRORS:
                 had_error = True
                 _LOGGER.exception(
                     "Jung Home: failed to migrate entity %s to a stable id",
@@ -397,7 +416,7 @@ def _migrate_to_stable_ids(
                     dev_reg.async_update_device(
                         device_entry.id, new_identifiers=new_identifiers
                     )
-            except Exception:
+            except _MIGRATION_ERRORS:
                 had_error = True
                 _LOGGER.exception(
                     "Jung Home: failed to migrate device %s to a stable id",
@@ -405,7 +424,7 @@ def _migrate_to_stable_ids(
                 )
 
         _LOGGER.info("Jung Home: migrated %s entities to firmware-stable ids", migrated)
-    except Exception:
+    except _MIGRATION_ERRORS:
         _LOGGER.exception("Jung Home: failed to migrate registry to stable ids")
         return False
     return not had_error

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -234,7 +234,12 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             self.groups = await self._fetch_groups_from_api(
                 self.config["host"], self.config["token"]
             )
-        except Exception as err:  # best-effort, never fatal
+        except (aiohttp.ClientError, TimeoutError, ValueError) as err:
+            # Best-effort, never fatal: the gateway being unreachable, slow, or
+            # answering with a non-JSON body (ValueError covers
+            # json.JSONDecodeError) just leaves the room list empty until the
+            # WebSocket handshake delivers it. Any other exception is a bug here
+            # rather than a gateway problem, so it is left to propagate.
             _LOGGER.debug("Could not fetch Jung Home groups: %s", err)
 
     def area_for_device(self, device: Device) -> str | None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,10 @@
 import copy
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
+import pytest
 from homeassistant.components.cover import CoverEntityFeature
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
@@ -314,10 +317,49 @@ async def test_legacy_unique_id_migrated(hass: HomeAssistant) -> None:
 
 
 async def test_migration_not_marked_done_on_failure(hass: HomeAssistant) -> None:
-    """If migration raises at the top level, the entry isn't flagged migrated.
+    """An expected migration failure leaves the entry unflagged but set up.
 
     Leaving ``stable_ids_migrated`` unset means setup retries the migration on the
-    next load instead of silently skipping it forever.
+    next load instead of silently skipping it forever. ValueError stands in for
+    Home Assistant rejecting a registry write (a unique_id already claimed) —
+    one of the failures the migration is designed to absorb.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=DEVICES),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+        patch(
+            "custom_components.junghome.er.async_entries_for_config_entry",
+            side_effect=ValueError("boom"),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Setup still succeeds, but the migration flag must NOT be set (so it retries).
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.data.get("stable_ids_migrated") is not True
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_migration_unexpected_error_fails_setup(hass: HomeAssistant) -> None:
+    """An unanticipated migration error must not be absorbed as a skipped item.
+
+    The migration rewrites the registry, so an unknown fault is a bug worth
+    surfacing rather than folding into the "one bad item, carry on" path where
+    it would be indistinguishable from malformed gateway data.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -342,10 +384,8 @@ async def test_migration_not_marked_done_on_failure(hass: HomeAssistant) -> None
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    # Setup still succeeds, but the migration flag must NOT be set (so it retries).
+    assert entry.state is ConfigEntryState.SETUP_ERROR
     assert entry.data.get("stable_ids_migrated") is not True
-    await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
 
 
 async def test_host_change_triggers_reload(
@@ -759,10 +799,12 @@ async def test_area_for_device_resolves_group_name(hass: HomeAssistant) -> None:
 
 
 async def test_async_fetch_groups_is_best_effort(hass: HomeAssistant) -> None:
-    """A groups fetch failure leaves groups empty and never raises."""
+    """A gateway-side groups failure leaves groups empty and never raises."""
     coordinator = _bare_coordinator(hass)
     with patch.object(
-        coordinator, "_fetch_groups_from_api", AsyncMock(side_effect=RuntimeError)
+        coordinator,
+        "_fetch_groups_from_api",
+        AsyncMock(side_effect=aiohttp.ClientError),
     ):
         await coordinator.async_fetch_groups()
     assert coordinator.groups == []
@@ -773,6 +815,24 @@ async def test_async_fetch_groups_is_best_effort(hass: HomeAssistant) -> None:
     ):
         await coordinator.async_fetch_groups()
     assert coordinator.groups == [{"id": "g", "name": "X"}]
+
+
+async def test_async_fetch_groups_lets_unexpected_errors_surface(
+    hass: HomeAssistant,
+) -> None:
+    """Best-effort covers gateway failures, not bugs in our own code.
+
+    A RuntimeError here is not the gateway being unreachable; it is a defect,
+    and swallowing it would hide it behind a debug-level log line forever.
+    """
+    coordinator = _bare_coordinator(hass)
+    with (
+        patch.object(
+            coordinator, "_fetch_groups_from_api", AsyncMock(side_effect=RuntimeError)
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await coordinator.async_fetch_groups()
 
 
 def _grouped_lamp() -> dict:


### PR DESCRIPTION
Four `except Exception` handlers treated *any* failure as a routine, absorbable one. A genuine defect in our own code was therefore indistinguishable from the gateway misbehaving, and disappeared behind a log line.

## Changes

**`_migrate_to_stable_ids`** (3 handlers) now catches `_MIGRATION_ERRORS` — the failures it is actually designed to absorb:

- malformed gateway JSON reaching slug/prefix construction (`KeyError`, `TypeError`, `AttributeError`) — note `by_datapoint` can hold a device with no `id`, so `device['id']` raising `KeyError` is genuinely reachable
- Home Assistant refusing a registry write because a unique_id or identifier is already claimed (`ValueError`, `HomeAssistantError`)

Anything else propagates and fails setup loudly. That's the deliberate call: this migration rewrites the entity and device registries, so an unknown fault is worth surfacing rather than being counted as "one bad item, carry on". The `had_error` → `stable_ids_migrated` contract is unchanged, so an absorbed failure still leaves the flag unset and the migration retries next load.

**`async_fetch_groups`** now catches `(aiohttp.ClientError, TimeoutError, ValueError)` — unreachable, slow, or non-JSON gateway (`ValueError` covers `json.JSONDecodeError`). Room grouping stays genuinely best-effort for those.

## Deliberately left broad

`coordinator.py:333`, `:399` and `:624` keep their catch-alls. Those guard the WebSocket reconnect loop and per-frame handling: narrowing them risks an unexpected frame killing the loop and silently ending live push, which is a worse failure than swallowing. Different job, different trade-off.

## Tests

- `test_async_fetch_groups_is_best_effort` — now uses `aiohttp.ClientError` rather than `RuntimeError`, so it tests the real contract
- `test_async_fetch_groups_lets_unexpected_errors_surface` — new; `RuntimeError` propagates
- `test_migration_not_marked_done_on_failure` — now uses `ValueError` (an absorbable registry rejection) and additionally asserts `entry.state is LOADED`. It previously used `RuntimeError` and still passed after this change, but for the wrong reason: setup had *failed* rather than survived. Pinning the state stops that hiding again.
- `test_migration_unexpected_error_fails_setup` — new; `RuntimeError` gives `SETUP_ERROR`

Verified: `mypy --strict` clean, ruff clean, 191 tests pass, coverage 98.12%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoLaQY1DE3kFH4ze4NtBAL