### PR TITLE
Bound the WebSocket connect and send paths

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -46,6 +46,17 @@ MAX_RECONNECT_FAILURES = 5
 # roughly once a second forever, never raising the repair issue and flapping every
 # controllable entity. A session shorter than this is treated as a failed attempt.
 STABLE_SESSION_SECONDS = 30
+# Bound for the WebSocket handshake. Home Assistant's shared session carries
+# aiohttp's default ClientTimeout(total=300, sock_connect=30), so a gateway that
+# accepts the TCP connection and then says nothing parks the reconnect loop for a
+# full five minutes: no retry, no failure counted, no progress toward the repair
+# issue, and every controllable entity unavailable throughout. A gateway on the
+# LAN either answers quickly or is not answering.
+WS_CONNECT_TIMEOUT = 30
+# Bound for a single outbound frame. `send_str` awaits the transport drain and
+# has no timeout of its own, so a peer that stops reading can block the calling
+# service call indefinitely. Short, because this is a LAN write of a few bytes.
+WS_SEND_TIMEOUT = 10
 # Repair-issue translation key for that "live push is dead" state.
 ISSUE_PUSH_FAILURE = "websocket_push_failure"
 
@@ -545,12 +556,55 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             },
         )
 
+    def _dispatch_text_frame(self, raw: str) -> None:
+        """Parse one TEXT frame and route it to the right handler.
+
+        Split out of ``_run_websocket`` so that function stays about the session
+        lifecycle. Never raises: a malformed frame must not tear down an
+        otherwise healthy connection.
+        """
+        _LOGGER.debug("Received WebSocket message: %s", raw)
+        self._log_ws_frame(raw)
+        try:
+            data = json.loads(raw)
+            if isinstance(data, list):
+                _LOGGER.error("Received WebSocket message is a list: %s", data)
+                return
+            if data.get("type") == "version":
+                self.gateway_version = data.get("data")
+                _LOGGER.info(
+                    "Jung Home gateway firmware version: %s", self.gateway_version
+                )
+                self._apply_gateway_version()
+                return
+            if data.get("type") == "message":
+                text = data.get("data")
+                if isinstance(text, str) and text.startswith("error:"):
+                    # The gateway reports a rejected command (e.g. a bad set) as
+                    # an `error:` message frame. There is no message_id
+                    # correlation, but surfacing it at WARNING beats dropping it.
+                    _LOGGER.warning("Jung Home gateway reported an error: %s", text)
+                else:
+                    _LOGGER.debug("Received message frame: %s", data)
+                return
+            self._handle_websocket_message(data)
+        except json.JSONDecodeError as e:
+            _LOGGER.error("Error decoding WebSocket message: %s", e)
+        except Exception as e:
+            _LOGGER.error("Unexpected error handling WebSocket message: %s", e)
+            _LOGGER.error("Message content: %s", raw)
+
     async def _run_websocket(self) -> None:
         """Open one WebSocket session and pump messages until it closes."""
         session = async_get_clientsession(self.hass, verify_ssl=False)
         url = f"wss://{self.config['host']}/ws"
         headers = {"token": f"{self.config['token']}"}
-        async with session.ws_connect(url, headers=headers, heartbeat=30) as ws:
+        # Only the handshake is bounded — wrapping the `async with` below would
+        # tear down a perfectly healthy session after WS_CONNECT_TIMEOUT. Once
+        # connected, `heartbeat=30` is what detects a silently dead peer.
+        async with asyncio.timeout(WS_CONNECT_TIMEOUT):
+            ws = await session.ws_connect(url, headers=headers, heartbeat=30)
+        async with ws:
             self.websocket = ws
             # Connected: resync state we may have missed while disconnected.
             # Logged at INFO (paired with the WARNING on disconnect) so the
@@ -575,45 +629,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             try:
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
-                        _LOGGER.debug("Received WebSocket message: %s", msg.data)
-                        self._log_ws_frame(msg.data)
-                        try:
-                            data = json.loads(msg.data)
-                            if isinstance(data, list):
-                                _LOGGER.error(
-                                    "Received WebSocket message is a list: %s", data
-                                )
-                                continue
-                            if data.get("type") == "version":
-                                self.gateway_version = data.get("data")
-                                _LOGGER.info(
-                                    "Jung Home gateway firmware version: %s",
-                                    self.gateway_version,
-                                )
-                                self._apply_gateway_version()
-                                continue
-                            if data.get("type") == "message":
-                                text = data.get("data")
-                                if isinstance(text, str) and text.startswith("error:"):
-                                    # The gateway reports a rejected command (e.g.
-                                    # a bad set) as an `error:` message frame. There
-                                    # is no message_id correlation, but surfacing it
-                                    # at WARNING beats silently dropping it.
-                                    _LOGGER.warning(
-                                        "Jung Home gateway reported an error: %s",
-                                        text,
-                                    )
-                                else:
-                                    _LOGGER.debug("Received message frame: %s", data)
-                                continue
-                            self._handle_websocket_message(data)
-                        except json.JSONDecodeError as e:
-                            _LOGGER.error("Error decoding WebSocket message: %s", e)
-                        except Exception as e:
-                            _LOGGER.error(
-                                "Unexpected error handling WebSocket message: %s", e
-                            )
-                            _LOGGER.error("Message content: %s", msg.data)
+                        self._dispatch_text_frame(msg.data)
                     elif msg.type == aiohttp.WSMsgType.ERROR:
                         raise ConnectionError(f"WebSocket error frame: {msg}")
                 # The gateway closed the socket cleanly: `async for` just ends,
@@ -884,7 +900,8 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         _LOGGER.debug("Sending WebSocket message: %s", message)
         if self.websocket and not self.websocket.closed:
             try:
-                await self.websocket.send_str(json.dumps(message))
+                async with asyncio.timeout(WS_SEND_TIMEOUT):
+                    await self.websocket.send_str(json.dumps(message))
                 _LOGGER.debug("WebSocket message sent successfully")
             except Exception as err:
                 raise HomeAssistantError(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -205,6 +205,14 @@ class _EmptyWS:
         self.closed = False
         self.close_code = 1000
 
+    def __await__(self):
+        """aiohttp's ws_connect result is awaitable as well as an async CM."""
+
+        async def _resolve() -> "Self":
+            return self
+
+        return _resolve().__await__()
+
     async def __aenter__(self) -> Self:
         return self
 
@@ -277,6 +285,14 @@ class _HoldingWS:
         self.closed = False
         self.close_code = 1000
         self.release = asyncio.Event()
+
+    def __await__(self):
+        """aiohttp's ws_connect result is awaitable as well as an async CM."""
+
+        async def _resolve() -> "Self":
+            return self
+
+        return _resolve().__await__()
 
     async def __aenter__(self) -> Self:
         return self
@@ -526,3 +542,50 @@ async def test_recovery_warns_once_and_rearms(
     coordinator._mark_session_stable(None)
 
     assert coordinator._unavailable_logged is False
+
+
+async def test_send_is_bounded_by_a_timeout(hass: HomeAssistant) -> None:
+    """A peer that stops reading must not hang the calling service call.
+
+    `send_str` awaits the transport drain and has no timeout of its own, so
+    without a bound a stalled gateway blocked the caller indefinitely.
+    """
+    coordinator = _coordinator(hass)
+    ws = AsyncMock()
+    ws.closed = False
+
+    async def _never_returns(_data: str) -> None:
+        await asyncio.Event().wait()
+
+    ws.send_str = _never_returns
+    coordinator.websocket = ws
+
+    with patch("custom_components.junghome.coordinator.WS_SEND_TIMEOUT", 0.01):
+        with pytest.raises(HomeAssistantError):
+            await coordinator.send_websocket_message({"type": "x"})
+
+
+async def test_connect_is_bounded_by_a_timeout(hass: HomeAssistant) -> None:
+    """A gateway that accepts the socket then says nothing must not park the loop.
+
+    The shared session's default is ClientTimeout(total=300), which would leave
+    the reconnect loop stuck for five minutes with every controllable entity
+    unavailable and no failure counted.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = []
+
+    async def _never_connects(*_args: object, **_kwargs: object) -> object:
+        await asyncio.Event().wait()
+
+    session = Mock()
+    session.ws_connect = Mock(side_effect=_never_connects)
+    with (
+        patch(
+            "custom_components.junghome.coordinator.async_get_clientsession",
+            return_value=session,
+        ),
+        patch("custom_components.junghome.coordinator.WS_CONNECT_TIMEOUT", 0.01),
+        pytest.raises(TimeoutError),
+    ):
+        await coordinator._run_websocket()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -29,6 +29,15 @@ class _FakeWS:
     def __init__(self, frames: list[_FakeMsg]) -> None:
         self._frames = frames
         self.closed = False
+        self.close_code = 1000
+
+    def __await__(self):
+        """aiohttp's ws_connect result is awaitable as well as an async CM."""
+
+        async def _resolve() -> "Self":
+            return self
+
+        return _resolve().__await__()
 
     async def __aenter__(self) -> Self:
         return self


### PR DESCRIPTION
Every REST call in `coordinator.py` uses `asyncio.timeout(30)`. The two WebSocket paths had no bound of their own and relied on whatever the shared session happened to impose.

## `send_str` — genuinely unbounded

`send_str` awaits the transport drain and has no timeout at all. A gateway that stops reading blocks the calling service call **indefinitely**. Now bounded at 10 s; the existing handler already maps the failure onto the `cannot_send` `HomeAssistantError` the user sees.

## The handshake — bounded, but far too generously

I checked this rather than assuming, and **my review overstated it**. `ws_connect` inherits Home Assistant's shared session, which sets no `timeout=` of its own, so aiohttp's default applies:

```
DEFAULT_TIMEOUT: ClientTimeout(total=300, connect=None, sock_read=None, sock_connect=30, ceil_threshold=5)
```

So it is *not* unbounded — the review said "indefinitely", which was wrong. But a gateway that accepts the TCP connection and then says nothing still parks the reconnect loop for **five minutes**: no retry, no failure counted, no progress toward the repair issue, and every `_controllable_over_websocket` entity unavailable throughout. A gateway on the LAN either answers quickly or is not answering, so this is now 30 s.

Only the handshake is wrapped — wrapping the `async with` would tear down a healthy long-lived session after the timeout. Once connected, `heartbeat=30` remains what detects a silently dead peer, and `DEFAULT_WS_CLIENT_TIMEOUT(ws_receive=None, ws_close=10.0)` is unchanged.

## Test fakes made faithful

The `ws_connect` stand-ins implemented only the async-context-manager half of aiohttp's contract. The real return value is **awaitable as well** (`_WSRequestContextManager`), which is why restructuring the call broke five tests that were otherwise fine. They now implement `__await__` too, so they model the API they stand in for.

## Also

Extracted `_dispatch_text_frame` so `_run_websocket` stays about the session lifecycle; the added timeout pushed it past the statement limit.

## Honest note on the tests

`test_send_is_bounded_by_a_timeout` and `test_connect_is_bounded_by_a_timeout` pin that the bound exists and is honoured (patching the constants to 0.01 s). They do **not** reproduce the old behaviour — an unbounded wait cannot be asserted without hanging the suite. On the previous code they fail with `AttributeError` because the constants don't exist, which proves the constants are new rather than the hang is fixed.

318 passed, coverage 98.03% (gate 95), `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)