### PR TITLE
Stop an unrelated push reverting optimistic switch state

### DIFF
--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -90,11 +90,24 @@ class JungHomeSocket(JungHomeEntity, SwitchEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug("Handling coordinator update for socket %s", self._name)
-        datapoint = self._find_datapoint(self._datapoint["id"])
-        if datapoint:
-            self._is_on = self._get_state_from_datapoint(datapoint)
-            _LOGGER.debug("Updated state for socket %s: %s", self._name, self._is_on)
-            self.async_write_ha_state()
+        # Only re-read on a poll, or on a push for *this* datapoint (see
+        # JungHomeEntity._should_refresh). Every push notifies every entity, so
+        # without this an unrelated device's push re-read this socket's stored
+        # value — which is still the pre-command one until the gateway echoes —
+        # and reverted the optimistic state written by turn_on/turn_off. The
+        # switch visibly flipped back and then on again. light, cover and climate
+        # already guard this way.
+        if self._should_refresh(self._datapoint["id"]):
+            datapoint = self._find_datapoint(self._datapoint["id"])
+            if datapoint:
+                self._is_on = self._get_state_from_datapoint(datapoint)
+                _LOGGER.debug(
+                    "Updated state for socket %s: %s", self._name, self._is_on
+                )
+        # Write unconditionally (even when the datapoint is momentarily absent) so
+        # the entity's availability tracks the gateway on every coordinator update,
+        # matching JungHomeSwitch below.
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the socket on."""
@@ -167,9 +180,12 @@ class JungHomeSwitch(JungHomeEntity, SwitchEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         _LOGGER.debug("Updating switch for %s", self._attr_unique_id)
-        datapoint = self._find_datapoint(self._datapoint["id"])
-        if datapoint is not None:
-            self._attr_is_on = self._get_state_from_datapoint(datapoint)
+        # Same guard as the socket above: an unrelated push must not revert the
+        # optimistic state written by turn_on/turn_off.
+        if self._should_refresh(self._datapoint["id"]):
+            datapoint = self._find_datapoint(self._datapoint["id"])
+            if datapoint is not None:
+                self._attr_is_on = self._get_state_from_datapoint(datapoint)
         # Write unconditionally (even when the datapoint is momentarily absent) so
         # the entity's availability tracks the gateway on every coordinator update.
         self.async_write_ha_state()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,6 +1,6 @@
 """Switch / socket platform tests for Jung Home."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
@@ -113,3 +113,65 @@ async def test_all_switch_entities(
     """
     entry = await init_platform(Platform.SWITCH)
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+async def test_unrelated_push_does_not_revert_optimistic_socket_state(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """An unrelated device's push must not flip a just-commanded socket back.
+
+    Every push notifies every entity. The socket used to re-read its own stored
+    datapoint — still the pre-command value until the gateway echoes — and
+    reverted the optimistic state, so the switch visibly flipped off and then on
+    again.
+    """
+    coordinator = init_integration.runtime_data
+    assert hass.states.get("switch.boiler").state == "on"
+
+    # Command it off. The gateway has not echoed yet, so the stored value is
+    # still "1"; only the optimistic write says otherwise.
+    with patch.object(coordinator, "send_websocket_message", AsyncMock()):
+        await hass.services.async_call(
+            "switch",
+            "turn_off",
+            {"entity_id": "switch.boiler"},
+            blocking=True,
+        )
+    assert hass.states.get("switch.boiler").state == "off"
+
+    # A push for a completely different device arrives before the echo.
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": "idlight1-001", "values": [{"key": "switch", "value": "1"}]},
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.boiler").state == "off", (
+        "an unrelated push reverted the optimistic socket state"
+    )
+
+
+async def test_the_gateway_echo_still_updates_the_socket(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The guard must not stop the real echo landing."""
+    coordinator = init_integration.runtime_data
+    socket_dp = next(
+        dp["id"]
+        for d in coordinator.data
+        if d["label"] == "Boiler"
+        for dp in d["datapoints"]
+        if dp["type"] == "switch"
+    )
+
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": socket_dp, "values": [{"key": "switch", "value": "0"}]},
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.boiler").state == "off"


### PR DESCRIPTION
## The bug

Every WebSocket push notifies **every** entity. `light`, `cover` and `climate` all guard their reads with `JungHomeEntity._should_refresh`, so they only re-read on a REST poll or on a push for their *own* datapoint. `cover.py` spells out why:

> "…so a level echo can't momentarily reset the position to the old value (a UI flicker)"

`switch.py` was the one platform that never adopted it. Both `JungHomeSocket` and `JungHomeSwitch` (the status LED) re-read their stored datapoint on every push from any device on the gateway.

Between issuing a command and the gateway echoing it, that stored value is still the **pre-command** one. So any unrelated push — a presence detector, another light, an energy reading — re-read it and reverted the optimistic state written by `turn_on`/`turn_off`. The switch visibly flipped back and then on again, with a spurious `state_changed` in each direction.

## Also

`JungHomeSocket` skipped `async_write_ha_state()` when its datapoint was momentarily absent, so availability stopped tracking the gateway on those cycles. Now unconditional — matching what `JungHomeSwitch` immediately below already does, and already documents.

## Tests

`test_unrelated_push_does_not_revert_optimistic_socket_state` turns the socket off, then fires a push for a *different* device before the echo. It fails on the previous code:

```
E  AssertionError: an unrelated push reverted the optimistic socket state
E  assert 'on' == 'off'
```

`test_the_gateway_echo_still_updates_the_socket` asserts the genuine echo for the socket's own datapoint still lands — it passes on both, so the guard demonstrably narrows nothing that matters.

329 passed, `switch.py` at 99%, total 98.07%. `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §4 (platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)