### PR TITLE
Fetch scenes over REST, and drive reauth from a rejected scene recall

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -247,6 +247,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
     # Fetch room groups before the platforms create entities, so each device can
     # suggest its area at creation time. Best-effort: never blocks setup.
     await coordinator.async_fetch_groups()
+    # Same reasoning for scenes: they otherwise arrive only in the WebSocket
+    # handshake, which happens after the platforms are set up.
+    await coordinator.async_fetch_scenes()
 
     # One-time migration of registry entries from the gateway's volatile device
     # ids to firmware-stable, label-based ids. Must run while the gateway's ids

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -329,6 +329,39 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             return []
         return [g for g in data if isinstance(g, dict)]
 
+    async def _fetch_scenes_from_api(self, host: str, token: str) -> list[Scene]:
+        """Fetch the gateway's scenes from the REST API."""
+        session = async_get_clientsession(self.hass, verify_ssl=False)
+        url = f"https://{host}/api/junghome/scenes/"
+        headers = {"token": f"{token}", "Content-Type": "application/json"}
+        async with asyncio.timeout(30):
+            async with session.get(url, headers=headers) as response:
+                response.raise_for_status()
+                data = await response.json()
+        if not isinstance(data, list):
+            return []
+        return cast("list[Scene]", [s for s in data if isinstance(s, dict)])
+
+    async def async_fetch_scenes(self) -> None:
+        """Populate ``self.scenes`` from REST, best-effort.
+
+        Scenes otherwise arrive only in the WebSocket handshake, which connects
+        *after* the platforms are set up — so `scene.*` entities did not exist at
+        the end of setup, and never appeared at all if the WebSocket could not
+        connect, even though every other platform keeps working on the REST poll.
+        Fetching here means scenes are present as soon as setup finishes and
+        survive a gateway whose WebSocket is unavailable.
+
+        Best-effort for the same reason as the groups fetch: a scene list is not
+        worth failing setup over, and the handshake delivers it moments later.
+        """
+        try:
+            self.scenes = await self._fetch_scenes_from_api(
+                self.config["host"], self.config["token"]
+            )
+        except (aiohttp.ClientError, TimeoutError, ValueError) as err:
+            _LOGGER.debug("Could not fetch Jung Home scenes: %s", err)
+
     async def async_fetch_groups(self) -> None:
         """Populate ``self.groups`` from REST, best-effort.
 
@@ -462,6 +495,26 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             async with asyncio.timeout(30):
                 async with session.post(url, headers=headers) as response:
                     response.raise_for_status()
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403):
+                # A revoked/expired token is permanent: reporting it as
+                # "reconnecting, try again in a moment" left the user retrying a
+                # scene forever with nothing prompting them to re-authenticate.
+                # The REST poll and the WebSocket upgrade both drive reauth on
+                # these statuses; this is the third path that can see one.
+                _LOGGER.warning(
+                    "Jung Home gateway rejected the token on scene recall "
+                    "(HTTP %s); starting reauthentication",
+                    err.status,
+                )
+                if self.config_entry is not None:
+                    self.config_entry.async_start_reauth(self.hass)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="auth_failed"
+                ) from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_send"
+            ) from err
         except (aiohttp.ClientError, TimeoutError) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="cannot_send"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "real_groups_fetch: let the test run the real _fetch_groups_from_api "
         "(pair with aioclient_mock); by default it is stubbed to avoid a socket.",
     )
+    config.addinivalue_line(
+        "markers",
+        "real_scenes_fetch: let the test run the real _fetch_scenes_from_api "
+        "(pair with aioclient_mock); by default it is stubbed to avoid a socket.",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -360,6 +365,25 @@ def mock_groups_fetch(request):
     with patch.object(
         JungHomeDataUpdateCoordinator,
         "_fetch_groups_from_api",
+        AsyncMock(return_value=[]),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_scenes_fetch(request):
+    """Keep the setup-time REST scenes fetch off the network.
+
+    The mirror of ``mock_groups_fetch``: ``async_setup_entry`` also fetches the
+    gateway's scenes over REST before the platforms are set up, so that scenes
+    exist even when the WebSocket never connects. Same defaulting, same opt-out.
+    """
+    if request.node.get_closest_marker("real_scenes_fetch") is not None:
+        yield
+        return
+    with patch.object(
+        JungHomeDataUpdateCoordinator,
+        "_fetch_scenes_from_api",
         AsyncMock(return_value=[]),
     ):
         yield

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,8 +1,10 @@
 """Scene platform tests for Jung Home."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
+import aiohttp
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -16,6 +18,7 @@ from syrupy.assertion import SnapshotAssertion
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.scene import JungHomeScene, _scene_slug
+from tests.conftest import _fake_run_websocket
 
 
 def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
@@ -133,3 +136,114 @@ async def test_all_scene_entities(
     )
     await hass.async_block_till_done()
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+@pytest.mark.real_scenes_fetch
+async def test_scenes_exist_without_the_websocket(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Scenes come up on the REST fetch alone.
+
+    They previously arrived only in the WebSocket handshake, which connects
+    *after* the platforms are set up — so scene entities did not exist at the end
+    of setup, and never appeared at all on a gateway whose WebSocket could not
+    connect, even though every other platform keeps working on the REST poll.
+    """
+    aioclient_mock.get(
+        "https://1.2.3.4/api/junghome/scenes/",
+        json=[{"id": "id0001", "label": "Movie night"}],
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+
+    async def _never_connects(self) -> None:
+        raise aiohttp.ClientError("no websocket here")
+
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(JungHomeDataUpdateCoordinator, "_run_websocket", _never_connects),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("scene.movie_night") is not None
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.real_scenes_fetch
+async def test_scene_fetch_failure_is_not_fatal(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """A scene list is not worth failing setup over."""
+    aioclient_mock.get("https://1.2.3.4/api/junghome/scenes/", status=500)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data.scenes == []
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_revoked_token_on_recall_starts_reauth(hass: HomeAssistant) -> None:
+    """A 401 on scene recall is permanent, so it must drive reauth.
+
+    It used to be reported as `cannot_send` — "the gateway is reconnecting, try
+    again in a moment" — leaving the user retrying a scene forever with nothing
+    prompting them to re-authenticate.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="h", data={CONF_HOST: "h", CONF_TOKEN: "t"}
+    )
+    entry.add_to_hass(hass)
+    coordinator = JungHomeDataUpdateCoordinator(
+        hass, {"host": "h", "token": "t"}, entry
+    )
+
+    class _Denied:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        def raise_for_status(self):
+            raise aiohttp.ClientResponseError(Mock(), (), status=401)
+
+    session = Mock()
+    session.post = Mock(return_value=_Denied())
+    with (
+        patch(
+            "custom_components.junghome.coordinator.async_get_clientsession",
+            return_value=session,
+        ),
+        patch.object(entry, "async_start_reauth") as start_reauth,
+        pytest.raises(HomeAssistantError),
+    ):
+        await coordinator.activate_scene("id0001")
+    start_reauth.assert_called_once()


### PR DESCRIPTION
Two independent gaps on the scene path, which is the one part of the integration that runs over REST rather than the WebSocket.

## 1. Scenes existed only if the WebSocket connected

`coordinator.scenes` was populated **only** by the WebSocket `scenes` broadcast, and the socket opens *after* the platforms are set up. So:

- `scene.*` entities did not exist at the end of `async_setup_entry`
- on a gateway whose WebSocket cannot connect, they **never appeared at all**

…even though every other platform keeps working on the 60 s REST poll, and `GET /scenes/` is documented in `docs/gateway-rest-api.md`.

`async_fetch_scenes` mirrors `async_fetch_groups` exactly — same 30 s timeout, same best-effort guard, fetched right next to it before the platforms are forwarded. A scene list is not worth failing setup over, and the handshake still delivers updates moments later.

## 2. A revoked token on scene recall looked transient

`activate_scene` mapped every `ClientError` — and `ClientResponseError` is one — onto `cannot_send`:

> "Could not reach the Jung Home gateway to send the command; it is reconnecting. Try again in a moment."

For a 401/403 that is never true. The user would retry a scene forever with nothing prompting them to re-authenticate. A rejected token now starts the reauth flow and raises the existing `auth_failed` message, matching what the REST poll (`coordinator.py:228`) and the WebSocket upgrade already do. **This was the third path that can see a 401 and the only one that swallowed it.** No new strings, so no translation work.

## Tests

- `test_scenes_exist_without_the_websocket` — `_run_websocket` raises permanently; the scene still appears. **Fails on the previous code:** `assert None is not None` for `scene.movie_night`.
- `test_scene_fetch_failure_is_not_fatal` — a 500 leaves the entry `LOADED` with an empty scene list.
- `test_revoked_token_on_recall_starts_reauth` — asserts `async_start_reauth` is called. (Previously `ClientResponseError` fell into the generic `ClientError` branch, so it never was.)

`conftest` gains `mock_scenes_fetch`, the mirror of the existing `mock_groups_fetch` — without it every entity test opens a real socket during setup, which the HA harness rejects. Same `real_scenes_fetch` opt-out marker for the tests that exercise the REST body.

330 passed, coverage 97.88% (gate 95), `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §3.4 and §4 (401/403 on the scene-recall path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)