### PR TITLE
Expose quantity datapoints that carry no unit

### DIFF
--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -90,7 +90,15 @@ async def async_setup_entry(
                         if is_presence_quantity(raw_label, unit):
                             continue
                         label = raw_label.strip() if raw_label else None
-                        if label and unit:
+                        # A unit is NOT required. An unrecognised unit already
+                        # becomes a unitless measurement sensor below, so refusing
+                        # a datapoint that simply has no unit was inconsistent —
+                        # and it fell through binary_sensor too (that platform
+                        # only claims presence-ish labels), so a labelled
+                        # unit-less quantity such as a counter or an index got no
+                        # entity at all and no log line. A label is still required:
+                        # it is the entity's name and part of its unique_id.
+                        if label:
                             uid = stable_unique_id(
                                 device, datapoint, label.replace(" ", "_").lower()
                             )
@@ -120,7 +128,7 @@ class JungHomeQuantity(JungHomeEntity, SensorEntity):
         device: Device,
         datapoint: Datapoint,
         label: str,
-        unit: str,
+        unit: str | None,
     ) -> None:
         """Initialize the quantity."""
         super().__init__(coordinator, device)
@@ -131,15 +139,25 @@ class JungHomeQuantity(JungHomeEntity, SensorEntity):
         self._attr_unique_id = stable_unique_id(
             device, datapoint, label.replace(" ", "_").lower()
         )
-        mapped = _UNIT_MAP.get(unit.strip().lower())
+        cleaned = (unit or "").strip()
+        mapped = _UNIT_MAP.get(cleaned.lower())
         if mapped is not None:
             device_class, state_class, ha_unit = mapped
         else:
-            # Unknown unit: expose a unitless measurement sensor (numeric, with
-            # statistics) rather than a stateless string with an arbitrary unit.
+            # Unknown or absent unit: expose a unitless measurement sensor
+            # (numeric, with statistics) rather than a stateless string with an
+            # arbitrary unit.
             device_class, state_class, ha_unit = None, _MEAS, None
-            if unit not in _warned_units:
-                _warned_units.add(unit)
+            if not cleaned:
+                # A quantity that genuinely carries no unit (a count, an index)
+                # is expected, not a mapping gap — don't warn about it.
+                _LOGGER.debug(
+                    "Jung Home quantity %r has no unit; exposing a unitless "
+                    "measurement sensor",
+                    label,
+                )
+            elif cleaned not in _warned_units:
+                _warned_units.add(cleaned)
                 _LOGGER.warning(
                     "Unmapped Jung Home quantity unit %r; exposing a unitless "
                     "measurement sensor",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,8 @@
 """Numeric sensor platform tests for Jung Home."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -12,6 +15,7 @@ from syrupy.assertion import SnapshotAssertion
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.sensor import JungHomeQuantity
+from tests.conftest import _fake_run_websocket
 
 
 def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
@@ -104,3 +108,92 @@ async def test_all_sensor_entities(
     """
     entry = await init_platform(Platform.SENSOR)
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+def _measurement_device(unit: str | None, label: str = "Cycle Count") -> dict:
+    """A Measurement device whose quantity carries `unit` (None = key absent)."""
+    values: list[dict] = [
+        {"key": "quantity", "value": "7"},
+        {"key": "quantity_label", "value": label},
+    ]
+    if unit is not None:
+        values.append({"key": "quantity_unit", "value": unit})
+    return {
+        "id": "idmeas1",
+        "type": "Measurement",
+        "label": "Boiler",
+        "datapoints": [{"id": "idmeas1-001", "type": "quantity", "values": values}],
+    }
+
+
+@pytest.mark.parametrize("unit", [None, "", "   "])
+async def test_quantity_without_a_unit_still_gets_a_sensor(
+    hass: HomeAssistant, unit: str | None
+) -> None:
+    """A labelled quantity with no unit must not vanish.
+
+    sensor.py required a unit, and binary_sensor only claims presence-ish labels,
+    so a unit-less quantity (a counter, an index) fell through both platforms —
+    no entity, no log. An *unrecognised* unit already became a unitless
+    measurement sensor, so refusing an absent one was inconsistent.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[_measurement_device(unit)]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.boiler_cycle_count")
+    assert state is not None, "a unit-less quantity produced no entity"
+    assert state.state == "7.0"
+    # Unitless measurement: numeric with statistics, but no unit or device class.
+    assert state.attributes.get("unit_of_measurement") is None
+    assert state.attributes.get("state_class") == "measurement"
+    assert state.attributes.get("device_class") is None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_presence_labelled_quantity_still_goes_to_binary_sensor(
+    hass: HomeAssistant,
+) -> None:
+    """The split point is unchanged: presence labels are not numeric sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.5",
+        data={CONF_HOST: "1.2.3.5", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    device = _measurement_device(None, label="Presence Detected")
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[device]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.boiler_presence_detected") is None
+    assert hass.states.get("binary_sensor.boiler_presence_detected") is not None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## The gap

`sensor.py` required **both** a label and a unit:

```python
if label and unit:
```

…and `binary_sensor.py` only claims labels that denote presence. So a quantity datapoint with a label but **no unit** — a counter, an index, a level — fell through *both* platforms: no entity, and no log line. The gateway reported the value and Home Assistant silently ignored it.

That was inconsistent with the code twenty lines below, which already handles an **unrecognised** unit by exposing a unitless `MEASUREMENT` sensor rather than dropping the datapoint. So `"?"` produced a sensor while `""` produced nothing, even though both end up unitless.

## Fix

A unit is now optional. A **label is still required** — it names the entity and forms part of its `unique_id`, so a nameless datapoint is still skipped.

An absent unit is an expected shape rather than a mapping gap, so it logs at debug instead of the `"Unmapped Jung Home quantity unit"` warning. As a side effect a whitespace-only unit no longer warns about itself.

**The presence split is untouched.** `is_presence_quantity` is still evaluated first, so a presence-labelled datapoint remains a `binary_sensor` — pinned by a test.

## Worth flagging in review

This **creates entities where there previously were none**, so an affected installation will see new sensors appear after upgrading. That is the intent — the gateway was already reporting the data — but it is user-visible, not a silent internal fix.

## Tests

Parametrised over `None` (key absent), `""` and `"   "`:

```
FAILED test_quantity_without_a_unit_still_gets_a_sensor[None]
FAILED test_quantity_without_a_unit_still_gets_a_sensor[]
```

Both fail on the previous code with *"a unit-less quantity produced no entity"*. The whitespace-only case passes on **both** — old code treated `"   "` as truthy — and the presence-label control passes on both too, so neither of those paths changed outcome. That is deliberate: the failing cases isolate exactly the behaviour being changed.

354 passed, `sensor.py` 99%, `binary_sensor.py` 100%, total 97.86%. `mypy --strict` and `ruff` clean.

See `CLAUDE-review.md` §4 (platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)