### PR TITLE
Run the checks against the tagged commit before publishing a release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
 on:
+  # Callable so the release workflow can gate on the exact tagged commit.
+  workflow_call:
   push:
     branches:
       - "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ name: Release
 #   2. git tag vX.Y.Z && git push origin vX.Y.Z
 #
 # This workflow fails if the tag doesn't match the manifest version, to keep
-# them in sync.
+# them in sync, and it re-runs lint, tests and hassfest/HACS validation against
+# the tagged commit before publishing anything. `test.yml` and friends only
+# trigger on branch pushes and pull requests, so a tag ran *none* of them: a tag
+# pushed alongside its commit could publish to every HACS user before CI on main
+# had finished, or even after it had failed.
 #
 # A plain X.Y.Z tag is a normal release. Anything with a suffix (e.g. 1.1.0b1,
 # 1.1.0-rc1) is published as a GitHub *pre-release*, which HACS hides from users
@@ -19,12 +23,23 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
+  # Gate: the same checks main runs, but against the tag. Called workflows run at
+  # the caller's ref, so these validate exactly what is about to be published.
+  lint:
+    uses: ./.github/workflows/lint.yml
+  test:
+    uses: ./.github/workflows/test.yml
+  validate:
+    uses: ./.github/workflows/validate.yml
+
   release:
+    needs: [lint, test, validate]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  # Callable so the release workflow can gate on the exact tagged commit.
+  workflow_call:
   push:
     branches:
       - "main"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,8 @@
 name: Validate
 
 on:
+  # Callable so the release workflow can gate on the exact tagged commit.
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron:  "0 0 * * *"


### PR DESCRIPTION
## The gap

`release.yml` verified the tag matched the manifest version, then published. **Nothing else ran.**

That isn't covered elsewhere, because `lint.yml`, `test.yml` and `validate.yml` all trigger on:

```yaml
on:
  push:
    branches: ["main"]
  pull_request:
    branches: ["main"]
```

A tag push is `refs/tags/...`, not a branch — so pushing a tag triggered **none** of them. And the documented release procedure is *"bump the manifest, commit, tag, push"*, so the tag and its commit typically arrive together. The release could publish to every HACS user **before** main's CI finished, or after it had failed outright. Now that the repo is in the HACS default store, that ships straight to anyone who has it installed.

## Fix

The three check workflows gain a `workflow_call` trigger, and the release job `needs:` all three:

```yaml
jobs:
  lint:     { uses: ./.github/workflows/lint.yml }
  test:     { uses: ./.github/workflows/test.yml }
  validate: { uses: ./.github/workflows/validate.yml }
  release:
    needs: [lint, test, validate]
```

A same-repo `uses: ./.github/workflows/...` runs at the **caller's ref**, so these validate exactly the commit about to be published — not whatever `main` happens to be. No duplication of the check definitions.

Also moves `contents: write` off the workflow and onto the `release` job, so the called workflows keep their own `permissions: {}` rather than running under a token that can write to the repo.

## Verification

`actionlint 1.7.7` — clean on all four workflows (it resolves local `uses:` references, so the reusable-workflow wiring is checked, not just the YAML).

## Trade-off worth knowing

**A flaky check now blocks publishing.** The HACS action talks to a backend and already produced one transient `Not Found` / "not loaded properly in HACS" during this work. A failed release job may just need re-running rather than investigating — that's the cost of the gate, and it seems clearly worth paying against shipping an untested release.

See `CLAUDE-review.md` §4 (tests/CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)