### PR TITLE
Backfill device-trigger strings into all 25 non-English locales

### DIFF
--- a/custom_components/junghome/translations/ca.json
+++ b/custom_components/junghome/translations/ca.json
@@ -92,6 +92,17 @@
       "no_covers": "No s'ha trobat cap persiana en aquesta passarel·la, així que no hi ha res a configurar."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Botó amunt {subtype}",
+      "down": "Botó avall {subtype}",
+      "press": "Botó {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "premut",
+      "depressed": "alliberat"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Connexió" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "L'escena {label} de Jung Home ja no està disponible a la passarel·la."
+    },
+    "invalid_trigger": {
+      "message": "El dispositiu Jung Home no admet l'activador {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/cs.json
+++ b/custom_components/junghome/translations/cs.json
@@ -92,6 +92,17 @@
       "no_covers": "Na této bráně nebyly nalezeny žádné žaluzie, není tedy co nastavovat."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Horní tlačítko {subtype}",
+      "down": "Dolní tlačítko {subtype}",
+      "press": "Tlačítko {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "stisknuto",
+      "depressed": "uvolněno"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Připojení" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Scéna Jung Home {label} již není na bráně dostupná."
+    },
+    "invalid_trigger": {
+      "message": "Zařízení Jung Home nepodporuje spouštěč {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/da.json
+++ b/custom_components/junghome/translations/da.json
@@ -92,6 +92,17 @@
       "no_covers": "Der blev ikke fundet nogen gardiner på denne gateway, så der er intet at konfigurere."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Op-knap {subtype}",
+      "down": "Ned-knap {subtype}",
+      "press": "Knap {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "trykket",
+      "depressed": "sluppet"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Forbindelse" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home-scenen {label} er ikke længere tilgængelig på gatewayen."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home-enheden understøtter ikke udløseren {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/de.json
+++ b/custom_components/junghome/translations/de.json
@@ -92,6 +92,17 @@
       "no_covers": "Auf diesem Gateway wurden keine Rollos gefunden, es gibt also nichts zu konfigurieren."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Taste oben {subtype}",
+      "down": "Taste unten {subtype}",
+      "press": "Taste {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "gedrückt",
+      "depressed": "losgelassen"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Verbindung" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Die Jung Home Szene {label} ist auf dem Gateway nicht mehr verfügbar."
+    },
+    "invalid_trigger": {
+      "message": "Das Jung Home-Gerät unterstützt den Auslöser {trigger} nicht."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/el.json
+++ b/custom_components/junghome/translations/el.json
@@ -92,6 +92,17 @@
       "no_covers": "Δεν βρέθηκαν ρολά σε αυτή την πύλη, επομένως δεν υπάρχει τίποτα για διαμόρφωση."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Επάνω κουμπί {subtype}",
+      "down": "Κάτω κουμπί {subtype}",
+      "press": "Κουμπί {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "πατήθηκε",
+      "depressed": "αφέθηκε"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Σύνδεση" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Η σκηνή {label} του Jung Home δεν είναι πλέον διαθέσιμη στην πύλη."
+    },
+    "invalid_trigger": {
+      "message": "Η συσκευή Jung Home δεν υποστηρίζει την ενεργοποίηση {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/es.json
+++ b/custom_components/junghome/translations/es.json
@@ -92,6 +92,17 @@
       "no_covers": "No se encontraron persianas en esta pasarela, así que no hay nada que configurar."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Botón arriba {subtype}",
+      "down": "Botón abajo {subtype}",
+      "press": "Botón {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "pulsado",
+      "depressed": "soltado"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Conexión" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "La escena {label} de Jung Home ya no está disponible en la pasarela."
+    },
+    "invalid_trigger": {
+      "message": "El dispositivo Jung Home no admite el activador {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/fi.json
+++ b/custom_components/junghome/translations/fi.json
@@ -92,6 +92,17 @@
       "no_covers": "Tästä yhdyskäytävästä ei löytynyt verhoja, joten määritettävää ei ole."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Ylöspainike {subtype}",
+      "down": "Alaspainike {subtype}",
+      "press": "Painike {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "painettu",
+      "depressed": "vapautettu"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Yhteys" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home -skene {label} ei ole enää käytettävissä yhdyskäytävässä."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home -laite ei tue liipaisinta {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/fr.json
+++ b/custom_components/junghome/translations/fr.json
@@ -92,6 +92,17 @@
       "no_covers": "Aucun volet n'a été trouvé sur cette passerelle, il n'y a donc rien à configurer."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Bouton haut {subtype}",
+      "down": "Bouton bas {subtype}",
+      "press": "Bouton {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "appuyé",
+      "depressed": "relâché"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Connexion" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "La scène Jung Home {label} n'est plus disponible sur la passerelle."
+    },
+    "invalid_trigger": {
+      "message": "L'appareil Jung Home ne prend pas en charge le déclencheur {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/hu.json
+++ b/custom_components/junghome/translations/hu.json
@@ -92,6 +92,17 @@
       "no_covers": "Ezen az átjárón nem található árnyékoló, így nincs mit beállítani."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Felső gomb {subtype}",
+      "down": "Alsó gomb {subtype}",
+      "press": "Gomb {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "megnyomva",
+      "depressed": "elengedve"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Kapcsolat" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "A(z) {label} Jung Home jelenet már nem érhető el az átjárón."
+    },
+    "invalid_trigger": {
+      "message": "A Jung Home eszköz nem támogatja a(z) {trigger} eseményindítót."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/it.json
+++ b/custom_components/junghome/translations/it.json
@@ -92,6 +92,17 @@
       "no_covers": "Non è stata trovata alcuna tapparella su questo gateway, quindi non c'è nulla da configurare."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Pulsante su {subtype}",
+      "down": "Pulsante giù {subtype}",
+      "press": "Pulsante {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "premuto",
+      "depressed": "rilasciato"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Connessione" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "La scena Jung Home {label} non è più disponibile sul gateway."
+    },
+    "invalid_trigger": {
+      "message": "Il dispositivo Jung Home non supporta il trigger {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/ja.json
+++ b/custom_components/junghome/translations/ja.json
@@ -92,6 +92,17 @@
       "no_covers": "このゲートウェイにはカバーが見つからなかったため、設定する項目はありません。"
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "上ボタンが{subtype}",
+      "down": "下ボタンが{subtype}",
+      "press": "ボタンが{subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "押されました",
+      "depressed": "離されました"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "接続" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home のシーン {label} はゲートウェイで利用できなくなりました。"
+    },
+    "invalid_trigger": {
+      "message": "Jung Home デバイスはトリガー {trigger} をサポートしていません。"
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/ko.json
+++ b/custom_components/junghome/translations/ko.json
@@ -92,6 +92,17 @@
       "no_covers": "이 게이트웨이에서 커버를 찾지 못했으므로 구성할 항목이 없습니다."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "위 버튼 {subtype}",
+      "down": "아래 버튼 {subtype}",
+      "press": "버튼 {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "눌림",
+      "depressed": "놓임"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "연결" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home 장면 {label}을(를) 게이트웨이에서 더 이상 사용할 수 없습니다."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home 기기가 {trigger} 트리거를 지원하지 않습니다."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/lt.json
+++ b/custom_components/junghome/translations/lt.json
@@ -92,6 +92,17 @@
       "no_covers": "Šiame sietuve žaliuzių nerasta, todėl nėra ko konfigūruoti."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Viršutinis mygtukas {subtype}",
+      "down": "Apatinis mygtukas {subtype}",
+      "press": "Mygtukas {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "paspaustas",
+      "depressed": "atleistas"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Ryšys" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "„Jung Home“ scena {label} sietuve nebepasiekiama."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home įrenginys nepalaiko aktyviklio {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/nb.json
+++ b/custom_components/junghome/translations/nb.json
@@ -92,6 +92,17 @@
       "no_covers": "Det ble ikke funnet noen persienner på denne gatewayen, så det er ingenting å konfigurere."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Opp-knapp {subtype}",
+      "down": "Ned-knapp {subtype}",
+      "press": "Knapp {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "trykket",
+      "depressed": "sluppet"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Tilkobling" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home-scenen {label} er ikke lenger tilgjengelig på gatewayen."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home-enheten støtter ikke utløseren {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/nl.json
+++ b/custom_components/junghome/translations/nl.json
@@ -92,6 +92,17 @@
       "no_covers": "Er is geen zonwering gevonden op deze gateway, dus er valt niets te configureren."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Knop omhoog {subtype}",
+      "down": "Knop omlaag {subtype}",
+      "press": "Knop {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "ingedrukt",
+      "depressed": "losgelaten"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Verbinding" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "De Jung Home-scène {label} is niet meer beschikbaar op de gateway."
+    },
+    "invalid_trigger": {
+      "message": "Het Jung Home-apparaat ondersteunt de trigger {trigger} niet."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/pl.json
+++ b/custom_components/junghome/translations/pl.json
@@ -92,6 +92,17 @@
       "no_covers": "Na tej bramce nie znaleziono żadnych rolet, więc nie ma nic do skonfigurowania."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Górny przycisk {subtype}",
+      "down": "Dolny przycisk {subtype}",
+      "press": "Przycisk {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "naciśnięty",
+      "depressed": "zwolniony"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Połączenie" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Scena Jung Home {label} nie jest już dostępna na bramce."
+    },
+    "invalid_trigger": {
+      "message": "Urządzenie Jung Home nie obsługuje wyzwalacza {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/pt-BR.json
+++ b/custom_components/junghome/translations/pt-BR.json
@@ -92,6 +92,17 @@
       "no_covers": "Nenhuma persiana foi encontrada neste gateway, então não há nada para configurar."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Botão para cima {subtype}",
+      "down": "Botão para baixo {subtype}",
+      "press": "Botão {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "pressionado",
+      "depressed": "solto"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Conexão" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "A cena {label} do Jung Home não está mais disponível no gateway."
+    },
+    "invalid_trigger": {
+      "message": "O dispositivo Jung Home não oferece suporte ao gatilho {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/ro.json
+++ b/custom_components/junghome/translations/ro.json
@@ -92,6 +92,17 @@
       "no_covers": "Nu au fost găsite jaluzele pe acest gateway, așadar nu este nimic de configurat."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Buton sus {subtype}",
+      "down": "Buton jos {subtype}",
+      "press": "Buton {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "apăsat",
+      "depressed": "eliberat"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Conexiune" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Scena Jung Home {label} nu mai este disponibilă pe gateway."
+    },
+    "invalid_trigger": {
+      "message": "Dispozitivul Jung Home nu acceptă declanșatorul {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/ru.json
+++ b/custom_components/junghome/translations/ru.json
@@ -92,6 +92,17 @@
       "no_covers": "На этом шлюзе жалюзи не найдены, поэтому настраивать нечего."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Верхняя кнопка {subtype}",
+      "down": "Нижняя кнопка {subtype}",
+      "press": "Кнопка {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "нажата",
+      "depressed": "отпущена"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Подключение" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Сцена Jung Home {label} больше недоступна на шлюзе."
+    },
+    "invalid_trigger": {
+      "message": "Устройство Jung Home не поддерживает триггер {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/sk.json
+++ b/custom_components/junghome/translations/sk.json
@@ -92,6 +92,17 @@
       "no_covers": "Na tejto bráne sa nenašli žiadne žalúzie, takže nie je čo nastavovať."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Horné tlačidlo {subtype}",
+      "down": "Dolné tlačidlo {subtype}",
+      "press": "Tlačidlo {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "stlačené",
+      "depressed": "uvoľnené"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Pripojenie" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Scéna Jung Home {label} už na bráne nie je dostupná."
+    },
+    "invalid_trigger": {
+      "message": "Zariadenie Jung Home nepodporuje spúšťač {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/sl.json
+++ b/custom_components/junghome/translations/sl.json
@@ -92,6 +92,17 @@
       "no_covers": "Na tem prehodu ni bilo najdenih senčil, zato ni ničesar za nastaviti."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Zgornji gumb {subtype}",
+      "down": "Spodnji gumb {subtype}",
+      "press": "Gumb {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "pritisnjen",
+      "depressed": "sproščen"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Povezava" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Scena Jung Home {label} na prehodu ni več na voljo."
+    },
+    "invalid_trigger": {
+      "message": "Naprava Jung Home ne podpira sprožilca {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/sv.json
+++ b/custom_components/junghome/translations/sv.json
@@ -92,6 +92,17 @@
       "no_covers": "Inga persienner hittades på den här gatewayen, så det finns inget att konfigurera."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Upp-knapp {subtype}",
+      "down": "Ned-knapp {subtype}",
+      "press": "Knapp {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "nedtryckt",
+      "depressed": "släppt"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Anslutning" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home-scenen {label} är inte längre tillgänglig på gatewayen."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home-enheten stöder inte utlösaren {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/tr.json
+++ b/custom_components/junghome/translations/tr.json
@@ -92,6 +92,17 @@
       "no_covers": "Bu ağ geçidinde panjur bulunamadı, dolayısıyla yapılandırılacak bir şey yok."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Yukarı düğmesi {subtype}",
+      "down": "Aşağı düğmesi {subtype}",
+      "press": "Düğme {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "basıldı",
+      "depressed": "bırakıldı"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Bağlantı" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "{label} adlı Jung Home sahnesi ağ geçidinde artık kullanılamıyor."
+    },
+    "invalid_trigger": {
+      "message": "Jung Home cihazı {trigger} tetikleyicisini desteklemiyor."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/uk.json
+++ b/custom_components/junghome/translations/uk.json
@@ -92,6 +92,17 @@
       "no_covers": "На цьому шлюзі жалюзі не знайдено, тому налаштовувати нічого."
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "Верхня кнопка {subtype}",
+      "down": "Нижня кнопка {subtype}",
+      "press": "Кнопка {subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "натиснута",
+      "depressed": "відпущена"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "Підключення" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Сцена Jung Home {label} більше недоступна на шлюзі."
+    },
+    "invalid_trigger": {
+      "message": "Пристрій Jung Home не підтримує тригер {trigger}."
     }
   },
   "issues": {

--- a/custom_components/junghome/translations/zh-Hans.json
+++ b/custom_components/junghome/translations/zh-Hans.json
@@ -92,6 +92,17 @@
       "no_covers": "此网关上未找到窗帘，因此无需配置。"
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "up": "上按钮{subtype}",
+      "down": "下按钮{subtype}",
+      "press": "按钮{subtype}"
+    },
+    "trigger_subtype": {
+      "pressed": "已按下",
+      "depressed": "已松开"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "gateway_connectivity": { "name": "连接" }
@@ -131,6 +142,9 @@
     },
     "scene_not_found": {
       "message": "Jung Home 场景 {label} 在网关上已不再可用。"
+    },
+    "invalid_trigger": {
+      "message": "Jung Home 设备不支持触发器 {trigger}。"
     }
   },
   "issues": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,89 @@
+"""Translation-file consistency checks.
+
+`strings.json` and the 26 files in `translations/` have to stay in lockstep: a
+key added to one and not the others silently falls back to English for every
+other locale, which is exactly how the device-trigger strings ended up
+English-only in 25 locales. hassfest only validates `en` for custom
+integrations, so this is the only automated guard available.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_COMPONENT = Path(__file__).parent.parent / "custom_components" / "junghome"
+_STRINGS = _COMPONENT / "strings.json"
+_TRANSLATIONS = sorted((_COMPONENT / "translations").glob("*.json"))
+
+
+def _load(path: Path) -> dict:
+    """Parse a translation file, rejecting duplicate keys.
+
+    `json.load` keeps the last of a duplicated key, so a botched merge that
+    writes the same block twice parses cleanly and compares equal. Reject it
+    here instead.
+    """
+
+    def _no_duplicates(pairs):
+        seen = set()
+        for key, _ in pairs:
+            if key in seen:
+                raise ValueError(f"duplicate key {key!r} in {path.name}")
+            seen.add(key)
+        return dict(pairs)
+
+    return json.loads(
+        path.read_text(encoding="utf-8"), object_pairs_hook=_no_duplicates
+    )
+
+
+def _leaves(obj: object, prefix: str = "") -> dict[str, str]:
+    """Flatten a nested translation dict to {dotted.key: value}."""
+    if not isinstance(obj, dict):
+        return {prefix: obj}
+    out: dict[str, str] = {}
+    for key, value in obj.items():
+        out.update(_leaves(value, f"{prefix}.{key}" if prefix else key))
+    return out
+
+
+def _placeholders(value: object) -> set[str]:
+    return set(re.findall(r"\{(\w+)\}", str(value)))
+
+
+def test_translations_directory_is_not_empty() -> None:
+    """Guard the parametrisation itself — an empty glob would vacuously pass."""
+    assert len(_TRANSLATIONS) >= 26
+
+
+@pytest.mark.parametrize("path", _TRANSLATIONS, ids=lambda p: p.stem)
+def test_locale_matches_strings_json(path: Path) -> None:
+    """Every locale carries exactly the keys `strings.json` defines."""
+    expected = _leaves(_load(_STRINGS))
+    actual = _leaves(_load(path))
+
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    assert not missing, f"{path.name} is missing {len(missing)} keys: {missing}"
+    assert not extra, f"{path.name} has {len(extra)} keys not in strings.json: {extra}"
+
+
+@pytest.mark.parametrize("path", _TRANSLATIONS, ids=lambda p: p.stem)
+def test_locale_preserves_placeholders(path: Path) -> None:
+    """A renamed/dropped {placeholder} raises KeyError when HA formats the string."""
+    expected = _leaves(_load(_STRINGS))
+    for key, value in _leaves(_load(path)).items():
+        if key in expected:
+            assert _placeholders(value) == _placeholders(expected[key]), (
+                f"{path.name}: placeholder mismatch in {key}"
+            )
+
+
+@pytest.mark.parametrize("path", [_STRINGS, *_TRANSLATIONS], ids=lambda p: p.stem)
+def test_no_angle_brackets(path: Path) -> None:
+    """`<`/`>` in translation text breaks Home Assistant's translation parser."""
+    for key, value in _leaves(_load(path)).items():
+        assert "<" not in str(value), f"{path.name}: '<' in {key}"
+        assert ">" not in str(value), f"{path.name}: '>' in {key}"


### PR DESCRIPTION
## Problem

The strings added with the device triggers (#125) landed only in `strings.json` and `translations/en.json`. A mechanical diff of all 26 locales against `strings.json` (60 leaf keys) found **every non-English locale missing exactly the same six keys**:

```
25 locales  device_automation.trigger_type.up / .down / .press
25 locales  device_automation.trigger_subtype.pressed / .depressed
25 locales  exceptions.invalid_trigger.message
                                   → 6 × 25 = 150 missing entries
```

So the device-trigger UI and the invalid-trigger error message fell back to English in every language. `CLAUDE.md` already mandates updating all 26 files together — the step was skipped, and nothing in CI catches it, since hassfest only validates `en` for custom integrations.

## Changes

**1. Backfilled all 150 entries.** Inserted textually rather than by re-dumping JSON, so untouched lines keep their existing formatting — the diff is **purely additive: 350 insertions, 0 deletions**, 14 lines per locale.

**2. Added `tests/test_translations.py`.** For every locale it asserts:

- identical leaf-key sets to `strings.json` — catches keys missing *and* dead keys
- identical `{placeholders}` per key — a renamed or dropped placeholder raises `KeyError` when HA formats the string at runtime
- no `<` / `>`, which break HA's translation parser (already a documented rule in `CLAUDE.md`)
- no duplicate JSON keys, which `json.load` silently collapses to the last value

The guard is not theoretical — while preparing this change it caught both a dropped key and an accidental double-insertion:

```
AssertionError: de.json is missing 1 keys: ['device_automation.trigger_subtype.pressed']
ValueError: duplicate key 'device_automation' in ca.json
```

## Verification

304 passed (224 before, +80 parametrised parity tests), `ruff` clean, no production code touched.

Translations are my best-effort renderings — the `trigger_type` strings compose with `{subtype}` (e.g. "Up button pressed"), so the subtypes are participles in each language. Native-speaker corrections welcome.

Found during a full platinum-scale review; see `CLAUDE-review.md` §1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)