### PR TITLE
Parse light brightness and colour temperature as floats

### DIFF
--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -248,9 +248,14 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         value = datapoint_value(datapoint, "brightness")
         if value is None:
             return 0
+        # Parse as a float, not an int: gateway numerics arrive as strings, and
+        # `int("50.0")` raises — which silently read as brightness 0, i.e. a lamp
+        # stuck at 0 % with nothing logged. Every other platform (cover, climate,
+        # sensor) already goes through float(). ValueError also covers NaN and
+        # OverflowError covers inf, both of which `round` rejects.
         try:
-            raw = int(value)
-        except (TypeError, ValueError):
+            raw = round(float(value))
+        except (TypeError, ValueError, OverflowError):
             raw = 0
         # Device reports 0-100; convert linearly to HA 0-255, clamping the
         # untrusted gateway value into HA's documented 0-255 brightness range.
@@ -268,9 +273,11 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         value = datapoint_value(datapoint, "color_temperature")
         if value is None:
             return None
+        # Same as brightness above: a decimal-formatted Kelvin value must not
+        # blank the colour temperature.
         try:
-            kelvin = int(value)
-        except (TypeError, ValueError):
+            kelvin = round(float(value))
+        except (TypeError, ValueError, OverflowError):
             return None
         # Clamp to this light's own advertised range (gateway-supplied where
         # available, defaults otherwise) so an out-of-range value doesn't violate

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -35,6 +36,7 @@ def _color_light(
     *,
     parent_groups: list | None = None,
     color_temp: str = "3000",
+    brightness: str = "50",
 ) -> JungHomeLight:
     device = {
         "id": "c",
@@ -49,7 +51,7 @@ def _color_light(
             {
                 "id": "c-2",
                 "type": "brightness",
-                "values": [{"key": "brightness", "value": "50"}],
+                "values": [{"key": "brightness", "value": brightness}],
             },
             {
                 "id": "c-4",
@@ -480,3 +482,44 @@ async def test_all_light_entities(
     """
     entry = await init_platform(Platform.LIGHT)
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_pct"),
+    [("50", 50), ("50.0", 50), ("49.6", 50), ("100.0", 100)],
+)
+async def test_decimal_brightness_is_parsed(
+    hass: HomeAssistant, raw: str, expected_pct: int
+) -> None:
+    """A decimal-formatted brightness must not read as 0.
+
+    Gateway numerics arrive as strings, and `int("50.0")` raises — which fell
+    through to brightness 0, showing the lamp at 0 % with nothing logged. Cover,
+    climate and sensor all parse via float(); this brings light into line.
+    """
+    light = _color_light(_bare_coordinator(hass), brightness=raw)
+    assert light.brightness == round(expected_pct * 255 / 100)
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "-inf", "", "abc"])
+async def test_unparseable_brightness_falls_back_to_zero(
+    hass: HomeAssistant, raw: str
+) -> None:
+    """Genuinely unusable values still degrade safely rather than raise."""
+    assert _color_light(_bare_coordinator(hass), brightness=raw).brightness == 0
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("2700", 2700), ("2700.0", 2700)])
+async def test_decimal_color_temp_is_parsed(
+    hass: HomeAssistant, raw: str, expected: int
+) -> None:
+    """A decimal-formatted Kelvin value must not blank the colour temperature."""
+    light = _color_light(_bare_coordinator(hass), color_temp=raw)
+    assert light.color_temp_kelvin == expected
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "abc"])
+async def test_unparseable_color_temp_is_none(hass: HomeAssistant, raw: str) -> None:
+    """An unusable Kelvin value yields None rather than raising."""
+    light = _color_light(_bare_coordinator(hass), color_temp=raw)
+    assert light.color_temp_kelvin is None


### PR DESCRIPTION
## The bug

Both light value extractors parsed with `int()` and caught the failure by falling back to a "safe" default:

```python
try:
    raw = int(value)
except (TypeError, ValueError):
    raw = 0          # brightness
```

But `int("50.0")` **raises**. Gateway numerics arrive as strings — the coordinator's own `_as_kelvin` documents exactly this and handles it properly — so a firmware that formats brightness with a decimal made the lamp read **0 % on every poll**, with nothing logged to explain it. Colour temperature went `None` the same way.

Cover, climate and sensor all already parse via `float()`. Light was the outlier:

```
'50'    int-> 50
'50.0'  int-> ValueError   round(float)-> 50
'49.6'  int-> ValueError   round(float)-> 50
'nan'   int-> ValueError   round(float)-> ValueError
'inf'   int-> ValueError   round(float)-> OverflowError
'abc'   int-> ValueError   round(float)-> ValueError
```

The last two rows are why `OverflowError` joins the caught set: `round` rejects NaN with `ValueError` and infinity with `OverflowError`. Genuinely unusable values still degrade to `0`/`None` rather than escaping into the platform — the existing defensive contract is kept, it just stops catching valid input.

## Tests

Parametrised over both real and unusable values. The four decimal cases fail on the previous code:

```
FAILED test_decimal_brightness_is_parsed[50.0-50]
FAILED test_decimal_brightness_is_parsed[49.6-50]
FAILED test_decimal_brightness_is_parsed[100.0-100]
FAILED test_decimal_color_temp_is_parsed[2700.0-2700]
```

The integer cases pass on both, so the normal path is provably unchanged. `_color_light` gains a `brightness` knob so the helper can drive the parsing directly.

341 passed, `light.py` at 99%, total 98.06%. `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §4 (platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)