### PR TITLE
Stop two same-named devices from reload-looping the entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,16 @@ When working on anything that touches the gateway protocol, consult
   updates, so entity `unique_id`s and device identifiers are derived from the
   device **label** + datapoint **suffix** (`stable_unique_id`), never the raw id.
   Don't reintroduce id-based identifiers.
+- **Slugs can collide, so never key per-device state by slug without guarding.**
+  Two devices whose labels slug identically (`"Lamp 1"` / `"Lamp-1"`) share one
+  `device_slug`, and `device_slug` deliberately does not disambiguate them —
+  per-poll disambiguation would make `unique_id`s depend on poll order. Identity
+  survives that (the second device just loses), but any *map keyed by slug* does
+  not: the second device overwrites the first within a single pass and looks like
+  a device that changed. That is exactly how the capability watcher used to
+  schedule a reload on every refresh, forever, from nothing but two devices
+  sharing a name. Use `duplicate_slugs()` (in `const.py`) to skip colliding slugs
+  — `_register_capability_reload` and the device-identifier migration both do.
 - **Entity naming.** Entities set `_attr_has_entity_name = True` and a short
   `_attr_name` (or `None` for a device's main feature, e.g. light/socket). The
   **device** carries the label; never bake the label into the entity name — doing

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     DOMAIN,
     datapoint_suffix,
     device_slug,
+    duplicate_slugs,
     gateway_device_id,
     gateway_device_info,
 )
@@ -104,6 +105,7 @@ def _register_capability_reload(
     their values, so a routine value push never triggers a reload).
     """
     capability_signatures: dict[str, tuple[str | None, frozenset[str]]] = {}
+    warned_collisions: set[str] = set()
     reload_scheduled = False
 
     @callback
@@ -111,9 +113,34 @@ def _register_capability_reload(
         nonlocal reload_scheduled
         if reload_scheduled or not coordinator.data:
             return
+        # Two devices whose labels slug identically share ONE key in the map
+        # below. Without this guard the second overwrote the first's signature
+        # within a single pass, so the comparison always saw a "change" and
+        # scheduled a reload — and since each reload rebuilds this closure with an
+        # empty map, it did so again immediately: an endless reload loop from
+        # nothing worse than two devices called "Lamp".
+        #
+        # A colliding slug cannot be fingerprinted meaningfully (which of the two
+        # devices does it describe?), so drop any stale entry and skip it. If the
+        # user renames one, the slug stops colliding and re-seeds cleanly.
+        collisions = duplicate_slugs(coordinator.data)
+        for slug, labels in collisions.items():
+            capability_signatures.pop(slug, None)
+            if slug not in warned_collisions:
+                warned_collisions.add(slug)
+                _LOGGER.warning(
+                    "Jung Home: %s devices share the label(s) %s, which resolve to "
+                    "the same identity (%s). Only one of them gets entities. Give "
+                    "them distinct labels in the JUNG HOME app",
+                    len(labels),
+                    ", ".join(sorted(labels)),
+                    slug,
+                )
         changed = False
         for device in coordinator.data:
             slug = device_slug(device)
+            if slug in collisions:
+                continue
             signature = _capability_signature(device)
             previous = capability_signatures.get(slug)
             capability_signatures[slug] = signature
@@ -399,35 +426,68 @@ def _migrate_to_stable_ids(
                     entity.entity_id,
                 )
 
-        dev_reg = dr.async_get(hass)
-        for device_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
-            try:
-                new_identifiers = set()
-                changed = False
-                for domain, identifier in device_entry.identifiers:
-                    if domain == DOMAIN and identifier in by_device:
-                        new_identifiers.add(
-                            (DOMAIN, device_slug(by_device[identifier]))
-                        )
-                        changed = True
-                    else:
-                        new_identifiers.add((domain, identifier))
-                if changed:
-                    dev_reg.async_update_device(
-                        device_entry.id, new_identifiers=new_identifiers
-                    )
-            except _MIGRATION_ERRORS:
-                had_error = True
-                _LOGGER.exception(
-                    "Jung Home: failed to migrate device %s to a stable id",
-                    device_entry.id,
-                )
+        had_error |= _migrate_device_identifiers(hass, entry, by_device)
 
         _LOGGER.info("Jung Home: migrated %s entities to firmware-stable ids", migrated)
     except _MIGRATION_ERRORS:
         _LOGGER.exception("Jung Home: failed to migrate registry to stable ids")
         return False
     return not had_error
+
+
+def _migrate_device_identifiers(
+    hass: HomeAssistant,
+    entry: JungHomeConfigEntry,
+    by_device: dict[str, Device],
+) -> bool:
+    """Re-point device-registry identifiers from volatile ids to stable slugs.
+
+    Split out of ``_migrate_to_stable_ids`` (which does the entity half) purely
+    for length. Returns True if any device failed, so the caller can withhold the
+    one-shot "migrated" flag and retry next setup.
+    """
+    had_error = False
+    dev_reg = dr.async_get(hass)
+    for device_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+        try:
+            new_identifiers = set()
+            changed = False
+            for domain, identifier in device_entry.identifiers:
+                if domain == DOMAIN and identifier in by_device:
+                    new_identifiers.add((DOMAIN, device_slug(by_device[identifier])))
+                    changed = True
+                else:
+                    new_identifiers.add((domain, identifier))
+            if not changed:
+                continue
+            # Two devices whose labels slug identically both want the same
+            # identifier. Writing it raises DeviceIdentifierCollisionError, a
+            # HomeAssistantError, which lands in the handler below as `had_error` —
+            # leaving the one-shot flag unset, so the migration re-ran and
+            # re-logged a full traceback on every single setup, forever. Skip the
+            # loser instead: the same "second device loses" outcome `device_slug`
+            # documents, but reported once and without blocking the migration.
+            clash = dev_reg.async_get_device(identifiers=new_identifiers)
+            if clash is not None and clash.id != device_entry.id:
+                _LOGGER.warning(
+                    "Jung Home: cannot migrate device %s to %s — already claimed "
+                    "by device %s, because two devices share a label. Give them "
+                    "distinct labels in the JUNG HOME app",
+                    device_entry.id,
+                    sorted(new_identifiers),
+                    clash.id,
+                )
+                continue
+            dev_reg.async_update_device(
+                device_entry.id, new_identifiers=new_identifiers
+            )
+        except _MIGRATION_ERRORS:
+            had_error = True
+            _LOGGER.exception(
+                "Jung Home: failed to migrate device %s to a stable id",
+                device_entry.id,
+            )
+    return had_error
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -198,6 +198,27 @@ def device_slug(device: Device) -> str:
     return "jung"  # pragma: no cover - "jung" always slugs to itself; unreachable
 
 
+def duplicate_slugs(devices: list[Device]) -> dict[str, list[str]]:
+    """Map each colliding device slug to the labels that produced it.
+
+    ``device_slug`` deliberately does not disambiguate two devices whose labels
+    slug identically (see its docstring: the gateway exposes no hardware id, and
+    per-poll disambiguation would make unique_ids depend on poll order). The
+    second such device simply loses — its entities can't register.
+
+    That is survivable for identity, but **any caller keeping per-device state
+    keyed by slug must skip a colliding slug**, because two devices would
+    otherwise overwrite each other's entry within a single pass and look like a
+    device that changes on every refresh. Returns only the slugs with more than
+    one device, so callers can skip them and report them.
+    """
+    by_slug: dict[str, list[str]] = {}
+    for device in devices:
+        label = device.get("label") or device.get("id") or ""
+        by_slug.setdefault(device_slug(device), []).append(str(label))
+    return {slug: labels for slug, labels in by_slug.items() if len(labels) > 1}
+
+
 def stable_unique_id(
     device: Device, datapoint: Datapoint, qualifier: str | None = None
 ) -> str:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,6 +24,7 @@ from custom_components.junghome.const import (
     DATA_AREA_ASSIGNED,
     DOMAIN,
     device_slug,
+    duplicate_slugs,
 )
 from custom_components.junghome.coordinator import (
     JungHomeDataUpdateCoordinator,
@@ -1519,3 +1520,116 @@ def test_scrub_masks_secrets_but_ignores_tiny_ones() -> None:
 
     # Nothing to do on empty input.
     assert _scrub(None, secrets) is None
+
+
+def _duplicate_label_devices() -> list[dict]:
+    """Two devices whose labels slug to the same value."""
+    devices = copy.deepcopy(DEVICES)[:2]
+    devices[0]["label"] = "Hall Light"
+    devices[1]["label"] = "Hall-Light"  # slugify -> hall_light as well
+    return devices
+
+
+async def test_duplicate_labels_do_not_cause_a_reload_loop(
+    hass: HomeAssistant,
+) -> None:
+    """Two devices sharing a slug must not schedule any capability reload.
+
+    The capability watcher keys its fingerprints by slug, so the second device
+    used to overwrite the first's entry inside a single pass; the comparison then
+    saw a change on every refresh and scheduled a reload, and each reload rebuilt
+    the watcher with an empty map — an endless loop from two devices called
+    "Lamp".
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        # Skip the migration path so this isolates the capability watcher.
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok", "stable_ids_migrated": True},
+    )
+    entry.add_to_hass(hass)
+    reloads = 0
+
+    def _count(entry_id: str) -> None:
+        nonlocal reloads
+        reloads += 1
+
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=_duplicate_label_devices()),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload", _count),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        # A second refresh must stay quiet too.
+        await entry.runtime_data.async_refresh()
+        await hass.async_block_till_done()
+
+    assert reloads == 0, f"duplicate labels scheduled {reloads} reload(s)"
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_duplicate_labels_still_complete_the_migration(
+    hass: HomeAssistant,
+) -> None:
+    """A colliding device identifier is skipped, not left retrying forever.
+
+    `DeviceIdentifierCollisionError` is a HomeAssistantError, so it was caught as
+    a per-item failure and withheld the one-shot flag — meaning the migration
+    re-ran and re-logged a full traceback on every setup, indefinitely.
+    """
+    devices = _duplicate_label_devices()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    dev_reg = dr.async_get(hass)
+    for device in devices:
+        dev_reg.async_get_or_create(
+            config_entry_id=entry.entry_id, identifiers={(DOMAIN, device["id"])}
+        )
+
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=devices),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    # The collision no longer blocks completion, so the migration stops re-running.
+    assert entry.data.get("stable_ids_migrated") is True
+    # Exactly one device holds the shared slug; the other kept its old identifier.
+    holders = [
+        d
+        for d in dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+        if (DOMAIN, "hall_light") in d.identifiers
+    ]
+    assert len(holders) == 1
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+def test_duplicate_slugs_reports_only_collisions() -> None:
+    """`duplicate_slugs` returns the colliding slugs with their labels."""
+    assert duplicate_slugs(_duplicate_label_devices()) == {
+        "hall_light": ["Hall Light", "Hall-Light"]
+    }
+    # Distinct labels collide with nothing.
+    assert duplicate_slugs(copy.deepcopy(DEVICES)) == {}
+    assert duplicate_slugs([]) == {}


### PR DESCRIPTION
Two devices whose labels slug identically — `"Hall Light"` and `"Hall-Light"`, both `hall_light` — put the integration into an **endless reload loop**.

## Mechanism

`_register_capability_reload` keys its fingerprint map by slug:

```python
capability_signatures[slug] = signature
if previous is not None and previous != signature:
    changed = True
```

Both devices share one key, so within a *single* pass the second overwrites the first — the comparison reads the **other device's** signature as `previous`, sees a change, and schedules a reload. Each reload rebuilds this closure with an empty map, so it happens again immediately. Forever, with every entity torn down and rebuilt each cycle.

It needs **no firmware update, no migration, and no pre-existing registry state**. A fresh setup with two identically-named devices loops from the first refresh. Measured with `stable_ids_migrated` pre-set so the migration path was skipped entirely:

```
>>> capability reloads scheduled: 4      (runaway capped at 3 re-entries)
>>> control (distinct labels) reloads: 0
```

## Fix

`duplicate_slugs()` (new, in `const.py`) reports colliding slugs with their labels. The watcher now:

- **skips** colliding slugs — a slug shared by two devices cannot be fingerprinted meaningfully, since it doesn't describe one device
- **drops** any stale entry for that slug, so a later rename re-seeds cleanly instead of comparing against a fingerprint from before the collision
- **warns once**, naming the labels. Until now the losing device silently had no entities and nothing said why

## The migration had the matching bug

`DeviceIdentifierCollisionError` is a `HomeAssistantError`, so it landed in `_MIGRATION_ERRORS` as a per-item failure and withheld the one-shot flag — meaning the migration **re-ran and re-logged a full traceback on every setup, indefinitely**:

```
ERROR:custom_components.junghome: Jung Home: failed to migrate device ... to a stable id
DeviceIdentifierCollisionError: Identifiers {('junghome', 'hall_light')} already registered with ...
```

It now pre-checks the target, skips the loser with a single warning, and completes — the same "second device loses" outcome `device_slug` already documents, without blocking the migration.

The device half of the migration moved into `_migrate_device_identifiers`; the added guard pushed the original past the statement limit.

## Tests

Both fail on the previous code:

- `test_duplicate_labels_do_not_cause_a_reload_loop` — `duplicate labels scheduled 1 reload(s)`
- `test_duplicate_labels_still_complete_the_migration` — **hangs** on old code, which is the runaway itself
- `test_duplicate_slugs_reports_only_collisions` — unit coverage for the helper

319 passed, `const.py` at 100%, total 98.06%. `mypy --strict` and `ruff` clean.

`CLAUDE.md` gains the invariant: never key per-device state by slug without guarding, since that is the trap this was.

> **Correction worth flagging.** My review listed this under "investigated and refuted", reasoning that "the reload is keyed on device ids, not slugs". That described `_reload_if_device_ids_changed` — the capability watcher is a *different* function and **is** keyed on slug. The refutation checked the wrong code; the bug is real and worse than originally reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)