### PR TITLE
Stay on the Home Assistant 2026.7 line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,25 @@
         "syrupy"
       ],
       "groupName": "home-assistant test stack"
+    },
+    {
+      "description": "Stay on the Home Assistant 2026.7 line: test against what users actually run, not a beta. 2026.8 exists only as betas so far. pytest-homeassistant-custom-component is capped alongside it because it pins homeassistant exactly, and 0.13.349 onwards target 2026.8 betas -- 0.13.348 is the last release on 2026.7.4. Lift both caps together once 2026.8.0 is released and a matching phacc exists.",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchPackageNames": [
+        "homeassistant"
+      ],
+      "allowedVersions": "<2026.8.0"
+    },
+    {
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchPackageNames": [
+        "pytest-homeassistant-custom-component"
+      ],
+      "allowedVersions": "<0.13.349"
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.12.0
-homeassistant==2026.8.0b3
+homeassistant==2026.7.4
 pip>=26.2
 ruff==0.16.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 mypy==2.3.0
-pytest-homeassistant-custom-component==0.13.351
+pytest-homeassistant-custom-component==0.13.348

--- a/tests/snapshots/test_climate.ambr
+++ b/tests/snapshots/test_climate.ambr
@@ -69,7 +69,7 @@
       ]),
       <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 17>,
       <ClimateEntityCapabilityAttribute.TARGET_TEMP_STEP: 'target_temp_step'>: 0.5,
-      <ClimateEntityStateAttribute.TARGET_TEMPERATURE: 'temperature'>: 21.5,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 21.5,
     }),
     'context': <ANY>,
     'entity_id': 'climate.living_room',


### PR DESCRIPTION
Reverts #149 and stops Renovate re-proposing it.

| | from | to |
|---|---|---|
| `homeassistant` | 2026.8.0b3 | **2026.7.4** |
| `pytest-homeassistant-custom-component` | 0.13.351 | **0.13.348** |

The two must move together — `phacc` pins `homeassistant` exactly, so `0.13.351` cannot install against anything but `2026.8.0b3`.

`tests/snapshots/test_climate.ambr` reverts with them. 2026.8 renamed the enum member `ClimateEntityStateAttribute.TEMPERATURE` → `TARGET_TEMPERATURE`; the serialized key is still `temperature` and the value is unchanged, so this only affects how syrupy renders the attribute. It does mean the `.ambr` is coupled to whichever HA is pinned and has to move in step with it.

## You are not giving up anything current

- **`2026.7.4` is already the newest stable Home Assistant.** `2026.8` exists only as `b0`–`b3`; there is no `2026.8.0` release yet.
- **`0.13.348` is the last phacc targeting the 2026.7 line.** `0.13.349` → `2026.8.0b0`, `0.13.350` → `2026.8.0b2`, `0.13.351` → `2026.8.0b3`.

So this is the newest possible combination that stays on 2026.7.*.

## Renovate caps

Both packages are capped (`homeassistant <2026.8.0`, `phacc <0.13.349`) with the reasoning inline, otherwise Renovate would re-open the same grouped bump within a day. **Lift both together** once `2026.8.0` ships and a matching phacc exists.

## Correction to what I said on the release PR

I previously implied the beta pin would reach HACS users. It would not — `manifest.json` declares `"requirements": []` and the shipped component names no Home Assistant version, so `requirements.txt` only decides what **CI** tests against. Staying on 2026.7 is still the right call for the better reason: the test suite should run against the release users are actually on.

Verified on the reverted stack: mypy `--strict` clean (17 source files), 224 tests pass, 34 snapshots pass, coverage 97.86%, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
