### PR TITLE
Drop every pin pytest-homeassistant-custom-component already sets

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,3 @@
 -r requirements.txt
 mypy==2.3.0
-pytest==9.0.3
-pytest-cov==7.1.0
 pytest-homeassistant-custom-component==0.13.348


### PR DESCRIPTION
Unblocks #149, and stops this class of Renovate PR recurring.

`pytest-homeassistant-custom-component` pins **`pytest`, `pytest-cov` and `syrupy` to exact versions**. Declaring them in `requirements_test.txt` too can never do anything except conflict:

| PR | Bump | Outcome |
|---|---|---|
| #142 | `pytest` → 9.1.1 | `phacc` requires `pytest==9.0.3` → red |
| #145 | `syrupy` → 5.5.3 | `phacc` requires `syrupy==5.3.2` → **merged anyway, left `main` unsatisfiable** until #147 |
| #149 | grouped bump | Renovate still resolved `pytest` to 9.1.1 *inside* the group → red the same way |

#144's grouping was necessary but not sufficient: Renovate resolves each package in a group to its own latest, so it re-picked `pytest==9.1.1` against `phacc`'s `pytest==9.0.3`.

Removing the lines is what actually settles it. pip installs all three transitively at whatever `phacc` pins, so they move in lockstep with it and cannot disagree.

Verified:

```
# only mypy + phacc declared
$ pip install --dry-run -r requirements_test.txt
  -> pytest-9.0.3  pytest-cov-7.1.0  syrupy-5.3.2      # exactly phacc's pins

# and a future phacc bump now resolves cleanly
$ pip install --dry-run mypy==2.3.0 \
      pytest-homeassistant-custom-component==0.13.351 homeassistant==2026.8.0b3
  -> pytest-9.0.3  pytest-cov-7.1.0  syrupy-5.5.3  homeassistant-2026.8.0b3
```

`mypy` stays — `phacc` does not pin it.

224 tests pass, coverage 97.86%, mypy `--strict` clean, ruff clean.

### Note on #149

With this in, the only thing #149 still needs is `homeassistant` moving with `phacc` — `0.13.351` requires `homeassistant==2026.8.0b3`, a **pre-release**. That is a deliberate call about tracking HA betas, not something to fix in config, so #149 is best closed and left to Renovate to regenerate once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
