### PR TITLE
Stop the blueprint firing a gesture when a button recovers

### DIFF
--- a/blueprints/automation/junghome/button_gestures.yaml
+++ b/blueprints/automation/junghome/button_gestures.yaml
@@ -99,9 +99,19 @@ triggers:
     entity_id: !input button
 
 conditions:
+  # A press, and a *real* one. An event entity restores its last state across a
+  # restart, an entry reload and a failed poll, so the `unavailable -> <restored
+  # timestamp>` transition re-presents the stored `event_type` and looked exactly
+  # like a fresh press here — firing a gesture, and the user's lights, on its own.
+  # A button whose last recorded edge was `pressed` (which is what happens when
+  # the socket drops between press and release) did it on *every* recovery.
+  # Requiring a real previous state costs nothing: the first genuine press after
+  # a recovery still transitions timestamp -> timestamp and fires normally.
   - condition: template
     value_template: >
       {{ trigger is defined and trigger.to_state is not none
+         and trigger.from_state is not none
+         and trigger.from_state.state not in ('unavailable', 'unknown')
          and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 
 actions:
@@ -119,9 +129,13 @@ actions:
       seconds: !input hold_time
     continue_on_timeout: true
   - variables:
+      # Same guard as the trigger condition: a recovery landing inside the hold
+      # window must not be mistaken for the second press of a double-click.
       evt: >-
         {{ wait.trigger.to_state.attributes.get('event_type')
-           if (wait.trigger is not none and wait.trigger.to_state is not none)
+           if (wait.trigger is not none and wait.trigger.to_state is not none
+               and wait.trigger.from_state is not none
+               and wait.trigger.from_state.state not in ('unavailable', 'unknown'))
            else none }}
 
   - choose:
@@ -155,6 +169,8 @@ actions:
               - >
                 {{ wait.trigger is not none
                    and wait.trigger.to_state is not none
+                   and wait.trigger.from_state is not none
+                   and wait.trigger.from_state.state not in ('unavailable', 'unknown')
                    and wait.trigger.to_state.attributes.get('event_type') == 'pressed' }}
             sequence:
               - choose: []

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,0 +1,159 @@
+"""Tests for the shipped button-gestures blueprint.
+
+The blueprint is real, user-facing logic that HACS does not install and CI never
+exercised. These tests load the actual YAML and render its templates through
+Home Assistant's own engine, so a change to the gesture logic has to survive the
+same cases a user's buttons produce.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.template import Template
+
+_BLUEPRINT = (
+    Path(__file__).parent.parent
+    / "blueprints"
+    / "automation"
+    / "junghome"
+    / "button_gestures.yaml"
+)
+
+
+class _BlueprintLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates Home Assistant's `!input` tag."""
+
+
+_BlueprintLoader.add_constructor(
+    "!input", lambda loader, node: f"!input {loader.construct_scalar(node)}"
+)
+
+
+@pytest.fixture(name="blueprint")
+def blueprint_fixture() -> dict:
+    """The parsed blueprint."""
+    # S506 is a false positive here: _BlueprintLoader subclasses SafeLoader and
+    # only adds a constructor for `!input`, so it cannot instantiate arbitrary
+    # objects.
+    source = _BLUEPRINT.read_text(encoding="utf-8")
+    return yaml.load(source, Loader=_BlueprintLoader)  # noqa: S506
+
+
+def test_blueprint_declares_the_expected_inputs(blueprint: dict) -> None:
+    """The inputs the README and docs tell users to fill in are all present."""
+    assert blueprint["blueprint"]["domain"] == "automation"
+    assert set(blueprint["blueprint"]["input"]) == {
+        "button",
+        "hold_time",
+        "double_click_window",
+        "single_action",
+        "double_action",
+        "hold_action",
+    }
+    # `mode: single` + silent max_exceeded is what stops a second press
+    # re-entering the gesture state machine mid-run.
+    assert blueprint["mode"] == "single"
+    assert blueprint["max_exceeded"] == "silent"
+
+
+def _render(hass: HomeAssistant, template: str, **variables: object) -> bool:
+    return Template(template, hass).async_render(variables, parse_result=True)
+
+
+def _event(event_type: str, stamp: str = "2026-08-01T12:00:00+00:00") -> State:
+    """An event entity's state: a timestamp carrying the event_type attribute."""
+    return State("event.button_a_up", stamp, {"event_type": event_type})
+
+
+async def test_press_condition_fires_on_a_real_press(
+    hass: HomeAssistant, blueprint: dict
+) -> None:
+    """A genuine press (timestamp -> timestamp) starts the gesture."""
+    condition = blueprint["conditions"][0]["value_template"]
+    trigger = {
+        "from_state": _event("depressed", "2026-08-01T11:59:59+00:00"),
+        "to_state": _event("pressed"),
+    }
+    assert _render(hass, condition, trigger=trigger) is True
+
+
+async def test_press_condition_ignores_recovery_from_unavailable(
+    hass: HomeAssistant, blueprint: dict
+) -> None:
+    """The `unavailable -> restored` transition must not fire a gesture.
+
+    Event entities restore their last state, so a restart, an entry reload or a
+    recovered poll re-presents the stored `event_type`. When that stored value is
+    `pressed` — which is exactly what a socket drop between press and release
+    leaves behind — every single recovery ran the user's action.
+    """
+    condition = blueprint["conditions"][0]["value_template"]
+    for stale in ("unavailable", "unknown"):
+        trigger = {
+            "from_state": State("event.button_a_up", stale),
+            "to_state": _event("pressed"),
+        }
+        assert _render(hass, condition, trigger=trigger) is False, stale
+
+
+async def test_press_condition_ignores_a_release(
+    hass: HomeAssistant, blueprint: dict
+) -> None:
+    """Only `pressed` opens a gesture; the release is handled inside it."""
+    condition = blueprint["conditions"][0]["value_template"]
+    trigger = {
+        "from_state": _event("pressed", "2026-08-01T11:59:59+00:00"),
+        "to_state": _event("depressed"),
+    }
+    assert _render(hass, condition, trigger=trigger) is False
+
+
+async def test_mid_gesture_wait_ignores_recovery(
+    hass: HomeAssistant, blueprint: dict
+) -> None:
+    """A recovery inside the hold window is not the second press of a double."""
+    evt = blueprint["actions"][1]["variables"]["evt"]
+    recovery = {
+        "trigger": {
+            "from_state": State("event.button_a_up", "unavailable"),
+            "to_state": _event("pressed"),
+        }
+    }
+    assert _render(hass, evt, wait=recovery) is None
+
+    real_second_press = {
+        "trigger": {
+            "from_state": _event("depressed", "2026-08-01T11:59:59+00:00"),
+            "to_state": _event("pressed"),
+        }
+    }
+    assert _render(hass, evt, wait=real_second_press) == "pressed"
+
+
+async def test_slow_double_wait_ignores_recovery(
+    hass: HomeAssistant, blueprint: dict
+) -> None:
+    """The same guard applies to the second (slow double-click) wait."""
+    default_branch = blueprint["actions"][2]["default"]
+    condition = default_branch[1]["choose"][0]["conditions"][0]
+
+    recovery = {
+        "trigger": {
+            "from_state": State("event.button_a_up", "unavailable"),
+            "to_state": _event("pressed"),
+        }
+    }
+    assert _render(hass, condition, wait=recovery) is False
+
+    real = {
+        "trigger": {
+            "from_state": _event("depressed", "2026-08-01T11:59:59+00:00"),
+            "to_state": _event("pressed"),
+        }
+    }
+    assert _render(hass, condition, wait=real) is True
+
+    # Nothing arrived within the window -> SINGLE, not DOUBLE.
+    assert _render(hass, condition, wait={"trigger": None}) is False


### PR DESCRIPTION
## The bug

The blueprint triggers on **any** state change of the event entity and keeps the ones whose `event_type` is `pressed`:

```yaml
triggers:
  - trigger: state
    entity_id: !input button
conditions:
  - condition: template
    value_template: >
      {{ trigger is defined and trigger.to_state is not none
         and trigger.to_state.attributes.get('event_type') == 'pressed' }}
```

`EventEntity` extends `RestoreEntity` (verified in HA source), so a restart, an entry reload or a recovered REST poll replays the stored state. The `unavailable -> <restored timestamp>` transition therefore **re-presents the stored `event_type`**, which looks exactly like a fresh press — and the user's single/double/hold action runs on its own. Lights turning themselves on.

It is self-reinforcing rather than a rare race: a socket drop *between* press and release is precisely what strands a button at `pressed`, and from then on **every** recovery replays it.

## Fix

Require a real previous state. This costs nothing — the first genuine press after a recovery still goes `timestamp -> timestamp` and fires normally; only the recovery transition itself is suppressed.

The same guard is applied to **both** `wait_for_trigger` results, so a recovery landing inside the hold window is not read as the second press of a double-click either.

Preferred over `not_from:` on the trigger, which would flip the state trigger's `match_all` behaviour and change which transitions arrive at all.

## New: the blueprint finally has tests

`tests/test_blueprint.py` loads the **shipped YAML** and renders its templates through Home Assistant's own template engine. This is real user-facing logic that HACS does not install and that nothing exercised — the review flagged it as having no test or CI validation.

Run against the previous version, the three recovery cases fail:

```
FAILED test_press_condition_ignores_recovery_from_unavailable
FAILED test_mid_gesture_wait_ignores_recovery
FAILED test_slow_double_wait_ignores_recovery
3 failed, 3 passed
```

The three that pass on both are the normal-behaviour cases — a real press fires, a release does not, a genuine second press is still a double — so the guard demonstrably does not break real presses.

322 passed, `ruff` and `mypy --strict` clean.

See `CLAUDE-review.md` §3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)