### PR TITLE
Release 1.4.0

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.4.0b1",
+  "version": "1.4.0",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
Promotes `1.4.0b1` to a stable release.

There are no code changes since the beta — this only drops the `b1` suffix from `custom_components/junghome/manifest.json`. Cutting from `main` as it stands: the six PRs currently open (#125, #130, #131, #132, #133, #134) are deliberately **not** included and will land in a later release.

Once merged, pushing the `v1.4.0` tag lets `.github/workflows/release.yml` verify tag-vs-manifest agreement and publish the GitHub release with generated notes. Because the version has no suffix, it publishes as a normal (non-prerelease) release, so HACS offers it to all users rather than only those opted into betas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u