### PR TITLE
Add per-device diagnostics

### DIFF
--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -8,8 +8,11 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 
+from .const import DOMAIN, device_slug
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceEntry
 
     from .coordinator import JungHomeConfigEntry
     from .models import Device
@@ -113,4 +116,42 @@ async def async_get_config_entry_diagnostics(
         # functions / groups / scenes) even on a spammy gateway where the rolling
         # log above has churned past it.
         "latest_websocket_frame_by_type": coordinator.ws_last_frame_by_type,
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: JungHomeConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a single device.
+
+    The entry-level dump above carries every device on the gateway, which is
+    unwieldy on a large installation when the question is about one blind or one
+    thermostat. This narrows it to the selected device while keeping the gateway
+    context needed to interpret it — firmware version, whether live push is up,
+    and the most recent error.
+
+    ``matched`` is None when the HA device has no counterpart in the current
+    poll, which is itself the useful signal: it means the gateway has stopped
+    reporting it (renamed label, removed hardware) and it is on its way to being
+    pruned.
+    """
+    coordinator = entry.runtime_data
+    # HA devices are keyed by the firmware-stable slug, so resolve back through
+    # the same function that produced the identifier.
+    slugs = {
+        identifier for domain, identifier in device.identifiers if domain == DOMAIN
+    }
+    matched = next(
+        (d for d in coordinator.data or [] if device_slug(d) in slugs),
+        None,
+    )
+    return {
+        "gateway_version": coordinator.gateway_version,
+        "ws_connected": coordinator.ws_connected,
+        "last_error": coordinator.last_error,
+        "last_error_at": coordinator.last_error_at,
+        "identifiers": sorted(slugs),
+        # Redacted with the same rule as the entry dump: a per-device report is
+        # pasted into public issues just as often as a full one.
+        "device": async_redact_data(matched, TO_REDACT) if matched else None,
     }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,6 +24,7 @@ from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.diagnostics import (
     _support_summary,
     async_get_config_entry_diagnostics,
+    async_get_device_diagnostics,
 )
 from tests.conftest import DEVICES, _fake_run_websocket
 
@@ -99,6 +100,70 @@ async def test_diagnostics(hass: HomeAssistant, init_integration) -> None:
     assert diag["support_summary"]["unhandled_function_types"] == []
     assert diag["support_summary"]["unhandled_datapoint_types"] == []
     assert diag["support_summary"]["function_types"]["ColorLight"] >= 1
+
+
+async def test_device_diagnostics(hass: HomeAssistant, init_integration) -> None:
+    """A per-device dump narrows to one device and keeps gateway context."""
+    coordinator = init_integration.runtime_data
+    coordinator.gateway_version = "1.5.0"
+    dev_reg = dr.async_get(hass)
+    slug = device_slug(DEVICES[0])
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, slug)})
+    assert device is not None
+
+    diag = await async_get_device_diagnostics(hass, init_integration, device)
+
+    assert diag["identifiers"] == [slug]
+    assert diag["device"] is not None
+    assert diag["device"]["label"] == DEVICES[0]["label"]
+    # Gateway context travels with the device so the dump is interpretable.
+    assert diag["gateway_version"] == "1.5.0"
+    assert diag["ws_connected"] is True
+
+
+async def test_device_diagnostics_redacts_credentials(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Per-device dumps get the same redaction as the entry dump.
+
+    They are pasted into public issues just as often, so a gateway payload that
+    ever carries a token/host must not leak through the narrower report.
+    """
+    coordinator = init_integration.runtime_data
+    devices = copy.deepcopy(DEVICES)
+    devices[0]["token"] = "super-secret"
+    devices[0]["host"] = "192.168.1.50"
+    coordinator.async_set_updated_data(devices)
+    await hass.async_block_till_done()
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, device_slug(DEVICES[0]))})
+    diag = await async_get_device_diagnostics(hass, init_integration, device)
+
+    assert diag["device"]["token"] == "**REDACTED**"
+    assert diag["device"]["host"] == "**REDACTED**"
+
+
+async def test_device_diagnostics_when_gateway_no_longer_reports_it(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A device the gateway has stopped reporting yields device=None.
+
+    That is the useful signal: it is on its way to being pruned rather than
+    simply absent from the dump for an unexplained reason.
+    """
+    dev_reg = dr.async_get(hass)
+    ghost = dev_reg.async_get_or_create(
+        config_entry_id=init_integration.entry_id,
+        identifiers={(DOMAIN, "ghost_device")},
+    )
+
+    diag = await async_get_device_diagnostics(hass, init_integration, ghost)
+
+    assert diag["identifiers"] == ["ghost_device"]
+    assert diag["device"] is None
+    # Gateway context is still present, so the report is not empty.
+    assert diag["ws_connected"] is True
 
 
 def test_support_summary_flags_unhandled_types() -> None:


### PR DESCRIPTION
`diagnostics.py` only implemented `async_get_config_entry_diagnostics`, so the "Download diagnostics" button on a *device* page returned the whole gateway. On an installation with dozens of devices that means scrolling a large dump to answer a question about one blind or one thermostat.

Adds `async_get_device_diagnostics`, which Home Assistant picks up automatically for the per-device download.

## What it returns

The selected device's payload plus the gateway context needed to interpret it — firmware version, whether live push is currently up, and the most recent error. Without that context a single-device dump can't distinguish "this device is broken" from "the WebSocket has been down for an hour and everything is stale".

Resolution goes back through `device_slug()`, the same function that produced the registry identifier, so it stays correct as the stable-ID scheme evolves.

`device` is `None` when the HA device has no counterpart in the current poll. That is deliberately surfaced rather than erroring: it means the gateway has stopped reporting it (label renamed, hardware removed) and it is on its way to being pruned by the stale-device debounce — which is usually the actual answer being looked for.

## Redaction

Reuses the existing `TO_REDACT` set. A per-device report gets pasted into public issues just as readily as a full one, so it must not become a way to leak a token or gateway address that the entry-level dump already scrubs. Covered by a test that plants both keys in the device payload.

## Tests

Three added to `tests/test_init.py`: normal device dump with gateway context, credential redaction, and the no-longer-reported case.

Verified: `mypy --strict` clean, ruff clean, 192 tests pass, coverage 98.31%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoLaQY1DE3kFH4ze4NtBAL