### PR TITLE
Stop a malformed gateway frame from removing every light

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -66,20 +66,36 @@ def _as_kelvin(raw: Any) -> int | None:
 
     Gateway numerics arrive as strings as often as numbers, so ``"2700"`` and
     ``2700`` are both accepted. ``bool`` is rejected explicitly (it is an ``int``
-    subclass, and ``True`` is not a temperature), and so are the non-finite
-    floats: ``json.loads`` accepts the ``NaN`` / ``Infinity`` literals, and both
-    survive naive comparisons (every ``NaN`` comparison is False, so a NaN range
-    would pass the sanity checks below).
+    subclass, and ``True`` is not a temperature).
+
+    Every conversion below can raise on untrusted JSON, and none of them raise
+    only ``ValueError``:
+
+    - ``float()`` on a huge ``int`` raises ``OverflowError``. ``json.loads``
+      parses integer literals at arbitrary precision, so a frame carrying a
+      400-digit integer reaches this function as an ``int`` Python cannot
+      represent as a float. (A huge *string* is safe — it becomes ``inf``.)
+    - ``json.loads`` also accepts the bare ``NaN`` / ``Infinity`` literals, and
+      ``round()`` rejects both: ``ValueError`` for NaN, ``OverflowError`` for
+      infinity. ``math.isfinite`` screens them out first so the intent is
+      explicit rather than incidental.
+
+    Catching the union keeps a malformed frame a no-op here instead of an
+    exception escaping into ``JungHomeLight.__init__`` and taking down the whole
+    light platform.
     """
     if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
         return None
     try:
         kelvin = float(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
     if not math.isfinite(kelvin):
         return None
-    return round(kelvin)
+    try:
+        return round(kelvin)
+    except (ValueError, OverflowError):  # pragma: no cover - isfinite guards it
+        return None
 
 
 def _parse_color_temp_range(raw: Any) -> tuple[int, int] | None:
@@ -331,27 +347,52 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     def color_temp_range_for_device(self, device: Device) -> tuple[int, int] | None:
         """Return the (min, max) Kelvin range a device's groups advertise.
 
-        The gateway publishes per-group capability metadata in its ``groups``
-        broadcast, including ``color_temperature_range``. Returns None when no
-        parent group advertises a usable range, in which case the light platform
-        keeps its built-in defaults.
+        **No firmware is known to send this.** Captured ``groups`` broadcasts
+        (``disk_dump/ws-capture*/groups.json``, 14 real groups) carry only
+        ``id`` / ``address`` / ``name`` / ``related_functions`` /
+        ``function_types`` — there is no colour-temperature field, and the name
+        ``color_temperature_range`` traces back to a speculative comment rather
+        than a capture. Nothing wires this into an entity yet for exactly that
+        reason; see the light-platform note in ``light.py``.
 
-        The exact wire shape is not pinned down in the gateway docs, so both
-        plausible encodings are accepted (``{"min": .., "max": ..}`` and a
-        two-element ``[min, max]``) and anything unrecognised or implausible is
-        rejected rather than guessed at. That keeps a surprising payload a no-op
-        — the light falls back to its defaults — instead of declaring a nonsense
-        range that Home Assistant would then enforce against the user.
+        It is kept because the ``groups`` broadcast is the only plausible source
+        for a per-fixture range, and having the parser and its tests in place
+        means confirming the field later is a one-line change instead of a
+        design question. Both plausible encodings are accepted
+        (``{"min": .., "max": ..}`` and ``[min, max]``); anything unrecognised
+        or implausible is rejected rather than guessed at.
+
+        Returns the range from the **first** parent group that advertises a
+        usable one. That is arbitrary when a device sits in several groups with
+        different ranges — it depends on the gateway's array order — so any
+        future caller must decide whether first-wins, intersection or union is
+        correct for its use. It is only defensible today because nothing
+        consumes the result.
         """
         parents = device.get("parent_groups") or []
-        if not parents:
+        # Untrusted gateway JSON: a non-list `parent_groups`, or an unhashable
+        # group id, must not raise out of a caller's constructor.
+        if not isinstance(parents, (list, tuple)) or not parents:
             return None
-        by_id = {g.get("id"): g for g in self.groups}
-        for parent in parents:
-            group = by_id.get(parent)
-            if group is None:
+        by_id: dict[Any, dict[str, Any]] = {}
+        for group in self.groups:
+            if not isinstance(group, dict):
                 continue
-            parsed = _parse_color_temp_range(group.get("color_temperature_range"))
+            group_id = group.get("id")
+            if not isinstance(group_id, (str, int)) or isinstance(group_id, bool):
+                continue
+            # First occurrence wins, matching the documented order above; a
+            # plain dict comprehension would silently keep the last duplicate.
+            by_id.setdefault(group_id, group)
+        for parent in parents:
+            if not isinstance(parent, (str, int)) or isinstance(parent, bool):
+                continue
+            parent_group = by_id.get(parent)
+            if parent_group is None:
+                continue
+            parsed = _parse_color_temp_range(
+                parent_group.get("color_temperature_range")
+            )
             if parsed is not None:
                 return parsed
         return None

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -123,24 +123,25 @@ class JungHomeLight(JungHomeEntity, LightEntity):
             if self._has_brightness
             else None
         )
-        # Prefer the range the gateway advertises for this device's group over the
-        # module defaults: a fixture whose real range is narrower than 2000-6500 K
-        # gets a slider it cannot honour, and — worse — a read outside the
-        # declared range is clamped, so the reported colour temperature silently
-        # differs from the device's. Resolve it BEFORE the first read below, which
-        # already clamps against it.
+        # The module defaults are authoritative. `coordinator.color_temp_range_for
+        # _device` can parse a per-group range out of the `groups` broadcast, but
+        # nothing is wired to it: no captured firmware sends a colour-temperature
+        # field on groups at all (see that method's docstring), so consuming it
+        # would be pure speculation. Two things have to be settled before it can
+        # drive an entity, and neither is answerable without a real capture:
+        #
+        #  - Clamping is asymmetric. Reads are clamped to the range below, writes
+        #    are not, and Home Assistant does not validate `color_temp_kelvin`
+        #    against the declared range either (the service schema is only
+        #    `cv.positive_int`). So `light.turn_on` at 6500 K against a narrower
+        #    advertised range reaches the hardware unchanged, and the entity then
+        #    reports the clamped value — a state contradicting both the device and
+        #    its own declared attributes. Today the window is wide enough that the
+        #    clamp effectively never fires; narrowing it makes that the common path.
+        #  - A group range is a *group* property. Applying it per-fixture is only
+        #    right if every fixture in the group shares it.
         self._min_kelvin, self._max_kelvin = DEFAULT_MIN_KELVIN, DEFAULT_MAX_KELVIN
         if self._has_color_temp:
-            advertised = coordinator.color_temp_range_for_device(device)
-            if advertised is not None:
-                self._min_kelvin, self._max_kelvin = advertised
-                _LOGGER.debug(
-                    "Light %s uses the gateway-advertised colour-temperature "
-                    "range %s-%sK",
-                    self._name,
-                    self._min_kelvin,
-                    self._max_kelvin,
-                )
             self._attr_min_color_temp_kelvin = self._min_kelvin
             self._attr_max_color_temp_kelvin = self._max_kelvin
         self._color_temp: int | None = (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 """Integration setup / entity / lifecycle tests for Jung Home."""
 
 import copy
+import json
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -921,6 +922,91 @@ def test_parse_color_temp_range_rejects_bad_payloads() -> None:
         [2000, 4000, 6500],
     ):
         assert _parse_color_temp_range(raw) is None, raw
+
+
+def test_parse_color_temp_range_survives_unrepresentable_numbers() -> None:
+    """A huge JSON integer is rejected, not raised on.
+
+    `json.loads` parses integer literals at arbitrary precision, so a frame can
+    hand us an `int` that `float()` cannot represent — which raises
+    `OverflowError`, not `ValueError`. This escaped the parser and propagated out
+    of `JungHomeLight.__init__`, so a single malformed frame removed every light
+    entity while the config entry still reported itself loaded.
+    """
+    huge = json.loads("9" * 400)  # an int, not a float
+    assert isinstance(huge, int)
+    with pytest.raises(OverflowError):
+        float(huge)
+    for raw in (
+        {"min": 2700, "max": huge},
+        {"min": huge, "max": 6500},
+        [huge, 6500],
+        [2700, huge],
+        {"min": -huge, "max": huge},
+    ):
+        assert _parse_color_temp_range(raw) is None, raw
+    # A huge *string* is representable (it becomes inf) and is rejected by the
+    # finiteness guard instead.
+    assert _parse_color_temp_range({"min": 2700, "max": "9" * 400}) is None
+
+
+def test_color_temp_range_for_device_survives_malformed_groups(
+    hass: HomeAssistant,
+) -> None:
+    """Non-scalar ids and a non-list parent_groups are rejected, not raised on.
+
+    Both would otherwise raise `TypeError` out of a constructor: an unhashable
+    id blows up the lookup dict, and a non-iterable `parent_groups` blows up the
+    loop.
+    """
+    coordinator = JungHomeDataUpdateCoordinator(
+        hass, {"host": "h", "token": "t"}, MockConfigEntry(domain=DOMAIN)
+    )
+    good = {"id": "g1", "color_temperature_range": {"min": 2700, "max": 4000}}
+    coordinator.groups = [good]
+    for device in (
+        {"id": "d", "parent_groups": 5},  # not iterable
+        {"id": "d", "parent_groups": "g1"},  # a bare string, not a list
+        {"id": "d", "parent_groups": [{"id": "g1"}]},  # unhashable member
+        {"id": "d", "parent_groups": [["g1"]]},
+        {"id": "d", "parent_groups": [None]},
+    ):
+        assert coordinator.color_temp_range_for_device(device) is None, device
+    # Unhashable / malformed group entries are skipped rather than raising.
+    coordinator.groups = [{"id": ["g1"]}, "not a dict", None, good]  # type: ignore[list-item]
+    assert coordinator.color_temp_range_for_device(
+        {"id": "d", "parent_groups": ["g1"]}
+    ) == (2700, 4000)
+
+
+def test_color_temp_range_for_device_first_group_wins(hass: HomeAssistant) -> None:
+    """When two parent groups disagree, the first in `parent_groups` wins.
+
+    Order-dependent by construction, which is only tolerable because nothing
+    consumes the result yet. Pinned so a future caller finds the behaviour
+    documented rather than discovering it.
+    """
+    coordinator = JungHomeDataUpdateCoordinator(
+        hass, {"host": "h", "token": "t"}, MockConfigEntry(domain=DOMAIN)
+    )
+    coordinator.groups = [
+        {"id": "g1", "color_temperature_range": {"min": 2700, "max": 4000}},
+        {"id": "g2", "color_temperature_range": {"min": 2200, "max": 6500}},
+    ]
+    assert coordinator.color_temp_range_for_device(
+        {"id": "d", "parent_groups": ["g1", "g2"]}
+    ) == (2700, 4000)
+    assert coordinator.color_temp_range_for_device(
+        {"id": "d", "parent_groups": ["g2", "g1"]}
+    ) == (2200, 6500)
+    # Duplicate ids resolve to the first occurrence, matching the docstring.
+    coordinator.groups = [
+        {"id": "g1", "color_temperature_range": {"min": 2700, "max": 4000}},
+        {"id": "g1", "color_temperature_range": {"min": 2200, "max": 6500}},
+    ]
+    assert coordinator.color_temp_range_for_device(
+        {"id": "d", "parent_groups": ["g1"]}
+    ) == (2700, 4000)
 
 
 async def test_async_fetch_groups_is_best_effort(hass: HomeAssistant) -> None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -13,7 +13,11 @@ from syrupy.assertion import SnapshotAssertion
 
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
-from custom_components.junghome.light import JungHomeLight
+from custom_components.junghome.light import (
+    DEFAULT_MAX_KELVIN,
+    DEFAULT_MIN_KELVIN,
+    JungHomeLight,
+)
 
 
 def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
@@ -356,10 +360,17 @@ async def test_light_brightness_and_color_temp_are_clamped(hass: HomeAssistant) 
     )
 
 
-async def test_light_uses_gateway_advertised_color_temp_range(
+async def test_light_ignores_any_gateway_advertised_color_temp_range(
     hass: HomeAssistant,
 ) -> None:
-    """The range the gateway advertises for the device's group wins over defaults."""
+    """A group range never reaches the entity — the module defaults are it.
+
+    The coordinator can parse `color_temperature_range` off a group, but no
+    captured firmware sends that field and consuming it is unresolved (asymmetric
+    clamping, group-vs-fixture semantics). This pins that the parser stays
+    disconnected, so wiring it up has to be a deliberate change with a capture
+    behind it rather than something that drifts in.
+    """
     coordinator = _bare_coordinator(hass)
     coordinator.groups = [
         {
@@ -368,17 +379,21 @@ async def test_light_uses_gateway_advertised_color_temp_range(
             "color_temperature_range": {"min": 2700, "max": 4000},
         }
     ]
-    light = _color_light(coordinator, parent_groups=["g1"])
-    assert light.min_color_temp_kelvin == 2700
-    assert light.max_color_temp_kelvin == 4000
-    # A read inside the advertised range is reported as-is.
-    assert light.color_temp_kelvin == 3000
+    # The coordinator does resolve it...
+    assert coordinator.color_temp_range_for_device(
+        {"id": "d1", "parent_groups": ["g1"]}
+    ) == (2700, 4000)
+    # ...but the light is unaffected, and does not clamp a read into it.
+    light = _color_light(coordinator, parent_groups=["g1"], color_temp="6500")
+    assert light.min_color_temp_kelvin == 2000
+    assert light.max_color_temp_kelvin == 6500
+    assert light.color_temp_kelvin == 6500
 
 
-async def test_light_color_temp_range_falls_back_to_defaults(
+async def test_light_color_temp_range_uses_module_defaults(
     hass: HomeAssistant,
 ) -> None:
-    """A missing or malformed advertised range leaves the module defaults in place."""
+    """Every group shape leaves the module defaults in place, valid or not."""
     coordinator = _bare_coordinator(hass)
     for groups in (
         [],  # no groups known yet
@@ -386,31 +401,30 @@ async def test_light_color_temp_range_falls_back_to_defaults(
         [{"id": "g1", "color_temperature_range": "2700-4000"}],  # garbage
         [{"id": "g1", "color_temperature_range": {"min": 4000, "max": 2700}}],
         [{"id": "g1", "color_temperature_range": {"min": 4000, "max": 4000}}],
+        [{"id": "g1", "color_temperature_range": {"min": 2700, "max": 4000}}],  # valid
     ):
         coordinator.groups = groups
         light = _color_light(coordinator, parent_groups=["g1"])
-        assert light.min_color_temp_kelvin == 2000, groups
-        assert light.max_color_temp_kelvin == 6500, groups
+        assert light.min_color_temp_kelvin == DEFAULT_MIN_KELVIN, groups
+        assert light.max_color_temp_kelvin == DEFAULT_MAX_KELVIN, groups
     # A device in no group at all also keeps the defaults.
     light = _color_light(coordinator)
-    assert (light.min_color_temp_kelvin, light.max_color_temp_kelvin) == (2000, 6500)
+    assert (light.min_color_temp_kelvin, light.max_color_temp_kelvin) == (
+        DEFAULT_MIN_KELVIN,
+        DEFAULT_MAX_KELVIN,
+    )
 
 
-async def test_light_clamps_reads_to_the_gateway_range(hass: HomeAssistant) -> None:
-    """Reads clamp to the resolved range, not to the module constants."""
+async def test_light_clamps_reads_to_the_module_defaults(hass: HomeAssistant) -> None:
+    """Reads clamp to the module defaults, which is the only range in play."""
     coordinator = _bare_coordinator(hass)
-    coordinator.groups = [
-        {"id": "g1", "color_temperature_range": {"min": 2700, "max": 4000}}
-    ]
-    # The initial read happens in __init__, so the range must already be resolved:
-    # 6500 K sits inside the module defaults but above this fixture's 4000 K.
-    light = _color_light(coordinator, parent_groups=["g1"], color_temp="6500")
-    assert light.color_temp_kelvin == 4000
+    light = _color_light(coordinator, color_temp="9000")
+    assert light.color_temp_kelvin == DEFAULT_MAX_KELVIN
     assert (
         light._get_color_temp_from_datapoint(
-            {"id": "x", "values": [{"key": "color_temperature", "value": "2000"}]}
+            {"id": "x", "values": [{"key": "color_temperature", "value": "1000"}]}
         )
-        == 2700
+        == DEFAULT_MIN_KELVIN
     )
     assert (
         light._get_color_temp_from_datapoint(


### PR DESCRIPTION
Follow-up to #137, from an adversarial review of that PR after it merged.

## The crash

`_as_kelvin` caught `TypeError`/`ValueError` around `float()`, but **`float()` on a large enough `int` raises `OverflowError`**. `json.loads` parses integer literals at arbitrary precision, so a `groups` frame carrying a 400-digit integer arrives as an `int` Python cannot represent as a float.

Reproduced against `main`:

```
>>> _parse_color_temp_range({"min": 2700, "max": json.loads("9"*400)})
OverflowError: int too large to convert to float
```

The exception escapes `_parse_color_temp_range` → `color_temp_range_for_device` → `JungHomeLight.__init__` → `async_setup_entry`, so the **light platform fails to set up**:

```
ERROR: Error while setting up junghome platform for light: int too large to convert to float
ENTRY STATE: ConfigEntryState.LOADED
LIGHTS: []            <- every light entity gone
COVERS: ['cover.bedroom_blind', 'cover.kitchen_shade']
```

Covers/sensors/climate survive and the entry still reports `LOADED`, which is the worst diagnostic shape — *"the integration is fine, my lights are gone."* This was a new crash site: before #137, `light.__init__` never touched `groups`. Reachable through the list encoding too (`[<huge int>, 6500]`).

The docstring beside the guard also had its reasoning backwards — it claimed a NaN range would "pass the sanity checks below", when `round()` in fact raises on both NaN (`ValueError`) and infinity (`OverflowError`). The stated rule was that these conversions only raise `ValueError`, and that belief is exactly what produced the bug, so it is corrected rather than left to mislead.

Also hardened the group lookup: a non-list `parent_groups`, or an unhashable group id, each raised `TypeError` out of the same constructor path.

## Unwiring the range from the lights

**No captured firmware sends this field.** The gateway captures in `disk_dump/ws-capture*/groups.json` contain 14 real groups, and every one has exactly:

```json
{"id": "id49167", "address": "0xC00F", "name": "WC",
 "related_functions": [...], "function_types": ["switch"]}
```

No colour, temperature or kelvin key anywhere. The name `color_temperature_range` traces to a speculative comment in 29bb3ed, not a capture.

Two further questions are unresolved, and both misreport state if guessed wrong:

- **Clamping is asymmetric.** Reads are clamped to the range; writes are not. Home Assistant does not validate `color_temp_kelvin` against the declared range either — the service schema is only `cv.positive_int` — so `light.turn_on` at 6500 K against a narrower advertised range reaches the hardware unchanged, and the entity then reports the clamped value. That state contradicts both the device and its own declared attributes. With the wide defaults the clamp effectively never fires; a gateway range makes it the common path.
- **A group range is a group property.** Applying it per-fixture is only correct if every fixture in that group shares it.

So the light platform goes back to the module defaults, and the parser stays with its tests. Confirming the field against a real capture later is a one-line change; consuming it today is speculation that can silently misreport a light's colour temperature.

## Tests

New regression coverage for the `OverflowError` payloads, non-scalar `parent_groups`/group ids, and first-match-wins group ordering (previously asserted by a fixture that could not distinguish first from last — the old test passed against a last-wins implementation too). The two light tests that asserted the wiring now pin that the range stays disconnected, so re-wiring has to be deliberate.

mypy `--strict` clean (17 files), **224 tests pass**, coverage 97.86%, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
