### PR TITLE
Scrub the host and token out of free-form diagnostics text

### DIFF
--- a/custom_components/junghome/diagnostics.py
+++ b/custom_components/junghome/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,25 @@ if TYPE_CHECKING:
 # retained in `devices` below: they're the stable identity anchor and are the
 # main thing that makes a diagnostics dump useful for debugging.
 TO_REDACT = {CONF_TOKEN, "token", CONF_HOST, "host"}
+
+# `async_redact_data` only masks values it can reach by *key*. Several fields
+# below are free-form text that can quote a secret inside a larger string, where
+# no key exists to match:
+#
+# - `last_error` is `str(err)`, and an aiohttp connect failure reads
+#   "Cannot connect to host <host>:443 ssl:True [...]" — re-leaking the host that
+#   TO_REDACT deliberately removes from `entry.data`.
+# - the raw WebSocket frames are gateway JSON kept verbatim for protocol
+#   debugging. The token travels as a connect header rather than a frame body,
+#   so it should never appear there, but a downloadable report that gets pasted
+#   into public issues is the wrong place to rely on "should".
+#
+# So those go through `_scrub`, which does a literal (case-insensitive) sweep for
+# the entry's own secrets.
+#
+# Only secrets of at least this length are swept: a one- or two-character host
+# would otherwise match constantly and shred the very output being debugged.
+_MIN_SCRUBBABLE = 4
 
 # Function/datapoint types the integration turns into entities. These mirror the
 # platform discovery (light/switch/sensor/event/cover/climate). The
@@ -55,6 +75,23 @@ _HANDLED_DATAPOINT_TYPES = {
 }
 
 
+def _secrets(entry: JungHomeConfigEntry) -> list[str]:
+    """Return the entry's secrets, longest first so the token wins any overlap."""
+    values = [str(entry.data.get(key) or "") for key in (CONF_TOKEN, CONF_HOST)]
+    return sorted(
+        (v for v in values if len(v) >= _MIN_SCRUBBABLE), key=len, reverse=True
+    )
+
+
+def _scrub(text: str | None, secrets: list[str]) -> str | None:
+    """Mask any of ``secrets`` appearing inside free-form ``text``."""
+    if not text:
+        return text
+    for secret in secrets:
+        text = re.sub(re.escape(secret), "**REDACTED**", text, flags=re.IGNORECASE)
+    return text
+
+
 def _support_summary(devices: list[Device]) -> dict[str, Any]:
     """Count device/datapoint types and flag any the integration doesn't handle."""
     function_types: Counter[str] = Counter(d.get("type") or "Unknown" for d in devices)
@@ -79,6 +116,7 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
     devices = coordinator.data or []
+    secrets = _secrets(entry)
     return {
         "entry": {
             "data": async_redact_data(entry.data, TO_REDACT),
@@ -93,7 +131,7 @@ async def async_get_config_entry_diagnostics(
         # REST/WebSocket failure (if any) — together they show how long a dump
         # taken mid-outage has been degraded and what's causing it.
         "ws_last_connected": coordinator.ws_last_connected,
-        "last_error": coordinator.last_error,
+        "last_error": _scrub(coordinator.last_error, secrets),
         "last_error_at": coordinator.last_error_at,
         # Quick map of what the gateway exposes vs what we implement — the first
         # thing to check when matching real hardware against our support.
@@ -110,12 +148,17 @@ async def async_get_config_entry_diagnostics(
         "groups": coordinator.groups,
         # The most recent raw WebSocket frames (live pushes), so the real wire
         # format can be matched against our parsing...
-        "recent_websocket_frames": list(coordinator.ws_frame_log),
+        "recent_websocket_frames": [
+            _scrub(frame, secrets) for frame in coordinator.ws_frame_log
+        ],
         # ...plus the latest *full* (untruncated) frame of each type, which always
         # retains the complete connect-time handshake (message / version /
         # functions / groups / scenes) even on a spammy gateway where the rolling
         # log above has churned past it.
-        "latest_websocket_frame_by_type": coordinator.ws_last_frame_by_type,
+        "latest_websocket_frame_by_type": {
+            frame_type: _scrub(frame, secrets)
+            for frame_type, frame in coordinator.ws_last_frame_by_type.items()
+        },
     }
 
 
@@ -136,6 +179,7 @@ async def async_get_device_diagnostics(
     pruned.
     """
     coordinator = entry.runtime_data
+    secrets = _secrets(entry)
     # HA devices are keyed by the firmware-stable slug, so resolve back through
     # the same function that produced the identifier.
     slugs = {
@@ -148,7 +192,7 @@ async def async_get_device_diagnostics(
     return {
         "gateway_version": coordinator.gateway_version,
         "ws_connected": coordinator.ws_connected,
-        "last_error": coordinator.last_error,
+        "last_error": _scrub(coordinator.last_error, secrets),
         "last_error_at": coordinator.last_error_at,
         "identifiers": sorted(slugs),
         # Redacted with the same rule as the entry dump: a per-device report is

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -29,6 +30,8 @@ from custom_components.junghome.coordinator import (
     _parse_color_temp_range,
 )
 from custom_components.junghome.diagnostics import (
+    _scrub,
+    _secrets,
     _support_summary,
     async_get_config_entry_diagnostics,
     async_get_device_diagnostics,
@@ -1441,3 +1444,78 @@ async def test_notify_websocket_closed_skips_during_teardown(
         coordinator._closing = True
         coordinator._notify_websocket_closed()
         assert notify.call_count == 1
+
+
+async def test_diagnostics_scrubs_host_from_free_form_text(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The host must not survive inside `last_error` or a raw WebSocket frame.
+
+    `async_redact_data` masks values by key; these are free-form strings where no
+    key exists to match. An aiohttp connect failure reads "Cannot connect to host
+    <host>:443 ...", which re-leaked exactly what TO_REDACT removes from
+    entry.data — and diagnostics get pasted into public issues.
+    """
+    coordinator = init_integration.runtime_data
+    host = init_integration.data[CONF_HOST]
+    token = init_integration.data[CONF_TOKEN]
+    coordinator.last_error = f"Cannot connect to host {host}:443 ssl:True [timeout]"
+    coordinator.ws_frame_log.append(f'{{"type":"x","url":"wss://{host}/ws"}}')
+    coordinator.ws_last_frame_by_type = {"version": f'{{"url":"wss://{host}/ws"}}'}
+
+    diag = await async_get_config_entry_diagnostics(hass, init_integration)
+
+    assert host not in diag["last_error"]
+    assert "**REDACTED**" in diag["last_error"]
+    # The surrounding context survives, so the dump is still debuggable.
+    assert "Cannot connect to host" in diag["last_error"]
+    assert host not in diag["recent_websocket_frames"][-1]
+    assert host not in diag["latest_websocket_frame_by_type"]["version"]
+    # The fixture's 3-character token is below the sweep threshold; see
+    # test_scrub_masks_secrets_but_ignores_tiny_ones for a realistic one.
+    assert token == "tok"
+
+
+async def test_device_diagnostics_scrubs_host_from_last_error(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The per-device dump gets the same treatment as the entry dump."""
+    coordinator = init_integration.runtime_data
+    host = init_integration.data[CONF_HOST]
+    coordinator.last_error = f"Cannot connect to host {host}:443"
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, device_slug(DEVICES[0]))})
+    diag = await async_get_device_diagnostics(hass, init_integration, device)
+
+    assert host not in diag["last_error"]
+
+
+def test_scrub_masks_secrets_but_ignores_tiny_ones() -> None:
+    """`_scrub` masks realistic secrets and leaves absurdly short ones alone.
+
+    A real gateway token is long; a one- or two-character value would match
+    everywhere and shred the very output being debugged, so short values are
+    deliberately not swept.
+    """
+    token = "eyJhbGciOiJIUzI1NiJ9.secret-token-value"
+    host = "junghome-0022d1059602.local"
+    secrets = _secrets(
+        SimpleNamespace(data={CONF_TOKEN: token, CONF_HOST: host})  # type: ignore[arg-type]
+    )
+
+    text = f"GET https://{host}/api with token={token} failed"
+    scrubbed = _scrub(text, secrets)
+    assert token not in scrubbed
+    assert host not in scrubbed
+    assert scrubbed.startswith("GET https://**REDACTED**/api")
+
+    # Case-insensitive: an error may echo a differently-cased hostname.
+    assert host not in _scrub(f"Cannot connect to host {host.upper()}:443", secrets)
+
+    # Below the threshold -> not swept, so a dump isn't shredded by a stub value.
+    assert _secrets(SimpleNamespace(data={CONF_TOKEN: "t", CONF_HOST: "h"})) == []  # type: ignore[arg-type]
+    assert _scrub("the host is h", []) == "the host is h"
+
+    # Nothing to do on empty input.
+    assert _scrub(None, secrets) is None


### PR DESCRIPTION
## Problem

`async_redact_data` masks values it can reach **by key**, so `entry.data`'s token and host are properly redacted. Three fields in the same dump are free-form text where no key exists to match, and they carried the secrets straight through.

**`last_error` is `str(err)`.** Verified against aiohttp — a connect failure formats as:

```
Cannot connect to host gw-secret-host.invalid:443 ssl:True [SSLCertVerificationError...]
```

So a dump taken during an outage — the most likely time to take one — re-leaked the very host `TO_REDACT` removes two lines above. Both `async_get_config_entry_diagnostics` and `async_get_device_diagnostics` were affected.

**`recent_websocket_frames` / `latest_websocket_frame_by_type`** are raw gateway JSON kept verbatim for protocol debugging. The token travels as a connect header rather than a frame body, so it *should* never appear there — but a report that gets pasted into public issues is the wrong place to rely on "should".

## Fix

`_scrub` sweeps the entry's own secrets out of those strings:

- **case-insensitively**, since an error may echo a differently-cased hostname
- **longest-first**, so the token wins any overlap with the host
- keeping surrounding context, so `Cannot connect to host **REDACTED**:443` still says what went wrong

Secrets shorter than 4 characters are deliberately **not** swept — a one-character host would match everywhere and shred the very output being debugged. Real tokens and hostnames are far longer. (This is why one assertion in the new integration test notes the fixture's 3-character `"tok"`; the threshold behaviour has its own unit test with a realistic token.)

## Scope note

This hardens a dump the user chooses to download and share; it is not a remote-exposure bug. Worth doing because the file already sets the policy that host and token don't belong in it, and these fields quietly broke that policy.

## Tests

- `test_diagnostics_scrubs_host_from_free_form_text` — host absent from `last_error` and both frame collections, context preserved
- `test_device_diagnostics_scrubs_host_from_last_error` — same policy on the narrower dump
- `test_scrub_masks_secrets_but_ignores_tiny_ones` — realistic token + hostname, case-insensitive match, and the short-value guard

314 passed, `diagnostics.py` now at **100%** coverage, total 98.06%. `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)