### PR TITLE
Scope scene unique_ids per gateway, migrating existing entities

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     datapoint_suffix,
     device_slug,
     duplicate_slugs,
+    entry_scope,
     gateway_device_id,
     gateway_device_info,
 )
@@ -283,6 +284,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
                 entry, data={**entry.data, "stable_ids_migrated": True}
             )
 
+    # One-time re-keying of scene entities onto per-gateway unique_ids. Separate
+    # flag from the stable-id migration above, which existing installs have
+    # already completed and so would never re-run.
+    if not entry.data.get("scene_ids_scoped"):
+        if _migrate_scene_unique_ids(hass, entry):
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, "scene_ids_scoped": True}
+            )
+
     # Register the synthetic gateway (hub) device up front, before the platforms
     # create the per-function devices that link to it via ``via_device``. Creating
     # it here rather than lazily (via the connectivity sensor) guarantees it
@@ -457,6 +467,54 @@ def _migrate_to_stable_ids(
         _LOGGER.info("Jung Home: migrated %s entities to firmware-stable ids", migrated)
     except _MIGRATION_ERRORS:
         _LOGGER.exception("Jung Home: failed to migrate registry to stable ids")
+        return False
+    return not had_error
+
+
+def _migrate_scene_unique_ids(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:
+    """Re-key scene entities from the old unscoped unique_id to the scoped one.
+
+    Scene ids used to be the scene label alone (``movie_night_scene``), which is
+    not unique across config entries — two gateways each holding a "Movie night"
+    scene produced the same unique_id and Home Assistant rejected the second
+    entity. They are now prefixed with ``entry_scope``.
+
+    Re-keying rather than letting the platform create fresh entities is what
+    keeps the user's ``entity_id``, name, area and history: a new unique_id would
+    otherwise register a *new* entity and orphan the old one.
+
+    Returns True on clean completion so the caller records the one-shot flag.
+    """
+    had_error = False
+    # Outer guard mirrors `_migrate_to_stable_ids`: enumerating the registry can
+    # itself fail, and a migration must never take setup down with it.
+    try:
+        prefix = f"{entry_scope(entry)}_"
+        ent_reg = er.async_get(hass)
+        for entity in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+            if entity.domain != Platform.SCENE:
+                continue
+            old_uid = entity.unique_id
+            if old_uid.startswith(prefix):
+                continue  # already scoped
+            new_uid = f"{prefix}{old_uid}"
+            try:
+                existing = ent_reg.async_get_entity_id(entity.domain, DOMAIN, new_uid)
+                if existing and existing != entity.entity_id:
+                    # A scoped entity already exists (e.g. a partially-completed
+                    # earlier pass); drop the stale unscoped one rather than
+                    # collide on the new id.
+                    ent_reg.async_remove(entity.entity_id)
+                else:
+                    ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
+            except _MIGRATION_ERRORS:
+                had_error = True
+                _LOGGER.exception(
+                    "Jung Home: failed to re-key scene entity %s to a scoped id",
+                    entity.entity_id,
+                )
+    except _MIGRATION_ERRORS:
+        _LOGGER.exception("Jung Home: failed to re-key scene unique ids")
         return False
     return not had_error
 

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -118,6 +118,22 @@ def gateway_device_id(entry: "ConfigEntry") -> str:
     return f"gateway_{entry.unique_id or entry.entry_id}"
 
 
+def entry_scope(entry: "ConfigEntry") -> str:
+    """Return a per-gateway prefix for ids that aren't tied to a device.
+
+    Device-backed ids are already unique per gateway, because they carry the
+    device slug. Scenes have no device, so their id was the scene label alone —
+    and Home Assistant requires a unique_id to be unique across *all* config
+    entries of an integration, so two gateways each holding a "Movie night"
+    scene collided and the second entity was rejected.
+
+    Anchored on the entry's ``unique_id`` (the typed host or the mDNS hostname),
+    which survives a reconfigure, and falling back to the entry id. Same anchor
+    as ``gateway_device_id``.
+    """
+    return slugify(entry.unique_id or entry.entry_id)
+
+
 def gateway_device_info(entry: "ConfigEntry", sw_version: str | None) -> DeviceInfo:
     """Return the ``DeviceInfo`` for the synthetic gateway (hub) device.
 

--- a/custom_components/junghome/scene.py
+++ b/custom_components/junghome/scene.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
-from .const import DOMAIN
+from .const import DOMAIN, entry_scope
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,6 +32,18 @@ def _scene_slug(label: str) -> str:
     if slug and slug != "unknown":
         return slug
     return "scene"
+
+
+def scene_unique_id(entry: JungHomeConfigEntry, label: str) -> str:
+    """Return the firmware-stable, per-gateway unique_id for a scene.
+
+    Scoped by ``entry_scope`` because a scene has no backing device to make it
+    unique: the id used to be the scene label alone, so two gateways each with a
+    "Movie night" scene produced the same unique_id and Home Assistant rejected
+    the second entity. ``_migrate_scene_unique_ids`` in ``__init__`` re-keys
+    entities created under the old unscoped scheme.
+    """
+    return f"{entry_scope(entry)}_{_scene_slug(label)}_scene"
 
 
 async def async_setup_entry(
@@ -70,7 +82,7 @@ async def async_setup_entry(
         for scene in coordinator.scenes or []:
             label = scene.get("label")
             if label:
-                uid = f"{_scene_slug(label)}_scene"
+                uid = scene_unique_id(entry, label)
                 # Two scenes whose labels slug identically collide on one uid, so
                 # only one entity can exist (same accepted limitation as devices —
                 # see const.device_slug). Surface the dropped one rather than

--- a/tests/snapshots/test_scene.ambr
+++ b/tests/snapshots/test_scene.ambr
@@ -32,7 +32,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'good_morning_scene',
+    'unique_id': '1_2_3_4_good_morning_scene',
     'unit_of_measurement': None,
   })
 # ---
@@ -82,7 +82,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'movie_night_scene',
+    'unique_id': '1_2_3_4_movie_night_scene',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -247,3 +247,193 @@ async def test_revoked_token_on_recall_starts_reauth(hass: HomeAssistant) -> Non
     ):
         await coordinator.activate_scene("id0001")
     start_reauth.assert_called_once()
+
+
+async def test_scene_migration_preserves_the_entity_id(hass: HomeAssistant) -> None:
+    """Re-keying must keep the user's entity_id, name, area and history.
+
+    Scoping the unique_id without migrating would register a *new* entity and
+    orphan the old one, silently breaking every automation that referenced it.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    # An entity created under the old, unscoped scheme, renamed by the user.
+    old = ent_reg.async_get_or_create(
+        Platform.SCENE,
+        DOMAIN,
+        "movie_night_scene",
+        config_entry=entry,
+        suggested_object_id="my_movie_scene",
+    )
+    ent_reg.async_update_entity(old.entity_id, name="My Movie Scene")
+    assert old.entity_id == "scene.my_movie_scene"
+
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    migrated = ent_reg.async_get("scene.my_movie_scene")
+    assert migrated is not None, "the entity_id changed — history and automations lost"
+    assert migrated.unique_id == "1_2_3_4_movie_night_scene"
+    assert migrated.name == "My Movie Scene"
+    # One-shot: the flag stops it re-running on every setup.
+    assert entry.data.get("scene_ids_scoped") is True
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.real_scenes_fetch
+async def test_two_gateways_can_share_a_scene_name(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """The bug being fixed: a same-named scene on two gateways.
+
+    unique_ids must be unique across *all* config entries of an integration, so
+    the unscoped id made Home Assistant reject the second gateway's entity.
+    """
+    for host in ("1.2.3.4", "5.6.7.8"):
+        aioclient_mock.get(
+            f"https://{host}/api/junghome/scenes/",
+            json=[{"id": "id0001", "label": "Movie night"}],
+        )
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id=host,
+            data={CONF_HOST: host, CONF_TOKEN: "tok"},
+        )
+        entry.add_to_hass(hass)
+        with (
+            patch.object(
+                JungHomeDataUpdateCoordinator,
+                "_fetch_devices_from_api",
+                AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+            ),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    scenes = [e for e in ent_reg.entities.values() if e.domain == Platform.SCENE]
+    assert len(scenes) == 2, f"expected one scene per gateway, got {len(scenes)}"
+    assert {e.unique_id for e in scenes} == {
+        "1_2_3_4_movie_night_scene",
+        "5_6_7_8_movie_night_scene",
+    }
+
+
+async def test_scene_migration_drops_a_stale_duplicate(hass: HomeAssistant) -> None:
+    """A leftover unscoped entity is removed when the scoped one already exists.
+
+    Reachable after a partially-completed earlier pass; re-keying onto an id
+    that is already taken would raise instead.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    # Already migrated...
+    ent_reg.async_get_or_create(
+        Platform.SCENE, DOMAIN, "1_2_3_4_movie_night_scene", config_entry=entry
+    )
+    # ...and the stale unscoped leftover that would collide with it.
+    stale = ent_reg.async_get_or_create(
+        Platform.SCENE, DOMAIN, "movie_night_scene", config_entry=entry
+    )
+
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert ent_reg.async_get(stale.entity_id) is None
+    assert (
+        ent_reg.async_get_entity_id(Platform.SCENE, DOMAIN, "1_2_3_4_movie_night_scene")
+        is not None
+    )
+    assert entry.data.get("scene_ids_scoped") is True
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_scene_migration_isolates_a_per_entity_failure(
+    hass: HomeAssistant,
+) -> None:
+    """One bad scene entity must not abort the pass or fail setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        Platform.SCENE, DOMAIN, "movie_night_scene", config_entry=entry
+    )
+    ent_reg.async_get_or_create(
+        Platform.SCENE, DOMAIN, "good_morning_scene", config_entry=entry
+    )
+
+    original = er.EntityRegistry.async_update_entity
+
+    def boom(self, entity_id, **kwargs):
+        if kwargs.get("new_unique_id") == "1_2_3_4_movie_night_scene":
+            raise ValueError("unique_id already registered")
+        return original(self, entity_id, **kwargs)
+
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+        patch.object(er.EntityRegistry, "async_update_entity", boom),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    # The other scene still migrated...
+    assert (
+        ent_reg.async_get_entity_id(
+            Platform.SCENE, DOMAIN, "1_2_3_4_good_morning_scene"
+        )
+        is not None
+    )
+    # ...and the flag stays unset so the next setup retries the failed one.
+    assert entry.data.get("scene_ids_scoped") is not True
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## The bug

A scene's `unique_id` was its label alone — `movie_night_scene`. Home Assistant requires a `unique_id` to be unique across **all** config entries of an integration, so two gateways each holding a "Movie night" scene produced the same id and the second entity was **rejected**: the scene simply never appeared, with only an error in the log.

Device-backed entities were never affected — their ids carry the device slug, which already differs per gateway. Scenes have no backing device, which is exactly why they had nothing to make them unique.

Ids are now prefixed with `entry_scope`, anchored on the entry's `unique_id` (the typed host or mDNS hostname, which survives a reconfigure) and falling back to the entry id — the same anchor `gateway_device_id` uses.

## The migration is the important half

**Changing an id without migrating would have been worse than the bug.** The platform would register a *new* entity and orphan the old one, losing the user's `entity_id`, name, area and history, and breaking every automation referencing it.

`_migrate_scene_unique_ids` re-keys existing entities **in place**, behind its own one-shot `scene_ids_scoped` flag — deliberately separate from `stable_ids_migrated`, which existing installs have already completed and which would therefore never re-run. It runs beside the existing migration, before the platforms are forwarded and before the update listener is registered, so the flag write can't trigger a mid-setup reload.

## An existing test caught a real defect

`test_migration_not_marked_done_on_failure` failed against my first draft: the registry enumeration sat *outside* the guard, so a failure there took setup down (`SETUP_ERROR`) instead of being absorbed. It now mirrors `_migrate_to_stable_ids` with an outer `except` as well as the per-item one. Good argument for the tests fixed back in #155.

## Snapshot diff

Exactly the two `unique_id`s and nothing else:

```diff
-    'unique_id': 'good_morning_scene',
+    'unique_id': '1_2_3_4_good_morning_scene',
-    'unique_id': 'movie_night_scene',
+    'unique_id': '1_2_3_4_movie_night_scene',
```

`entity_id`, name and attributes are untouched — that's the property that matters, and `CLAUDE.md` is right that a `unique_id` change in a snapshot normally means a bug. Here it's the change being made, and the migration is what makes it safe.

## Tests

Both headline tests fail on the previous code, the second demonstrating the bug directly:

```
E  AssertionError: assert 'movie_night_scene' == '1_2_3_4_movie_night_scene'
E  AssertionError: expected one scene per gateway, got 1
```

- `test_scene_migration_preserves_the_entity_id` — a user-renamed entity keeps `scene.my_movie_scene` **and** its name across the re-key
- `test_two_gateways_can_share_a_scene_name` — one scene entity per gateway
- plus the migration's collision and per-item-failure branches, so `__init__.py` stays at 98% rather than dropping to 96%

354 passed, total 97.90%. `mypy --strict` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)