### PR TITLE
Warn once per outage instead of on every reconnect attempt

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -185,8 +185,12 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         self._ws_task: asyncio.Task[None] | None = None
         self._closing = False
         self._reconnect_delay = INITIAL_RECONNECT_DELAY
-        # Consecutive failed reconnects; reset to 0 by every successful connect.
+        # Consecutive failed reconnects; reset once a session proves stable (see
+        # ``_mark_session_stable``), not merely on a successful handshake.
         self._reconnect_failures = 0
+        # Whether the current outage has already produced its one WARNING, so the
+        # retry loop degrades to DEBUG instead of warning once a minute forever.
+        self._unavailable_logged = False
         # Repair-issue id, scoped to this entry so two gateways each report
         # their own outage instead of overwriting one shared issue.
         self._push_failure_issue_id = f"{ISSUE_PUSH_FAILURE}_{config_entry.entry_id}"
@@ -480,11 +484,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                         self.config_entry.async_start_reauth(self.hass)
                     return
                 self._record_error(err)
-                _LOGGER.warning("Jung Home WebSocket disconnected: %s", err)
+                self._log_disconnected(err)
                 self._note_reconnect_failure()
             except Exception as err:
                 self._record_error(err)
-                _LOGGER.warning("Jung Home WebSocket disconnected: %s", err)
+                self._log_disconnected(err)
                 self._note_reconnect_failure()
             if self._closing:
                 break
@@ -495,6 +499,22 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 self._reconnect_delay + random.uniform(0, RECONNECT_JITTER)  # noqa: S311
             )
             self._reconnect_delay = min(self._reconnect_delay * 2, MAX_RECONNECT_DELAY)
+
+    def _log_disconnected(self, err: BaseException) -> None:
+        """Log a dropped WebSocket once at WARNING, then at DEBUG.
+
+        The reconnect loop retries forever, so warning on every attempt turned an
+        unreachable gateway into a warning a minute for as long as it stayed down
+        — exactly the noise the `log-when-unavailable` rule exists to prevent.
+        The first drop is the newsworthy one; the rest repeat the same fact.
+        ``_mark_session_stable`` clears the flag, so a genuine recovery followed
+        by a genuine outage warns again.
+        """
+        if self._unavailable_logged:
+            _LOGGER.debug("Jung Home WebSocket still disconnected: %s", err)
+            return
+        self._unavailable_logged = True
+        _LOGGER.warning("Jung Home WebSocket disconnected: %s", err)
 
     def _note_reconnect_failure(self) -> None:
         """Count a failed reconnect and, past the threshold, tell the user.
@@ -625,6 +645,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         """
         self._reconnect_delay = INITIAL_RECONNECT_DELAY
         self._reconnect_failures = 0
+        if self._unavailable_logged:
+            # Pair the single WARNING above with a matching recovery line, so an
+            # outage has a visible end without trawling debug logs.
+            _LOGGER.warning("Jung Home WebSocket reconnected")
+            self._unavailable_logged = False
         ir.async_delete_issue(self.hass, DOMAIN, self._push_failure_issue_id)
 
     def _notify_websocket_closed(self) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 from datetime import timedelta
 from typing import Self
 from unittest.mock import AsyncMock, Mock, patch
@@ -491,3 +492,37 @@ async def test_rest_poll_still_runs_under_a_continuous_push_stream(
     assert poll.call_count >= 2, (
         f"pushes starved the REST poll (ran {poll.call_count} times in 3 minutes)"
     )
+
+
+async def test_repeated_reconnect_failures_warn_only_once(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An unreachable gateway warns once, then drops to DEBUG.
+
+    The loop retries forever, so warning on every attempt meant a gateway that
+    stayed down produced a warning roughly once a minute indefinitely — the
+    noise `log-when-unavailable` exists to prevent.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = []
+    with caplog.at_level(logging.WARNING):
+        await _run_failing_loop(coordinator, 5)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "disconnected" in r.message
+    ]
+    assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
+
+
+async def test_recovery_warns_once_and_rearms(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """A stable reconnect logs the matching recovery and re-arms the warning."""
+    coordinator = _coordinator(hass)
+    coordinator._unavailable_logged = True
+
+    coordinator._mark_session_stable(None)
+
+    assert coordinator._unavailable_logged is False


### PR DESCRIPTION
## Problem

`_websocket_loop` logged a WARNING on **every** failed reconnect:

```python
except Exception as err:
    self._record_error(err)
    _LOGGER.warning("Jung Home WebSocket disconnected: %s", err)
    self._note_reconnect_failure()
```

The loop retries forever with the backoff capped at `MAX_RECONNECT_DELAY = 60`, so a gateway that stays unreachable — powered off, moved, replaced — produces a warning roughly **once a minute, indefinitely**.

That is exactly the noise the Silver `log-when-unavailable` rule exists to prevent, and `quality_scale.yaml` marks that rule `done`. The convention is to log once at WARNING and drop to DEBUG for the rest of the same outage.

## Fix

`_log_disconnected` warns on the first drop and logs every later attempt in the same outage at DEBUG. A single `"Jung Home WebSocket reconnected"` WARNING is emitted when a session proves stable, so an outage has a visible end without trawling debug logs.

The flag is cleared in `_mark_session_stable`, so a genuine recovery followed by a genuine outage warns again — it does not go permanently silent after the first one for the lifetime of the entry.

Also corrects a comment that the flap fix in #157 made stale: `_reconnect_failures` no longer resets "by every successful connect", only once a session has held up for `STABLE_SESSION_SECONDS`.

## Tests

- `test_repeated_reconnect_failures_warn_only_once` — drives five failed reconnects and asserts exactly one warning. **Fails on the previous code:** `expected one warning, got 5`.
- `test_recovery_warns_once_and_rearms` — the stability callback re-arms the warning for the next outage.

311 passed, coverage 98.01% (gate 95), `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §2 (`log-when-unavailable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)