### PR TITLE
Pin the device registry, which no test covered

### DIFF
--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -1,0 +1,200 @@
+# serializer version: 1
+# name: test_device_registry_entries
+  list([
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'bedroom_blind',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'PositionAndAngle',
+      'name': 'Bedroom Blind',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'boiler',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'Socket',
+      'name': 'Boiler',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'button_a',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'RockerSwitch',
+      'name': 'Button A',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'dimmer',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'DimmerLight',
+      'name': 'Dimmer',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'Gateway',
+      'name': 'JUNG HOME Gateway',
+      'sw_version': None,
+      'via_device': None,
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'hall_light',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'OnOff',
+      'name': 'Hall Light',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'hallway_sensor',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'Measurement',
+      'name': 'Hallway Sensor',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'kitchen_shade',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'Position',
+      'name': 'Kitchen Shade',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'living_room',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'Thermostat',
+      'name': 'Living Room',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+    dict({
+      'area_id': None,
+      'entry_type': None,
+      'identifiers': list([
+        tuple(
+          'junghome',
+          'strip',
+        ),
+      ]),
+      'manufacturer': 'Jung',
+      'model': 'ColorLight',
+      'name': 'Strip',
+      'sw_version': 'Unknown Version',
+      'via_device': list([
+        tuple(
+          'junghome',
+          'gateway_1.2.3.4',
+        ),
+      ]),
+    }),
+  ])
+# ---

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from syrupy.assertion import SnapshotAssertion
 
 from custom_components.junghome import (
     STALE_DEVICE_PRUNE_MISSES,
@@ -1701,3 +1702,70 @@ async def test_pruning_a_device_is_logged(
 
     assert "removing device" in caplog.text
     assert "ghost_device" in caplog.text
+
+
+async def test_device_registry_entries(
+    hass: HomeAssistant, init_integration, snapshot: SnapshotAssertion
+) -> None:
+    """Pin the device-registry rows.
+
+    `snapshot_platform` in the per-platform tests is entity-only, so every
+    device-level attribute was unpinned: the slug in `identifiers`, the
+    `via_device` link to the synthetic hub, and manufacturer/model/sw_version/
+    area. A change to `device_slug`, to `device_info`, or to the hub wiring was
+    invisible to the suite unless it happened to alter an entity `unique_id`.
+
+    Registry ids are random per run, so `via_device_id` is resolved back to the
+    parent's identifiers and the rows are sorted by identifier.
+    """
+    dev_reg = dr.async_get(hass)
+    devices = dr.async_entries_for_config_entry(dev_reg, init_integration.entry_id)
+    assert devices, "no devices registered"
+
+    by_id = {device.id: sorted(device.identifiers) for device in devices}
+    rows = sorted(
+        (
+            {
+                "identifiers": sorted(device.identifiers),
+                "name": device.name,
+                "manufacturer": device.manufacturer,
+                "model": device.model,
+                "sw_version": device.sw_version,
+                "area_id": device.area_id,
+                "entry_type": device.entry_type,
+                # Resolved, because the raw id is random per run.
+                "via_device": by_id.get(device.via_device_id),
+            }
+            for device in devices
+        ),
+        key=lambda row: row["identifiers"],
+    )
+    assert rows == snapshot
+
+
+async def test_every_device_links_to_the_gateway_hub(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Each per-function device hangs off the synthetic hub via `via_device`.
+
+    Asserted separately from the snapshot so the *invariant* is stated, not just
+    recorded — a regenerated snapshot could otherwise quietly accept a broken
+    topology.
+    """
+    dev_reg = dr.async_get(hass)
+    hub = dev_reg.async_get_device(
+        identifiers={(DOMAIN, gateway_device_id(init_integration))}
+    )
+    assert hub is not None
+    assert hub.via_device_id is None, "the hub must not be hung off anything"
+
+    others = [
+        device
+        for device in dr.async_entries_for_config_entry(
+            dev_reg, init_integration.entry_id
+        )
+        if device.id != hub.id
+    ]
+    assert others
+    for device in others:
+        assert device.via_device_id == hub.id, f"{device.name} is not linked to the hub"


### PR DESCRIPTION
The last item still genuinely open from the original `CLAUDE.md` backlog.

## The gap

The per-platform snapshot tests use `snapshot_platform`, which is **entity-only**. Every device-level attribute was unpinned:

- the label-derived slug in `identifiers` — the whole stable-identity scheme
- the `via_device` link to the synthetic gateway hub
- `manufacturer` / `model` / `sw_version` / `area_id` / `entry_type`

A change to `device_slug`, to `device_info`, or to the hub wiring was invisible to the suite unless it happened to alter an entity `unique_id` as a side effect.

## What's added

**`test_device_registry_entries`** snapshots every row. Registry ids are random per run, so `via_device_id` is resolved back to the parent's identifiers and rows are sorted by identifier — the snapshot is stable across runs and machines.

**`test_every_device_links_to_the_gateway_hub`** asserts the topology as an *invariant* rather than only recording it. A regenerated snapshot could otherwise quietly accept a broken topology — exactly the failure mode `CLAUDE.md` warns about for `unique_id` changes ("a `unique_id` change in it is a bug, not a snapshot to accept").

## Mutation-checked

Both tests were verified to catch real regressions, not just record current state:

| Mutation | Result |
|---|---|
| drop `via_device` from `device_info` | `AssertionError: Hall Light is not linked to the hub` + snapshot mismatch |
| change the hub's `model` | snapshot mismatch |

Source files were restored afterwards; this PR touches `tests/` only.

## Side benefit

The snapshot now documents the literal `"Unknown Version"` `sw_version` placeholder that `device_info` emits for devices without their own version. It's a known nit rather than something I've changed here — but if it's ever cleaned up, the diff will say so out loud.

352 passed, 35 snapshots. `ruff` clean, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)