### PR TITLE
Drop the last Shelly reference from the coordinator comment

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -31,8 +31,8 @@ MAX_RECONNECT_DELAY = 60
 # Small random addition to each reconnect wait, so multiple gateways/entries on
 # the same network don't all retry in lockstep after a shared network blip.
 RECONNECT_JITTER = 0.5
-# Consecutive failed reconnects before raising a repair issue, mirroring Shelly's
-# MAX_PUSH_UPDATE_FAILURES. Below this the exponential backoff has waited well
+# Consecutive failed reconnects before raising a repair issue, following the core
+# convention of bounding push failures. Below this the backoff has waited well
 # under a minute in total, which an ordinary blip (gateway reboot, Wi-Fi hiccup)
 # rides out silently; past it the gateway has been unreachable long enough that
 # the user is unknowingly running on the 60 s REST poll and deserves to be told.


### PR DESCRIPTION
Follow-up to #140.

That PR removed the Shelly references from `CLAUDE.md` and `const.py`, and the same fix was pushed to the `repair-websocket-degraded` branch — but #138 was merged from the commit immediately before it, so this one comment survived into `main`:

```
# Consecutive failed reconnects before raising a repair issue, mirroring Shelly's
# MAX_PUSH_UPDATE_FAILURES. ...
```

Reworded to state the convention directly. Comment only — no behaviour change. `git grep -i shelly` is now empty across the tree.

mypy `--strict` clean (17 files), 208 tests pass, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
