### PR TITLE
Count WebSocket flaps and clean closes as failures; clear the issue on stop

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -12,12 +12,13 @@ from urllib.parse import quote
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -38,6 +39,13 @@ RECONNECT_JITTER = 0.5
 # rides out silently; past it the gateway has been unreachable long enough that
 # the user is unknowingly running on the 60 s REST poll and deserves to be told.
 MAX_RECONNECT_FAILURES = 5
+# How long a session must stay up before it counts as a genuine recovery rather
+# than a flap. Resetting the backoff at the moment of connect made the escalation
+# unreachable: a gateway that accepts the upgrade and drops us immediately (a
+# reboot loop, a websocket server restart cycle, a client limit) would reconnect
+# roughly once a second forever, never raising the repair issue and flapping every
+# controllable entity. A session shorter than this is treated as a failed attempt.
+STABLE_SESSION_SECONDS = 30
 # Repair-issue translation key for that "live push is dead" state.
 ISSUE_PUSH_FAILURE = "websocket_push_failure"
 
@@ -524,18 +532,25 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         headers = {"token": f"{self.config['token']}"}
         async with session.ws_connect(url, headers=headers, heartbeat=30) as ws:
             self.websocket = ws
-            # Connected: reset the backoff and resync state we may have missed
-            # while disconnected. Logged at INFO (paired with the WARNING on
-            # disconnect) so the drop/recover story is visible without enabling
-            # debug logging during a long soak.
-            self._reconnect_delay = INITIAL_RECONNECT_DELAY
-            # Live push is back, so clear the counter and the degraded-mode
-            # repair issue (a no-op when it was never raised).
-            self._reconnect_failures = 0
-            ir.async_delete_issue(self.hass, DOMAIN, self._push_failure_issue_id)
+            # Connected: resync state we may have missed while disconnected.
+            # Logged at INFO (paired with the WARNING on disconnect) so the
+            # drop/recover story is visible without enabling debug logging
+            # during a long soak.
+            #
+            # The backoff and the failure counter are deliberately NOT reset
+            # here. A successful upgrade proves nothing yet — a gateway stuck in
+            # a reboot loop accepts the handshake and drops us straight away, and
+            # resetting on connect made that flap immortal: the delay went back
+            # to 1 s before the doubling could ever apply, and the counter never
+            # reached MAX_RECONNECT_FAILURES so the repair issue never appeared.
+            # `_mark_session_stable` below does the reset once the session has
+            # actually lasted STABLE_SESSION_SECONDS.
             _LOGGER.info("Jung Home WebSocket connected")
             self.ws_connected = True
             self.ws_last_connected = dt_util.utcnow()
+            cancel_stable = async_call_later(
+                self.hass, STABLE_SESSION_SECONDS, self._mark_session_stable
+            )
             await self.async_request_refresh()
             try:
                 async for msg in ws:
@@ -581,10 +596,36 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                             _LOGGER.error("Message content: %s", msg.data)
                     elif msg.type == aiohttp.WSMsgType.ERROR:
                         raise ConnectionError(f"WebSocket error frame: {msg}")
+                # The gateway closed the socket cleanly: `async for` just ends,
+                # without raising. Returning normally here would make the drop
+                # invisible — no warning, no `last_error`, and no reconnect-failure
+                # count, so a gateway that politely closes every session would
+                # never raise the repair issue that exists for exactly this
+                # silent degradation. Route it through the same failure path a
+                # noisy drop takes.
+                if not self._closing:
+                    raise ConnectionError(
+                        f"gateway closed the WebSocket (code {ws.close_code})"
+                    )
             finally:
+                cancel_stable()
                 self.websocket = None
                 self.ws_connected = False
                 self._notify_websocket_closed()
+
+    @callback
+    def _mark_session_stable(self, _now: datetime) -> None:
+        """Treat the live session as a genuine recovery once it has held up.
+
+        Fires ``STABLE_SESSION_SECONDS`` after a successful connect, and is
+        cancelled if the session dies first — so a flapping gateway keeps
+        escalating its backoff and keeps accumulating failures towards the repair
+        issue, while a gateway that is actually back clears both (and the issue,
+        a no-op when it was never raised).
+        """
+        self._reconnect_delay = INITIAL_RECONNECT_DELAY
+        self._reconnect_failures = 0
+        ir.async_delete_issue(self.hass, DOMAIN, self._push_failure_issue_id)
 
     def _notify_websocket_closed(self) -> None:
         """Push the WebSocket-down state to listeners after a live drop.
@@ -797,6 +838,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         """Stop the coordinator and close the WebSocket connection."""
         _LOGGER.debug("Stopping coordinator and closing WebSocket")
         self._closing = True
+        # Drop the degraded-push repair issue on the way out. It was only ever
+        # deleted on a successful reconnect, so unloading, disabling or removing
+        # the entry while degraded stranded it in the repairs UI forever, naming
+        # a gateway that may no longer be configured. A no-op when unraised.
+        ir.async_delete_issue(self.hass, DOMAIN, self._push_failure_issue_id)
         if self._ws_task is not None:
             self._ws_task.cancel()
             try:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for the Jung Home data update coordinator."""
 
+import asyncio
 import json
 from datetime import timedelta
 from typing import Self
@@ -20,7 +21,9 @@ from pytest_homeassistant_custom_component.common import (
 
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import (
+    INITIAL_RECONNECT_DELAY,
     MAX_RECONNECT_FAILURES,
+    STABLE_SESSION_SECONDS,
     JungHomeDataUpdateCoordinator,
 )
 
@@ -199,6 +202,7 @@ class _EmptyWS:
 
     def __init__(self) -> None:
         self.closed = False
+        self.close_code = 1000
 
     async def __aenter__(self) -> Self:
         return self
@@ -265,16 +269,118 @@ async def test_no_repair_issue_below_failure_threshold(hass: HomeAssistant) -> N
     )
 
 
-async def test_repair_issue_cleared_on_successful_reconnect(
-    hass: HomeAssistant,
+class _HoldingWS:
+    """A WebSocket that connects and stays open until `release` is set."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_code = 1000
+        self.release = asyncio.Event()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> object:
+        await self.release.wait()
+        raise StopAsyncIteration
+
+
+async def test_repair_issue_cleared_once_session_proves_stable(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Getting the WebSocket back deletes the issue and resets the counter."""
+    """A session that *holds up* clears the issue and resets the counter.
+
+    Recovery is judged on the session lasting `STABLE_SESSION_SECONDS`, not on
+    the handshake succeeding — see the flapping test below for why.
+    """
     coordinator = _coordinator(hass)
     coordinator.data = []
     await _run_failing_loop(coordinator, MAX_RECONNECT_FAILURES)
     registry = ir.async_get(hass)
     assert registry.async_get_issue(DOMAIN, coordinator._push_failure_issue_id)
 
+    coordinator._closing = False
+    ws = _HoldingWS()
+    session = Mock()
+    session.ws_connect = Mock(return_value=ws)
+    with (
+        patch(
+            "custom_components.junghome.coordinator.async_get_clientsession",
+            return_value=session,
+        ),
+        patch.object(coordinator, "async_request_refresh", AsyncMock()),
+    ):
+        # NB: not async_block_till_done — the session is deliberately still open,
+        # so the task never completes. Yield just enough for it to reach the pump.
+        task = hass.async_create_task(coordinator._run_websocket())
+        for _ in range(5):
+            await asyncio.sleep(0)
+        # Still connected, but not yet proven stable.
+        assert registry.async_get_issue(DOMAIN, coordinator._push_failure_issue_id)
+
+        freezer.tick(timedelta(seconds=STABLE_SESSION_SECONDS + 1))
+        async_fire_time_changed(hass)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert (
+            registry.async_get_issue(DOMAIN, coordinator._push_failure_issue_id) is None
+        )
+        assert coordinator._reconnect_failures == 0
+        assert coordinator._reconnect_delay == INITIAL_RECONNECT_DELAY
+
+        coordinator._closing = True
+        ws.release.set()
+        await task
+
+
+async def test_flapping_session_keeps_escalating(hass: HomeAssistant) -> None:
+    """A connect that drops straight away is a failure, not a recovery.
+
+    Resetting the backoff on connect made the escalation unreachable: the delay
+    returned to 1 s before the doubling could apply and the failure counter never
+    reached the repair-issue threshold, so a gateway in a reboot loop reconnected
+    about once a second forever with nothing surfaced to the user.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = []
+    coordinator._reconnect_failures = MAX_RECONNECT_FAILURES - 1
+    coordinator._reconnect_delay = 8
+
+    session = Mock()
+    session.ws_connect = Mock(return_value=_EmptyWS())
+    with (
+        patch(
+            "custom_components.junghome.coordinator.async_get_clientsession",
+            return_value=session,
+        ),
+        patch.object(coordinator, "async_request_refresh", AsyncMock()),
+        pytest.raises(ConnectionError),
+    ):
+        await coordinator._run_websocket()
+
+    # The instant close neither reset the backoff nor cleared the counter.
+    assert coordinator._reconnect_delay == 8
+    assert coordinator._reconnect_failures == MAX_RECONNECT_FAILURES - 1
+
+
+async def test_clean_server_close_is_counted_as_a_failure(
+    hass: HomeAssistant,
+) -> None:
+    """A gateway that closes the socket politely still escalates.
+
+    `async for` simply ends on a clean close, so this used to return normally:
+    no warning, no `last_error`, no failure count — and therefore never the
+    repair issue that exists for exactly this silent degradation.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = []
     coordinator._closing = False
     session = Mock()
     session.ws_connect = Mock(return_value=_EmptyWS())
@@ -284,11 +390,22 @@ async def test_repair_issue_cleared_on_successful_reconnect(
             return_value=session,
         ),
         patch.object(coordinator, "async_request_refresh", AsyncMock()),
+        pytest.raises(ConnectionError, match="closed the WebSocket"),
     ):
         await coordinator._run_websocket()
 
+
+async def test_stop_clears_the_repair_issue(hass: HomeAssistant) -> None:
+    """Unloading while degraded must not strand the issue in the repairs UI."""
+    coordinator = _coordinator(hass)
+    coordinator.data = []
+    await _run_failing_loop(coordinator, MAX_RECONNECT_FAILURES)
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, coordinator._push_failure_issue_id)
+
+    await coordinator.stop()
+
     assert registry.async_get_issue(DOMAIN, coordinator._push_failure_issue_id) is None
-    assert coordinator._reconnect_failures == 0
 
 
 def _pushable_device() -> dict:


### PR DESCRIPTION
Three defects in the same reconnect-lifecycle code, all of which stopped the degraded-push repair issue from doing its job. Fixed together because they share the code.

## 1. Backoff reset on connect made escalation unreachable

`_reconnect_delay` **and** `_reconnect_failures` were reset the instant `ws_connect` returned — before a single frame was exchanged — while the doubling only applies to the *next* attempt. A gateway that accepts the handshake and drops immediately (reboot loop, websocket-server restart cycle, client limit) looped:

```
reset to 1 s → drop → sleep ~1-1.5 s → connect → reset to 1 s → …
```

So the exponential backoff **could never engage**, `MAX_RECONNECT_FAILURES` was never reached (no repair issue), and every `_controllable_over_websocket` entity flapped available/unavailable once a second — spamming the state machine and recorder with nothing explaining it.

Now the reset happens `STABLE_SESSION_SECONDS` (30 s) into a session via `_mark_session_stable`, scheduled with `async_call_later` and cancelled if the session dies first. A session that holds up is a recovery; one that doesn't is another failure.

## 2. A clean server-side close was not counted at all

`_run_websocket` returned **normally** when the gateway closed the socket — `async for` just ends, without raising — so neither `_record_error` nor `_note_reconnect_failure` ran. A gateway that politely closes every session produced:

- no warning (nothing above DEBUG)
- no `last_error`, so diagnostics showed nothing
- no failure count, so **never** the repair issue

which is precisely the silent degradation the issue exists for. It now raises `ConnectionError` and takes the same path as a noisy drop.

## 3. `stop()` never deleted the issue

It was only ever deleted on a successful reconnect. Unloading, disabling or removing the entry while degraded stranded `websocket_push_failure` in the repairs UI forever, naming a gateway that may no longer be configured.

## Behaviour change worth a look in review

After a genuine outage the issue now clears **~30 s after** the socket comes back, rather than instantly. That is the intent — "connected" is not the same as "recovered" — but it is a deliberate, user-visible change.

## Tests

Four tests, replacing `test_repair_issue_cleared_on_successful_reconnect` (which asserted the old clear-on-connect semantics):

- `test_repair_issue_cleared_once_session_proves_stable` — holds a session open, asserts the issue survives the connect and clears only after the stability window
- `test_flapping_session_keeps_escalating` — an instant close neither resets the backoff nor clears the counter
- `test_clean_server_close_is_counted_as_a_failure`
- `test_stop_clears_the_repair_issue`

227 passed, coverage 97.87% (gate 95), `mypy --strict` and `ruff` clean.

> Touches the same regions as #154; whichever lands second will need a small rebase on `coordinator.py` and the `test_coordinator.py` imports.

Found during a full platinum-scale review; see `CLAUDE-review.md` §1.4, §1.5, §3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)