### PR TITLE
Document HACS default-store installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What?
 
-[![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 [![GitHub release](https://img.shields.io/github/v/release/ernetas/junghome)](https://github.com/ernetas/junghome/releases)
 
 This is a custom Jung Home integration based on WebSocket communication with Jung Home Gateway. A gateway is required.
@@ -41,14 +41,30 @@ Any feedback is welcome, this is my first integration with HomeAssistant.
 
 ## HACS (recommended)
 
-Until this is in the HACS default store, add it as a custom repository:
+**Jung Home is in the HACS default store** — no custom repository needed.
 
 [![Open your Home Assistant instance and open this repository inside HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ernetas&repository=junghome&category=integration)
 
-1. HACS → ⋮ (top right) → **Custom repositories**.
-2. Repository: `https://github.com/ernetas/junghome`, Category: **Integration**. Add.
-3. Find **Jung Home** in HACS, **Download** the latest release, then restart Home Assistant.
-4. Settings → Devices & Services → **Add Integration** → Jung Home (see [Setup](#setup)).
+1. **HACS** → search for **Jung Home**.
+2. **Download**, then restart Home Assistant.
+3. Settings → Devices & Services → **Add Integration** → Jung Home (see
+   [Setup](#setup)). In most cases the gateway is discovered for you and appears
+   there on its own, so you can just click **Configure**.
+
+The button above opens the repository straight in your HACS. If HACS is new to
+you, install it first: <https://hacs.xyz/docs/use/download/download/>.
+
+### Updating
+
+HACS notifies you when a new release is out (**HACS → Jung Home → Update**).
+Restart Home Assistant afterwards. Config entries, entity IDs and automations
+survive updates — entity `unique_id`s are derived from device labels rather than
+the gateway's internal ids precisely so they stay put.
+
+### Beta releases
+
+Pre-releases are hidden by default. To test one, open **HACS → Jung Home → ⋮ →
+Redownload** and enable **Show beta versions**.
 
 ## Manual
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,7 +1,8 @@
 # Publishing & releasing
 
-How this integration is distributed through HACS, and how to get it into the
-HACS **default store**.
+How this integration is released and distributed. It is listed in the HACS
+**default store**, so users install it by searching HACS — see
+[Distribution](#distribution-hacs-default-store).
 
 ## Cutting a release
 
@@ -28,45 +29,36 @@ suffix and marks the GitHub release as a **pre-release**. HACS hides pre-release
 unless a user enables **show beta versions** for the repo, so only opt-in testers
 get it. Promote to stable later by releasing a plain `X.Y.Z`.
 
-## Custom repository (works today)
+## Distribution: HACS default store
 
-Users add `https://github.com/ernetas/junghome` as a HACS custom repository,
-category **Integration**. See the README. Nothing else required.
+**Jung Home is in the [hacs/default](https://github.com/hacs/default) list**, so
+users find it by searching HACS for "Jung Home" — no custom repository step. The
+README documents the user-facing flow.
 
-## Getting into the HACS default store
+Adding a custom repository still works and is occasionally useful for testing an
+unreleased branch: HACS -> ⋮ -> **Custom repositories**, repository
+`https://github.com/ernetas/junghome`, category **Integration**.
 
-So users find "Jung Home" without adding a custom repo. Status:
+### What getting there required (all done)
 
-Done:
-- ✅ Public repo, MIT license, `custom_components/junghome/` layout
-- ✅ `manifest.json` (`documentation`, `issue_tracker`, `codeowners`, `version`, `iot_class`)
-- ✅ `hacs.json` with `name`
-- ✅ Repo **description** and **topics** set
-- ✅ A GitHub **release** (`v1.0.0`)
-- ✅ **Brand icons** merged into home-assistant/brands and live at
-  <https://brands.home-assistant.io/junghome/icon.png> (the `ignore: brands` line
-  has been removed from `.github/workflows/validate.yml`)
+- Public repo, MIT license, `custom_components/junghome/` layout
+- `manifest.json` with `documentation`, `issue_tracker`, `codeowners`,
+  `version`, `iot_class`
+- `hacs.json` with `name`
+- Repo **description** and **topics** set
+- A GitHub **release**
+- **Brand icons** merged into home-assistant/brands, live at
+  <https://brands.home-assistant.io/junghome/icon.png> (so the `ignore: brands`
+  line is gone from `.github/workflows/validate.yml`)
+- Green `Validate` workflow (hassfest + the HACS action) on every push/PR to
+  `main`
+- A merged PR adding `ernetas/junghome` to the `integration` list in
+  [hacs/default](https://github.com/hacs/default)
 
-Remaining, in order:
+### Staying in it
 
-### 1. Make validation green
-
-The `Validate` workflow runs hassfest + the HACS action on every push/PR to
-`main`. Confirm both pass now that brands are live and the `ignore` is removed.
-
-### 2. PR to hacs/default
-
-Add the repo to the [hacs/default](https://github.com/hacs/default) list:
-
-```sh
-gh repo fork hacs/default --clone
-cd default
-# add "ernetas/junghome" to the `integration` file (JSON array), keeping it sorted
-git checkout -b add-junghome
-git commit -am "Add ernetas/junghome"
-git push -u origin add-junghome
-gh pr create --repo hacs/default --fill
-```
-
-The HACS bot validates the repo on the PR; brands must already be merged or it
-fails. After the PR is merged, "Jung Home" appears in the default store.
+The HACS action keeps running in `Validate` on every push and PR. If it starts
+failing, the listing is at risk — treat a red HACS check on `main` as urgent
+rather than cosmetic. Note that the action talks to the HACS backend, so a
+transient `Not Found` / "not loaded properly in HACS" is an infrastructure blip
+rather than a repo defect; re-run before investigating.


### PR DESCRIPTION
The repository is now listed in [hacs/default](https://github.com/hacs/default), so the custom-repository instructions in the README are obsolete — and actively misleading, since they'd have users add a custom repo for something they can now just search for.

## README

- Install is now **HACS → search "Jung Home" → Download → restart**.
- Badge switched from `HACS Custom` to `HACS Default`.
- Added a pointer to the HACS install docs for anyone who doesn't have HACS yet.
- Noted that the gateway is usually auto-discovered, so step 3 is often just clicking **Configure**.

Two short sections that were missing entirely:

- **Updating** — where the update appears, and that config entries, entity IDs and automations survive it. That last point is worth stating: it's the obvious user question, and it's exactly what the label-derived `unique_id` scheme exists to guarantee.
- **Beta releases** — pre-releases are hidden unless you enable *Show beta versions*, which was documented only in `docs/publishing.md` (a contributor doc).

## docs/publishing.md

The "Getting into the HACS default store" section was a to-do list describing the listing as pending, with fork/PR instructions for `hacs/default`. Replaced with:

- what distribution looks like now (default store; custom repo still available for testing an unreleased branch)
- the requirements kept as a record of what the listing depends on, rather than as pending work
- a note that a red HACS check on `main` puts the listing at risk and should be treated as urgent — with the caveat that the action's `Not Found` / "not loaded properly in HACS" failure is an infrastructure blip rather than a repo defect (it hit #157 and passed on a re-run)

Docs only; 309 tests still pass. No overlap with the README sections in #158, so the two should merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)