### PR TITLE
Release 1.5.0b2

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.0b1",
+  "version": "1.5.0b2",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
Second beta of 1.5.0, cut from `main` as it stands.

The only change over **v1.5.0b1** is #152:

| | from | to |
|---|---|---|
| `homeassistant` | 2026.8.0b3 | **2026.7.4** |
| `pytest-homeassistant-custom-component` | 0.13.351 | **0.13.348** |

Plus the Renovate caps that keep it there, and the `test_climate.ambr` revert that has to move with the HA pin.

**The shipped integration is byte-identical to b1.** `manifest.json` declares `"requirements": []`, so these pins only decide what CI tests against. What changed is that the suite now runs against the newest *stable* Home Assistant instead of a 2026.8 beta — which is the point.

Still a beta rather than 1.5.0 for one remaining reason: #137's gateway-advertised colour-temperature parser is deliberately unwired (no captured firmware sends the field), so it is dormant code carried into this line. Everything else in 1.5.0 has been on the beta channel since b1.

Verified on `main` against the pinned stack: mypy `--strict` clean (17 source files), 224 tests pass, 34 snapshots pass, coverage 97.86%, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAURieNJYbxeFy628D7Z2u
