### PR TITLE
Release 1.5.0b1

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.4.0",
+  "version": "1.5.0b1",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
First beta of 1.5.0, cut from `main` as it stands. Everything merged since v1.4.0:

| PR | |
|---|---|
| #125 | Device triggers for rocker buttons |
| #131 | Don't add a discovered gateway twice when its host is typed manually |
| #132 | Verify the gateway is reachable before committing a reconfigured host |
| #133 | Narrow the best-effort `except` handlers so real bugs surface |
| #134 | Per-device diagnostics |
| #138 | Repair issue when WebSocket push stays down |
| #139 | syrupy snapshot tests for every platform |
| #146 | Stop a malformed gateway frame from removing every light |

Plus housekeeping: #136/#140/#143 (docs and wording), #144/#147/#150 (Renovate and dependency pins), #149 (test stack).

## Why a beta rather than 1.5.0

Two reasons, both worth exposure on the beta channel first:

- **#149 moved the pinned Home Assistant to `2026.8.0b3`** — itself a Home Assistant beta, required exactly by `pytest-homeassistant-custom-component==0.13.351`. Shipping that as a stable release would put every HACS user on an HA beta's API surface.
- **#137's gateway-advertised colour-temperature parser is deliberately not wired to any entity.** No captured firmware sends `color_temperature_range` at all — the 14 real groups in the gateway captures carry only `id`, `address`, `name`, `related_functions`, `function_types` — so the parser exists with its tests but the light platform keeps its built-in defaults. #146 covers the reasoning.

Because the version carries a suffix, `.github/workflows/release.yml` publishes this as a GitHub **pre-release** and passes `--latest=false`, so HACS only offers it to users who have opted into betas for this repository.

Verified on `main` against the pinned stack: mypy `--strict` clean (17 source files), **224 tests pass**, 34 snapshots pass, coverage 97.86%, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
