### PR TITLE
Group the Home Assistant test stack for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "pytest-homeassistant-custom-component pins homeassistant, pytest and syrupy to exact versions, so bumping any of them on its own is an unresolvable dependency conflict rather than a test failure. Move the whole set in one PR.",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchPackageNames": [
+        "homeassistant",
+        "pytest",
+        "pytest-homeassistant-custom-component",
+        "syrupy"
+      ],
+      "groupName": "home-assistant test stack"
+    }
   ]
 }


### PR DESCRIPTION
Both currently-open Renovate PRs fail CI, and neither failure is about this integration — both die in **Install requirements**, before a single test runs.

`pytest-homeassistant-custom-component` pins `homeassistant`, `pytest` and `syrupy` to **exact** versions. Renovate treats each as an independent dependency, so it proposes bumps that cannot resolve:

| PR | Bump | Why it cannot install |
|---|---|---|
| #142 | `pytest` 9.0.3 → 9.1.1 | `phacc==0.13.348` requires `pytest==9.0.3` → `ResolutionImpossible` |
| #141 | `phacc` 0.13.348 → 0.13.351 | `0.13.351` requires `homeassistant==2026.8.0b3`; `requirements.txt` pins `2026.7.4` → `ResolutionImpossible` |

For reference, the exact pins each phacc release carries:

```
0.13.348 -> pytest==9.0.3, syrupy==5.3.2, homeassistant==2026.7.4
0.13.351 -> pytest==9.0.3, syrupy==5.5.3, homeassistant==2026.8.0b3
```

Grouping the four packages makes Renovate propose them as one coherent bump that can actually resolve. It does **not** decide whether a given bump is desirable — `0.13.351` requiring a Home Assistant *beta* is still a judgement call, it just becomes a reviewable one instead of a permanently-red PR.

Once this lands, Renovate should supersede #141 and #142 with a single grouped PR on its next run; they can be closed then.

Worth knowing for #139: it adds an explicit `syrupy==5.3.2` line. That currently matches phacc's transitive pin exactly, so it installs fine today — but it is the *same latent trap*, and would turn the next phacc bump into a third unresolvable PR. Flagged separately on that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
