### PR TITLE
Use the gateway's advertised colour-temperature range per light

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import math
 import random
 from collections import deque
 from datetime import datetime, timedelta
@@ -40,8 +41,61 @@ RECONNECT_JITTER = 0.5
 WS_FRAME_LOG_SIZE = 60
 WS_FRAME_MAX_CHARS = 2000
 
+# Sanity bounds for a gateway-advertised colour-temperature range. Anything
+# outside this is not a plausible tunable-white range and is treated as an
+# unrecognised payload rather than trusted (a bogus range would otherwise be
+# declared to Home Assistant, which enforces it against the user).
+MIN_PLAUSIBLE_KELVIN = 1000
+MAX_PLAUSIBLE_KELVIN = 20000
+
 # Config entry carrying the coordinator as runtime_data.
 type JungHomeConfigEntry = ConfigEntry[JungHomeDataUpdateCoordinator]
+
+
+def _as_kelvin(raw: Any) -> int | None:
+    """Coerce one end of a gateway range to Kelvin, or None if it isn't a number.
+
+    Gateway numerics arrive as strings as often as numbers, so ``"2700"`` and
+    ``2700`` are both accepted. ``bool`` is rejected explicitly (it is an ``int``
+    subclass, and ``True`` is not a temperature), and so are the non-finite
+    floats: ``json.loads`` accepts the ``NaN`` / ``Infinity`` literals, and both
+    survive naive comparisons (every ``NaN`` comparison is False, so a NaN range
+    would pass the sanity checks below).
+    """
+    if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
+        return None
+    try:
+        kelvin = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(kelvin):
+        return None
+    return round(kelvin)
+
+
+def _parse_color_temp_range(raw: Any) -> tuple[int, int] | None:
+    """Parse a gateway colour-temperature range, or None if unusable.
+
+    Accepts ``{"min": 2700, "max": 6500}`` and ``[2700, 6500]``. Rejects
+    non-numeric, reversed, zero-width and implausible ranges — the caller then
+    falls back to the light platform's defaults.
+    """
+    if isinstance(raw, dict):
+        low, high = raw.get("min"), raw.get("max")
+    elif isinstance(raw, (list, tuple)) and len(raw) == 2:
+        low, high = raw[0], raw[1]
+    else:
+        return None
+    low_k, high_k = _as_kelvin(low), _as_kelvin(high)
+    if low_k is None or high_k is None:
+        return None
+    # Reversed and zero-width ranges are both nonsense; Home Assistant would
+    # reject (or mis-render) a min >= max colour-temperature entity.
+    if low_k >= high_k:
+        return None
+    if low_k < MIN_PLAUSIBLE_KELVIN or high_k > MAX_PLAUSIBLE_KELVIN:
+        return None
+    return low_k, high_k
 
 
 class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
@@ -78,8 +132,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # WebSocket `scene` command is unimplemented on the gateway.
         self.scenes: list[Scene] = []
         # Last `groups` broadcast (per-room capability metadata, e.g. which groups
-        # advertise color_temperature_range). Not consumed by any entity; kept for
-        # diagnostics so unimplemented capabilities are visible.
+        # advertise color_temperature_range). Read by `area_for_device` and
+        # `color_temp_range_for_device`, and surfaced in diagnostics so the
+        # capabilities we do not yet implement stay visible.
         self.groups: list[dict[str, Any]] = []
         # Bounded log of recent raw WebSocket frames for diagnostics.
         self.ws_frame_log: deque[str] = deque(maxlen=WS_FRAME_LOG_SIZE)
@@ -252,6 +307,34 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             name = by_id.get(parent)
             if name:
                 return str(name)
+        return None
+
+    def color_temp_range_for_device(self, device: Device) -> tuple[int, int] | None:
+        """Return the (min, max) Kelvin range a device's groups advertise.
+
+        The gateway publishes per-group capability metadata in its ``groups``
+        broadcast, including ``color_temperature_range``. Returns None when no
+        parent group advertises a usable range, in which case the light platform
+        keeps its built-in defaults.
+
+        The exact wire shape is not pinned down in the gateway docs, so both
+        plausible encodings are accepted (``{"min": .., "max": ..}`` and a
+        two-element ``[min, max]``) and anything unrecognised or implausible is
+        rejected rather than guessed at. That keeps a surprising payload a no-op
+        — the light falls back to its defaults — instead of declaring a nonsense
+        range that Home Assistant would then enforce against the user.
+        """
+        parents = device.get("parent_groups") or []
+        if not parents:
+            return None
+        by_id = {g.get("id"): g for g in self.groups}
+        for parent in parents:
+            group = by_id.get(parent)
+            if group is None:
+                continue
+            parsed = _parse_color_temp_range(group.get("color_temperature_range"))
+            if parsed is not None:
+                return parsed
         return None
 
     def known_unique_ids(self, domain: str) -> set[str]:
@@ -500,8 +583,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             if msg_type in ("scenes", "scenes-new", "scenes-deleted"):
                 self._handle_scenes_broadcast(msg_type, data)
             elif msg_type == "groups":
-                # Full groups list (on connect and on change). Not consumed by any
-                # entity, but kept for diagnostics (capability metadata).
+                # Full groups list (on connect and on change). Carries per-room
+                # capability metadata (area names, colour-temperature ranges) and
+                # is surfaced in diagnostics.
                 self.groups = [g for g in data if isinstance(g, dict)]
             else:
                 _LOGGER.debug("Received %s broadcast (%d items)", msg_type, len(data))

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -19,6 +19,12 @@ _LOGGER = logging.getLogger(__name__)
 # Commands are cheap async WebSocket sends; don't serialise them.
 PARALLEL_UPDATES = 0
 
+# Fallback colour-temperature range, used only when the gateway advertises none
+# for the device's group (see JungHomeLight.__init__). Deliberately left wide:
+# the direct BT-Mesh mapping in docs/bt-mesh-direct.md is 2000-6000 K, but that
+# is one JUNG luminaire's Generic Level mapping, not a per-fixture limit, and
+# narrowing the ceiling to 6000 would cap fixtures that genuinely reach further.
+# A real per-device range should come from the gateway, not from this constant.
 DEFAULT_MIN_KELVIN = 2000
 DEFAULT_MAX_KELVIN = 6500
 
@@ -117,14 +123,31 @@ class JungHomeLight(JungHomeEntity, LightEntity):
             if self._has_brightness
             else None
         )
+        # Prefer the range the gateway advertises for this device's group over the
+        # module defaults: a fixture whose real range is narrower than 2000-6500 K
+        # gets a slider it cannot honour, and — worse — a read outside the
+        # declared range is clamped, so the reported colour temperature silently
+        # differs from the device's. Resolve it BEFORE the first read below, which
+        # already clamps against it.
+        self._min_kelvin, self._max_kelvin = DEFAULT_MIN_KELVIN, DEFAULT_MAX_KELVIN
+        if self._has_color_temp:
+            advertised = coordinator.color_temp_range_for_device(device)
+            if advertised is not None:
+                self._min_kelvin, self._max_kelvin = advertised
+                _LOGGER.debug(
+                    "Light %s uses the gateway-advertised colour-temperature "
+                    "range %s-%sK",
+                    self._name,
+                    self._min_kelvin,
+                    self._max_kelvin,
+                )
+            self._attr_min_color_temp_kelvin = self._min_kelvin
+            self._attr_max_color_temp_kelvin = self._max_kelvin
         self._color_temp: int | None = (
             self._get_color_temp_from_datapoint(self._color_temp_datapoint)
             if self._has_color_temp
             else None
         )
-        if self._has_color_temp:
-            self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
-            self._attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
 
         # Color mode is fixed by the device's capabilities (datapoints), not by
         # the current value. Home Assistant requires supported_color_modes to be
@@ -248,9 +271,10 @@ class JungHomeLight(JungHomeEntity, LightEntity):
             kelvin = int(value)
         except (TypeError, ValueError):
             return None
-        # Clamp to the advertised range so an out-of-range gateway value doesn't
-        # violate the declared min/max color-temperature contract.
-        return max(DEFAULT_MIN_KELVIN, min(DEFAULT_MAX_KELVIN, kelvin))
+        # Clamp to this light's own advertised range (gateway-supplied where
+        # available, defaults otherwise) so an out-of-range value doesn't violate
+        # the declared min/max color-temperature contract.
+        return max(self._min_kelvin, min(self._max_kelvin, kelvin))
 
     async def _set_brightness(self, brightness: int) -> None:
         """Set the brightness of the light."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,7 +20,10 @@ from custom_components.junghome.const import (
     DOMAIN,
     device_slug,
 )
-from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
+from custom_components.junghome.coordinator import (
+    JungHomeDataUpdateCoordinator,
+    _parse_color_temp_range,
+)
 from custom_components.junghome.diagnostics import (
     _support_summary,
     async_get_config_entry_diagnostics,
@@ -756,6 +759,63 @@ async def test_area_for_device_resolves_group_name(hass: HomeAssistant) -> None:
     assert (
         coordinator.area_for_device({"id": "d", "parent_groups": ["g2"]}) == "Bathroom"
     )
+
+
+async def test_color_temp_range_for_device_reads_group_metadata(
+    hass: HomeAssistant,
+) -> None:
+    """color_temp_range_for_device resolves the group's advertised Kelvin range."""
+    coordinator = _bare_coordinator(hass)
+    device = {"id": "d", "parent_groups": ["g1"]}
+    # Both plausible encodings are accepted, and values may be strings.
+    coordinator.groups = [
+        {"id": "g1", "color_temperature_range": {"min": 2700, "max": 6500}}
+    ]
+    assert coordinator.color_temp_range_for_device(device) == (2700, 6500)
+    coordinator.groups = [{"id": "g1", "color_temperature_range": ["2700", "6500"]}]
+    assert coordinator.color_temp_range_for_device(device) == (2700, 6500)
+    # No parent groups / an id that doesn't resolve / a group without a range.
+    assert coordinator.color_temp_range_for_device({"id": "d"}) is None
+    assert (
+        coordinator.color_temp_range_for_device({"id": "d", "parent_groups": ["gX"]})
+        is None
+    )
+    coordinator.groups = [{"id": "g1", "name": "Living room"}]
+    assert coordinator.color_temp_range_for_device(device) is None
+    # The first parent group advertising a usable range wins.
+    coordinator.groups = [
+        {"id": "g0", "name": "no range here"},
+        {"id": "g1", "color_temperature_range": {"min": 2200, "max": 4000}},
+    ]
+    assert coordinator.color_temp_range_for_device(
+        {"id": "d", "parent_groups": ["g0", "g1"]}
+    ) == (2200, 4000)
+
+
+def test_parse_color_temp_range_rejects_bad_payloads() -> None:
+    """The range parser only trusts a well-formed, plausible pair of numbers."""
+    assert _parse_color_temp_range({"min": "2700", "max": 6500.4}) == (2700, 6500)
+    assert _parse_color_temp_range([2700, 6500]) == (2700, 6500)
+    for raw in (
+        None,
+        "2700-6500",
+        42,
+        {},  # no keys at all
+        {"min": 2700},  # half a range
+        {"min": "warm", "max": "cool"},  # non-numeric
+        {"min": None, "max": 6500},
+        {"min": {"nested": 1}, "max": 6500},  # not a scalar
+        {"min": True, "max": 6500},  # bool is an int subclass, but not a Kelvin
+        {"min": 6500, "max": 2700},  # reversed
+        {"min": 4000, "max": 4000},  # zero-width
+        {"min": 10, "max": 6500},  # implausibly low
+        {"min": 2700, "max": 999999},  # implausibly high
+        {"min": float("nan"), "max": float("nan")},  # json.loads accepts NaN
+        {"min": 2700, "max": float("inf")},  # ...and Infinity
+        [2700],  # wrong arity
+        [2000, 4000, 6500],
+    ):
+        assert _parse_color_temp_range(raw) is None, raw
 
 
 async def test_async_fetch_groups_is_best_effort(hass: HomeAssistant) -> None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -21,7 +21,12 @@ def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
     return coordinator
 
 
-def _color_light(coordinator: JungHomeDataUpdateCoordinator) -> JungHomeLight:
+def _color_light(
+    coordinator: JungHomeDataUpdateCoordinator,
+    *,
+    parent_groups: list | None = None,
+    color_temp: str = "3000",
+) -> JungHomeLight:
     device = {
         "id": "c",
         "type": "ColorLight",
@@ -40,10 +45,12 @@ def _color_light(coordinator: JungHomeDataUpdateCoordinator) -> JungHomeLight:
             {
                 "id": "c-4",
                 "type": "color_temperature",
-                "values": [{"key": "color_temperature", "value": "3000"}],
+                "values": [{"key": "color_temperature", "value": color_temp}],
             },
         ],
     }
+    if parent_groups is not None:
+        device["parent_groups"] = parent_groups
     return JungHomeLight(coordinator, device, device["datapoints"][0])
 
 
@@ -341,6 +348,70 @@ async def test_light_brightness_and_color_temp_are_clamped(hass: HomeAssistant) 
             {"id": "x", "values": [{"key": "color_temperature", "value": "1000"}]}
         )
         == 2000
+    )
+
+
+async def test_light_uses_gateway_advertised_color_temp_range(
+    hass: HomeAssistant,
+) -> None:
+    """The range the gateway advertises for the device's group wins over defaults."""
+    coordinator = _bare_coordinator(hass)
+    coordinator.groups = [
+        {
+            "id": "g1",
+            "name": "Living room",
+            "color_temperature_range": {"min": 2700, "max": 4000},
+        }
+    ]
+    light = _color_light(coordinator, parent_groups=["g1"])
+    assert light.min_color_temp_kelvin == 2700
+    assert light.max_color_temp_kelvin == 4000
+    # A read inside the advertised range is reported as-is.
+    assert light.color_temp_kelvin == 3000
+
+
+async def test_light_color_temp_range_falls_back_to_defaults(
+    hass: HomeAssistant,
+) -> None:
+    """A missing or malformed advertised range leaves the module defaults in place."""
+    coordinator = _bare_coordinator(hass)
+    for groups in (
+        [],  # no groups known yet
+        [{"id": "g1", "name": "Living room"}],  # group without the capability
+        [{"id": "g1", "color_temperature_range": "2700-4000"}],  # garbage
+        [{"id": "g1", "color_temperature_range": {"min": 4000, "max": 2700}}],
+        [{"id": "g1", "color_temperature_range": {"min": 4000, "max": 4000}}],
+    ):
+        coordinator.groups = groups
+        light = _color_light(coordinator, parent_groups=["g1"])
+        assert light.min_color_temp_kelvin == 2000, groups
+        assert light.max_color_temp_kelvin == 6500, groups
+    # A device in no group at all also keeps the defaults.
+    light = _color_light(coordinator)
+    assert (light.min_color_temp_kelvin, light.max_color_temp_kelvin) == (2000, 6500)
+
+
+async def test_light_clamps_reads_to_the_gateway_range(hass: HomeAssistant) -> None:
+    """Reads clamp to the resolved range, not to the module constants."""
+    coordinator = _bare_coordinator(hass)
+    coordinator.groups = [
+        {"id": "g1", "color_temperature_range": {"min": 2700, "max": 4000}}
+    ]
+    # The initial read happens in __init__, so the range must already be resolved:
+    # 6500 K sits inside the module defaults but above this fixture's 4000 K.
+    light = _color_light(coordinator, parent_groups=["g1"], color_temp="6500")
+    assert light.color_temp_kelvin == 4000
+    assert (
+        light._get_color_temp_from_datapoint(
+            {"id": "x", "values": [{"key": "color_temperature", "value": "2000"}]}
+        )
+        == 2700
+    )
+    assert (
+        light._get_color_temp_from_datapoint(
+            {"id": "x", "values": [{"key": "color_temperature", "value": "3500"}]}
+        )
+        == 3500
     )
 
 


### PR DESCRIPTION
## The bug

`light.py` hardcoded `DEFAULT_MIN_KELVIN = 2000` / `DEFAULT_MAX_KELVIN = 6500` and used them for two different jobs:

1. declaring the entity's colour-temperature range to Home Assistant, and
2. **clamping reads** in `_get_color_temp_from_datapoint`.

The second one is the real problem. If a fixture's actual range is narrower than 2000-6500 K, a gateway value outside the *declared* window was silently rewritten to the window edge, so Home Assistant reported a colour temperature the device was not at — a wrong state, not just a wrong slider. And the slider itself let users command temperatures the fixture cannot reach.

Meanwhile the gateway already tells us the answer: its `groups` broadcast carries per-group capability metadata including `color_temperature_range`. The coordinator cached it (for diagnostics) and no entity consumed it — `coordinator.py` said as much in a comment.

## The fix

- **`JungHomeDataUpdateCoordinator.color_temp_range_for_device(device)`** resolves a device's `parent_groups` against the cached groups and returns the first usable advertised `(min, max)` Kelvin pair, or `None`. Same lookup shape as the existing `area_for_device`.
- **`JungHomeLight.__init__`** resolves that range *before* its first colour-temperature read (ordering matters — the read clamps), stores it as `self._min_kelvin` / `self._max_kelvin`, and declares it via `_attr_min_color_temp_kelvin` / `_attr_max_color_temp_kelvin`.
- **`_get_color_temp_from_datapoint`** now clamps against the resolved range rather than the module constants.
- Only lights that actually expose a `color_temperature` datapoint do the group lookup; everything else keeps the defaults untouched.

**The 2000/6500 fallback is deliberately unchanged.** `docs/bt-mesh-direct.md` maps Kelvin 2000…6000 onto int16 for direct BT-Mesh Generic Level control, and `tools/bt-mesh-direct/` uses the same bounds — but that is one JUNG luminaire's level mapping, not evidence of a universal ceiling. Lowering the fallback to 6000 would cap fixtures that genuinely go further, with no read benefit. Real per-device ranges should come from the gateway; the constant is only what we use when it stays quiet.

## Defensive parsing, and what could not be confirmed

**The wire shape of `color_temperature_range` is not documented.** `docs/gateway-websocket.md` documents the `groups` frame only as "array" and never shows a group object; `docs/gateway-rest-api.md` documents `GET /groups/` but shows no payload; there are no captured diagnostics dumps or group fixtures in the repo. The key name comes from an earlier commit (29bb3ed) that observed the metadata on real hardware without recording its encoding. **So this PR parses tolerantly rather than to a confirmed schema, and that is on purpose.**

`_parse_color_temp_range` accepts both plausible encodings — `{"min": 2700, "max": 6500}` and `[2700, 6500]` — with numbers or numeric strings (most gateway numerics arrive as strings). It rejects, falling back to defaults:

- non-numeric values, missing keys, wrong arity, and anything that isn't a dict/2-element sequence;
- `bool` (an `int` subclass, but `True` is not a temperature);
- **non-finite floats** — `json.loads` happily parses the `NaN` / `Infinity` literals, and NaN would sail through every comparison below (all NaN comparisons are False), while `int(float("inf"))` raises `OverflowError`, which is *not* a `ValueError` and would have escaped a naive `except (TypeError, ValueError)`;
- reversed (`min > max`) and zero-width (`min == max`) ranges;
- implausible Kelvin (outside 1000…20000), so a bogus advertised range can't be declared to Home Assistant, which would then enforce it against the user.

The rationale throughout: an unrecognised payload should be a **no-op** (keep the known-safe defaults), never a guess that becomes an enforced entity contract.

## Tests

`tests/test_light.py`:
- the gateway-advertised range is honoured over the defaults;
- missing / absent-capability / garbage / reversed / zero-width ranges all fall back to 2000-6500, as does a device in no group;
- a read outside the resolved range is clamped **to that range** — including the read performed inside `__init__`, which guards the resolution-before-read ordering.

`tests/test_init.py` (next to the existing `area_for_device` tests):
- `color_temp_range_for_device` across both encodings, no parent groups, unresolvable ids, a group without the capability, and first-usable-range-wins;
- a table of malformed payloads the parser must reject.

## Verification

- `mypy --strict`: clean, 16 source files
- `pytest`: **194 passed** (189 on `main`), coverage **98.36%** branch (98.31% on `main`, gate 95%)
- `ruff check` + `ruff format --check`: clean

No new strings — `strings.json` and `translations/` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u