### PR TITLE
Make automatic device removal conservative, visible and reversible

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ specifically — see the repair notice above.
 The gateway rejected the stored token, usually because it was revoked in the app
 or the gateway was factory-reset. Follow the reauth prompt to issue a new one.
 
+**A device disappeared from Home Assistant.**
+The integration removes a device once the gateway has stopped reporting it for
+ten consecutive polls (about ten minutes) — that is how a device you delete in
+the JUNG HOME app also leaves Home Assistant. A removal is logged as a warning
+naming the device, so check the log if one goes unexpectedly. If the device is
+still installed, make sure it is powered and in range of the mesh; it is re-added
+automatically once the gateway reports it again, though any custom name, area or
+`entity_id` you had set is not restored. You can also remove a stale device
+yourself from its device page (**⋮ → Delete**); Home Assistant refuses this while
+the gateway is still reporting the device, since it would simply come straight
+back.
+
 **A device you added in the app doesn't show up.**
 New devices are picked up on the next REST poll (within a minute). If it still
 doesn't appear, download diagnostics (**⋮ → Download diagnostics** on the entry)

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -42,7 +42,19 @@ PLATFORMS: list[Platform] = [
 # entities — and because identity is label-derived, the platform would then
 # re-create them under whatever label the next poll reports, losing the user's
 # entity_id/customisations. Requiring persistence rides out a transient blip.
-STALE_DEVICE_PRUNE_MISSES = 3
+#
+# The threshold is deliberately generous (10 polls ~ 10 minutes). Removal is
+# destructive and irreversible from the user's side — it takes the entity
+# registry entries with it, so custom names, areas and entity_ids are lost and
+# automations referencing them break — while the cost of removing late is only
+# that a device the user deleted in the app lingers for a few extra minutes.
+# Home Assistant core integrations that prune do so on the *first* miss, but
+# they trust their hub's device list; this gateway is documented above as
+# occasionally returning a partial one, so the same confidence isn't available.
+# It is also not known whether the gateway omits an unreachable BT-Mesh device
+# from `/functions/`; if it does, a device that is merely out of range must not
+# be deleted for it.
+STALE_DEVICE_PRUNE_MISSES = 10
 
 # Failures the stable-id migration can realistically hit, and therefore the only
 # ones it treats as "this item didn't migrate, carry on":
@@ -210,6 +222,17 @@ def _make_stale_device_pruner(
                 missing_polls[device_entry.id] = misses
                 continue
             missing_polls.pop(device_entry.id, None)
+            # Say so. This deletes the device and every entity on it, which the
+            # user otherwise discovers by noticing something has silently gone.
+            _LOGGER.warning(
+                "Jung Home: removing device %s (%s) — the gateway has not "
+                "reported it for %s consecutive polls. If it is still installed, "
+                "check that it is reachable; it will be re-added when the gateway "
+                "reports it again",
+                device_entry.name or device_entry.id,
+                ", ".join(sorted(slugs)),
+                STALE_DEVICE_PRUNE_MISSES,
+            )
             # Forget this device's unique_ids from the platforms' discovery sets
             # BEFORE removing it, so if the gateway reports it again the platforms
             # treat it as new and re-create its entities (otherwise the stale
@@ -488,6 +511,39 @@ def _migrate_device_identifiers(
                 device_entry.id,
             )
     return had_error
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: JungHomeConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Let the user delete a device the gateway no longer reports.
+
+    Without this the automatic pruner is the *only* way a device can leave the
+    registry, so a device the gateway has genuinely stopped reporting — hardware
+    removed, or relabelled in the app, which changes its label-derived identity —
+    sits there with no way to clear it from the UI.
+
+    A device the gateway *is* currently reporting is refused: the next poll would
+    re-create it immediately, so allowing the delete would just look broken.
+    """
+    coordinator = getattr(config_entry, "runtime_data", None)
+    live = {device_slug(d) for d in (coordinator.data or [])} if coordinator else set()
+    # The synthetic hub is not in the device list but is not stale either.
+    live.add(gateway_device_id(config_entry))
+    slugs = {
+        identifier
+        for domain, identifier in device_entry.identifiers
+        if domain == DOMAIN
+    }
+    if slugs & live:
+        return False
+    if coordinator is not None:
+        # Mirror the pruner: drop the ids so the platforms treat the device as new
+        # if the gateway ever reports it again.
+        coordinator.forget_device_unique_ids(device_entry.id)
+    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -18,6 +19,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome import (
     STALE_DEVICE_PRUNE_MISSES,
+    async_remove_config_entry_device,
     async_unload_entry,
 )
 from custom_components.junghome.const import (
@@ -25,6 +27,7 @@ from custom_components.junghome.const import (
     DOMAIN,
     device_slug,
     duplicate_slugs,
+    gateway_device_id,
 )
 from custom_components.junghome.coordinator import (
     JungHomeDataUpdateCoordinator,
@@ -1633,3 +1636,68 @@ def test_duplicate_slugs_reports_only_collisions() -> None:
     # Distinct labels collide with nothing.
     assert duplicate_slugs(copy.deepcopy(DEVICES)) == {}
     assert duplicate_slugs([]) == {}
+
+
+async def test_user_can_delete_a_device_the_gateway_dropped(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """An orphaned device can be removed from the UI.
+
+    The automatic pruner is deliberately slow and conservative, so without a
+    manual path a device the gateway has genuinely stopped reporting sits in the
+    registry with no way to clear it.
+    """
+    dev_reg = dr.async_get(hass)
+    ghost = dev_reg.async_get_or_create(
+        config_entry_id=init_integration.entry_id,
+        identifiers={(DOMAIN, "ghost_device")},
+    )
+
+    assert await async_remove_config_entry_device(hass, init_integration, ghost) is True
+
+
+async def test_user_cannot_delete_a_live_device(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Deleting a device the gateway still reports is refused.
+
+    The next poll would re-create it immediately, so allowing it would just look
+    broken to the user.
+    """
+    dev_reg = dr.async_get(hass)
+    live = dev_reg.async_get_device(identifiers={(DOMAIN, device_slug(DEVICES[0]))})
+    assert live is not None
+
+    assert await async_remove_config_entry_device(hass, init_integration, live) is False
+
+
+async def test_the_gateway_hub_cannot_be_deleted(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The synthetic hub is never in the device list but is not stale either."""
+    dev_reg = dr.async_get(hass)
+    hub = dev_reg.async_get_device(
+        identifiers={(DOMAIN, gateway_device_id(init_integration))}
+    )
+    assert hub is not None
+
+    assert await async_remove_config_entry_device(hass, init_integration, hub) is False
+
+
+async def test_pruning_a_device_is_logged(
+    hass: HomeAssistant, init_integration, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Removal must not be silent — it deletes every entity on the device."""
+    coordinator = init_integration.runtime_data
+    dev_reg = dr.async_get(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=init_integration.entry_id,
+        identifiers={(DOMAIN, "ghost_device")},
+    )
+    with caplog.at_level(logging.WARNING):
+        for _ in range(STALE_DEVICE_PRUNE_MISSES):
+            coordinator.async_update_listeners()
+            await hass.async_block_till_done()
+
+    assert "removing device" in caplog.text
+    assert "ghost_device" in caplog.text


### PR DESCRIPTION
Follow-up to the pruner question. Removing a device deletes every entity on it **and its registry entries** — custom names, areas and `entity_id`s are lost, and automations referencing them break. Recorder history survives; nothing else does. Three things made that riskier than it needed to be.

## 1. The threshold was three polls (~3 minutes)

I surveyed the 1468 integrations in the pinned Home Assistant:

| Pattern | Count |
|---|---|
| Auto-prune (`remove_config_entry_id`) | 83 |
| User-driven removal (`async_remove_config_entry_device`) | 61 |
| **Miss-counting before removal** | **0** |

Auto-pruning is normal. `unifi_access` is structurally identical to this pruner — iterate registry devices, drop any not in the current list — but removes on the **first** miss, no counter. Nothing in core debounces.

They can do that because their hub's device list is authoritative. This one isn't, and the constant's own comment already says so:

> "the gateway occasionally returns a partial device list on a single poll (notably right after a reload)"

A counter over an unreliable signal is a mitigation, not a guarantee. And it is **not established** whether the gateway omits an unreachable BT-Mesh device from `/functions/` — `docs/gateway-rest-api.md` doesn't say. If it does, a device that is merely out of range is a deletion candidate after three minutes.

Raised to **10**. Removing late costs a few minutes of lag on a device the user deleted in the app; removing wrongly costs their configuration. The asymmetry is not close.

## 2. Removal was completely silent

Now logged at WARNING, naming the device and what to check. A device vanishing should be findable in the log, not noticed weeks later.

## 3. The pruner was the only removal path

No `async_remove_config_entry_device`, so a genuinely-gone device — hardware removed, or **relabelled in the app**, which changes its label-derived identity and orphans the old entry — could not be cleared from the UI at all. Added, and it refuses a device the gateway is still reporting, since the next poll would re-create it and the delete would look broken.

## Not fixed here

Whether `/functions/` lists unreachable devices is the question that actually determines whether the pruner is safe at *any* threshold, and it needs the hardware: power a device off, wait, and see whether it stays in the list. If it drops out, this should stop auto-removing entirely and rely on the manual path.

## Tests + docs

Four new tests: an orphaned device is removable, a live one is refused, the synthetic hub is refused, and pruning emits the warning. The existing prune tests already referenced `STALE_DEVICE_PRUNE_MISSES` symbolically, so the threshold change needed no test edits.

README documents the behaviour under Troubleshooting — until now nothing told users devices could disappear on their own.

331 passed, coverage 98.03%, `mypy --strict` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)