### PR TITLE
Reload the entry when reconfiguring out of SETUP_RETRY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,16 +202,19 @@ Don't re-open them. The items below are what that audit actually found.
   `coordinator.py` (the reconnect loop, the message-handler catch-all, and the
   WebSocket send path). The `__init__.py` handlers this issue originally cited
   no longer exist.
+- ~~**Zeroconf host update double-reloads.**~~ **Investigated and refuted.**
+  Core's reload *and* its 2026.12.0 deprecation report both sit behind
+  `entry.state in (LOADED, SETUP_RETRY)`, and this integration's update listener
+  dispatches synchronously inside `async_update_entry` — so core re-reads the
+  state as UNLOAD_IN_PROGRESS and neither fires. `reload_on_update=False` is
+  passed anyway to state the intent, but it changes nothing today. Don't
+  re-raise this without measuring it again.
 - **Reconfigure verifies reachability but not identity** (residual of #132).
   `async_step_reconfigure` probes the new host, but never calls
   `_abort_if_unique_id_mismatch`, so a *different* gateway at a valid address is
   accepted and only surfaces later as a reauth. Keying the entry on the gateway
   serial/MAC from the mDNS TXT record would fix this, `discovery-update-info`
   for manually-added entries, and the manual-vs-discovered duplicate at once.
-- **Zeroconf host update double-reloads.** `_abort_if_unique_id_configured`
-  is called with the default `reload_on_update=True` while the entry's own
-  update listener already reloads on a host change. HA emits a deprecation
-  report for this that becomes a hard failure in **2026.12.0**.
 - **Diagnostics dump raw WebSocket frames unredacted.**
   `recent_websocket_frames` / `latest_websocket_frame_by_type` bypass
   `async_redact_data`, and `last_error` re-leaks the host that `TO_REDACT`

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigEntryState, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TOKEN, Platform
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
@@ -431,6 +431,15 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.hass.config_entries.async_update_entry(
                     entry, data={**entry.data, CONF_HOST: host}
                 )
+                # That listener only exists while the entry is loaded — it is
+                # registered on the last line of a successful `async_setup_entry`.
+                # A user reconfiguring a gateway that is failing to set up (the
+                # usual reason to reconfigure) is in SETUP_RETRY, where there is
+                # no listener, so nothing would pick the new host up until HA's
+                # retry timer next fired — up to 10 minutes later. Schedule the
+                # reload explicitly there; it also cancels the pending retry.
+                if entry.state is not ConfigEntryState.LOADED:
+                    self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="reconfigure_successful")
 
         return self.async_show_form(
@@ -450,7 +459,19 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         hostname = (discovery_info.hostname or "").rstrip(".") or self._host
         # Stable per-gateway id; update the stored host if its IP changed.
         await self.async_set_unique_id(hostname)
-        self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})
+        # `reload_on_update=False`: the entry's own update listener
+        # (`async_reload_entry`) is what reloads on a host change, which is
+        # exactly what Home Assistant asks integrations that have a listener to
+        # do (it reports the alternative as deprecated, breaking in 2026.12.0).
+        #
+        # This is belt-and-braces rather than a bug fix: today the listener
+        # dispatches synchronously inside `async_update_entry`, so by the time
+        # core re-checks `entry.state` it already reads UNLOAD_IN_PROGRESS and
+        # core's own reload branch never runs. Saying so explicitly keeps that
+        # from depending on listener dispatch order.
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: self._host}, reload_on_update=False
+        )
         # Also skip gateways already added manually under a different unique id.
         if any(
             entry.data.get(CONF_HOST) in (self._host, hostname)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import pytest
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -854,3 +854,88 @@ async def test_options_flow_drops_orphaned_flagged_cover(hass: HomeAssistant) ->
         result = await hass.config_entries.options.async_init(entry.entry_id)
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "no_covers"
+
+
+async def test_reconfigure_reloads_an_entry_stuck_in_setup_retry(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A gateway that is failing to set up picks the new host up immediately.
+
+    The host-change update listener is registered on the last line of a
+    *successful* setup, so it does not exist in SETUP_RETRY — which is the usual
+    state to reconfigure from. Without an explicit reload the new host sat unused
+    until Home Assistant's retry timer next fired, up to 10 minutes later.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "t"},
+    )
+    entry.add_to_hass(hass)
+    # Setup fails, leaving the entry in SETUP_RETRY (and with no update listener).
+    with patch.object(
+        JungHomeDataUpdateCoordinator,
+        "_fetch_devices_from_api",
+        AsyncMock(side_effect=aiohttp.ClientError("unreachable")),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert not entry.update_listeners
+
+    aioclient_mock.get("https://5.6.7.8/api/junghome/functions", json=[])
+    fetch, run_ws = _no_network()
+    with (
+        fetch,
+        run_ws,
+        patch.object(hass.config_entries, "async_schedule_reload") as schedule_reload,
+    ):
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "5.6.7.8"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_HOST] == "5.6.7.8"
+    schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+async def test_zeroconf_ip_change_updates_the_stored_host(
+    hass: HomeAssistant,
+) -> None:
+    """Re-discovery at a new address updates the entry (discovery-update-info).
+
+    Covers the `updates={CONF_HOST: ...}` path on a *loaded* entry, which the
+    other zeroconf abort tests never reach.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="junghome-abc.local",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "x"},
+    )
+    entry.add_to_hass(hass)
+
+    info = ZeroconfServiceInfo(
+        ip_address="9.9.9.9",
+        ip_addresses=["9.9.9.9"],
+        port=443,
+        hostname="junghome-abc.local.",
+        type="_junghome._tcp.local.",
+        name="junghome._junghome._tcp.local.",
+        properties={},
+    )
+    fetch, run_ws = _no_network()
+    with fetch, run_ws:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert entry.state is ConfigEntryState.LOADED
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "zeroconf"}, data=info
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == "9.9.9.9"


### PR DESCRIPTION
## The bug

`async_step_reconfigure` writes the new host and deliberately leaves the reload to the entry's `add_update_listener`, to avoid a double reload. But that listener is registered on the **last line of a successful `async_setup_entry`** and removed on unload — so it does not exist while the entry is in `SETUP_RETRY`.

That is the usual state to reconfigure from: an unreachable gateway is precisely what makes a user go and fix the address. So the new host was stored and then sat unused until Home Assistant's retry timer next fired — **up to 10 minutes**, with the entry still retrying the old address in the meantime.

Fix: schedule the reload explicitly when the entry is not `LOADED`. `async_schedule_reload` calls `entry.async_cancel_retry_setup()` first, so it also stops the stale address being retried.

## A correction worth reading

This branch also passes `reload_on_update=False` on the zeroconf host update. My review had flagged that as a live bug — a double reload plus a deprecation report that becomes a hard failure in HA 2026.12.0. **Measuring it showed that was wrong**, so I'm not claiming it here.

Both core's reload and its deprecation report sit behind the same guard:

```python
and reload_on_update
and entry.state in (ConfigEntryState.LOADED, ConfigEntryState.SETUP_RETRY)
```

Instrumenting the real flow shows the integration's own update listener dispatches *synchronously* inside `async_update_entry`, so by the time core re-checks the state it reads `UNLOAD_IN_PROGRESS`:

```
>>> async_update_entry calls (host, returned, state): [('9.9.9.9', True, UNLOAD_IN_PROGRESS)]
>>> schedule_reload: []
>>> report_usage: []
```

Identical with and without the flag — no double reload, no deprecation. The flag is kept as belt-and-braces, since it states the intent core asks for and stops the behaviour depending on listener dispatch order, but it is **not** a behaviour change today and the comment says so.

## Tests

- `test_reconfigure_reloads_an_entry_stuck_in_setup_retry` — drives a real setup failure into `SETUP_RETRY`, asserts there is no update listener, then asserts the reconfigure schedules the reload itself. **Fails on the previous code.**
- `test_zeroconf_ip_change_updates_the_stored_host` — covers the `updates={CONF_HOST: ...}` path on a *loaded* entry, which the existing zeroconf abort tests never reached (they use a bare `MockConfigEntry`, so core's update branch is skipped entirely — the reason my first attempt at this test passed against broken code).

311 passed, `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §3.5 (real) and §3.6 (refuted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)