### PR TITLE
Fix the snapshot suite's dependency pin and shared-fixture leak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,21 @@ When working on anything that touches the gateway protocol, consult
   `pytest_homeassistant_custom_component`'s `hass` fixture, `MockConfigEntry`,
   `aioclient_mock`. Needs the pinned `homeassistant`; runs on Python 3.14 like
   the other workflows. Run `pytest`; wired into `.github/workflows/test.yml`.
-  Snapshot tests are still absent — see the backlog notes below.
+- **Snapshot tests.** Each platform test file ends with a
+  `test_all_<platform>_entities` case running
+  `pytest_homeassistant_custom_component.common.snapshot_platform` over a
+  single-platform setup (the `init_platform` fixture patches `PLATFORMS` down to
+  one, because `snapshot_platform` refuses a mixed entry). The committed
+  `tests/snapshots/*.ambr` pin every entity's registry entry — `unique_id`
+  included — plus state and attributes, so a change to `stable_unique_id` or to
+  a platform's published attributes shows up as a diff instead of silently
+  re-keying users' entities. Regenerate with `pytest --snapshot-update` and
+  **review the diff**; a `unique_id` change in it is a bug, not a snapshot to
+  accept. A deleted entity surfaces as `N snapshots unused` with a non-zero exit
+  but **no `FAILED` line** — don't misread that as flaky infrastructure.
+  Fixtures hand the coordinator a `deepcopy` of `PRISTINE_DEVICES`: the
+  coordinator merges pushes into the device dicts it is given, so sharing the
+  module-level list by reference lets one test's actuation leak into the next.
 
 ## Ideas from comparing against Home Assistant core conventions
 
@@ -203,13 +217,16 @@ starting so work isn't duplicated.
 - **Per-device diagnostics** (#134, `device-diagnostics`).
   `diagnostics.py` implements only `async_get_config_entry_diagnostics`; adding
   `async_get_device_diagnostics` would let a user download one device's data.
-- **Device triggers for button gestures** (#125,
-  `it-rec:claude/button-device-triggers`). No `device_trigger.py`; the shipped
-  blueprint is currently the only path from raw edges to single/double/hold.
-- **Snapshot testing** (PR branch `snapshot-tests`). No `syrupy`, no `.ambr`
-  files — snapshots would catch unintended entity-attribute/unique-id
-  regressions more cheaply than hand-written assertions, especially now that
-  the platform files exist.
+- ~~**Device triggers for button gestures**~~ — **done** (#125).
+  `device_trigger.py` exposes the press/release primitives on the device page;
+  the shipped blueprint still derives single/double/hold from those edges,
+  since the gateway reports no native gestures.
+- **Device-registry snapshots.** The entity snapshots pin every `unique_id`,
+  but `snapshot_platform` is entity-only: `device_slug()`, `via_device`,
+  `manufacturer`/`model`/`sw_version` and `area_id` are not pinned by any
+  snapshot, so a change there is invisible to the suite. `device_slug` changes
+  are caught indirectly (it composes into every entity `unique_id`); the rest
+  would need an explicit loop over `dr.async_entries_for_config_entry`.
 - **Reusable JSON device/API fixtures.** No `tests/fixtures/` (core
   integrations keep per-model fixtures there); current tests build
   device/datapoint dicts inline.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,3 @@ mypy==2.3.0
 pytest==9.0.3
 pytest-cov==7.1.0
 pytest-homeassistant-custom-component==0.13.348
-syrupy==5.3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -265,7 +265,7 @@ async def init_platform(
     snapshot pins never depend on what an earlier test pushed.
     """
     entries: list[MockConfigEntry] = []
-    fetch_devices = AsyncMock(return_value=PRISTINE_DEVICES)
+    fetch_devices = AsyncMock(return_value=deepcopy(PRISTINE_DEVICES))
     with (
         patch.object(
             JungHomeDataUpdateCoordinator, "_fetch_devices_from_api", fetch_devices
@@ -313,7 +313,7 @@ async def init_integration(hass: HomeAssistant) -> AsyncGenerator[MockConfigEntr
         patch.object(
             JungHomeDataUpdateCoordinator,
             "_fetch_devices_from_api",
-            AsyncMock(return_value=DEVICES),
+            AsyncMock(return_value=deepcopy(PRISTINE_DEVICES)),
         ),
         patch.object(
             JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket


### PR DESCRIPTION
Follow-up to #139, from an adversarial review of that PR after it merged.

## 1. Drop the explicit `syrupy` pin — it is already breaking Renovate

`pytest-homeassistant-custom-component==0.13.348` **already pins `syrupy==5.3.2` exactly**. The extra line is redundant today and unsatisfiable the moment either package moves:

```
0.13.348 -> pytest==9.0.3, syrupy==5.3.2, homeassistant==2026.7.4
0.13.351 -> pytest==9.0.3, syrupy==5.5.3, homeassistant==2026.8.0b3
```

This is no longer hypothetical — **#145 (`syrupy` → 5.5.3) is already open and already red**, and either merge order gives `ResolutionImpossible` at install time, before any test runs:

```
$ printf 'pytest-homeassistant-custom-component==0.13.348\nsyrupy==5.5.3\n' > req.txt
$ pip install --dry-run -r req.txt
ERROR: ResolutionImpossible
  The user requested syrupy==5.5.3
  pytest-homeassistant-custom-component 0.13.348 depends on syrupy==5.3.2
```

The coupling is tight in the *code*, not just the metadata: phacc's syrupy shim tracks syrupy's private API version-for-version, and mixing them fails at import with `ImportError: cannot import name 'is_xdist_controller' from 'syrupy.utils'`.

syrupy still arrives transitively at an exactly-pinned version, so nothing is unpinned by removing the line. #144 groups these packages for Renovate so the whole set moves together; this removes the immediate breakage.

## 2. Deep-copy the device list in `init_integration` too

#139 correctly diagnosed that the coordinator merges pushes into the device dicts it is handed, so sharing the module-level `DEVICES` by reference lets one test's actuation leak into every later test — and it fixed that for the snapshot fixture. But `init_integration`, used by nearly everything else, still passed the list by reference.

**This is a live failure on `main`, not a theoretical one.** Running the test files in reverse order:

```
$ pytest -q $(ls tests/test_*.py | tac)
FAILED tests/test_init.py::test_all_entity_types_created
  AttributeError: 'NoneType' object has no attribute 'state'
1 failed, 220 passed
```

With this change: `221 passed`. Reproduced 3/3 runs each way.

It does not show up in CI today only because ordering happens to be deterministic — `pytest-randomly` is *not* installed, contrary to what #139's body claimed. The day anyone adds it, CI goes intermittently red on a pre-existing test.

Also deep-copies at the second by-reference handoff inside `init_platform`, which is inert today (every caller goes through `_setup`, which already copies) but is the same trap for the next test that doesn't.

## 3. Update the docs that now contradict the tree

`CLAUDE.md` still says snapshot tests are absent and lists them as an open backlog item — #136 landed before #139 and could not know. Also marks device triggers done (#125), and records the **device-registry blind spot** as its own backlog item: `snapshot_platform` is entity-only, so `device_slug()`, `via_device`, `manufacturer`/`model`/`sw_version` and `area_id` are pinned by nothing. Verified — changing `manufacturer` to `"REGRESSION"` leaves all 221 tests green.

Documents the deleted-entity signature too, which is genuinely confusing: an orphaned snapshot exits non-zero reporting `N snapshots unused` and `221 passed`, with **no `FAILED` line**.

mypy `--strict` clean (17 files), 221 tests pass, coverage 97.85%, ruff clean, stable across repeated and reversed-order runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
