### PR TITLE
Release 1.5.0b3

### DIFF
--- a/custom_components/junghome/manifest.json
+++ b/custom_components/junghome/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ernetas/junghome/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.0b2",
+  "version": "1.5.0b3",
   "zeroconf": ["_junghome._tcp.local."]
 }


### PR DESCRIPTION
Third beta of 1.5.0, and the first with substantive fixes since b1 — twenty commits, most of them correctness rather than features. Manifest bump only; `release.yml` publishes on the `v1.5.0b3` tag and marks it a pre-release, so HACS won't auto-update anyone who hasn't opted into betas.

## The big one

**WebSocket pushes were deferring the REST poll.** Every push went through `async_set_updated_data`, which re-arms the refresh timer — so a gateway pushing more than once a minute never polled again. The poll is the only thing that discovers new devices, prunes removed ones, assigns areas and detects gateway id churn, so all four silently stopped. One presence detector is enough to trigger it.

## Also fixed, roughly by user impact

- Two devices sharing a label put the entry into an **endless reload loop**
- The shipped blueprint **ran the user's action** every time a button recovered from `unavailable`
- **Scenes never appeared at all** if the WebSocket couldn't connect
- A lamp read **0 % forever** if the gateway formatted brightness with a decimal
- An unrelated device's push **reverted a just-commanded switch**, so it visibly flipped back and on again
- Quantity datapoints with no unit produced **no entity and no log line**
- `send_str` had **no timeout**, so a stalled gateway hung the service call indefinitely
- A gateway that flapped, or closed cleanly, **never escalated to the repair issue** — and the issue was orphaned on unload
- Device-trigger strings existed **only in English** (150 missing entries across 25 locales)
- Diagnostics **leaked the gateway host** through `last_error` and raw WebSocket frames
- Reconfiguring an entry stuck in `SETUP_RETRY` **did nothing for up to 10 minutes**
- A revoked token on scene recall was reported as a transient "try again" failure

## Behaviour changes — worth reading before upgrading

- **New entities may appear.** Unit-less quantity datapoints now create sensors that previously didn't exist. The data was always being reported; it was just discarded.
- **Scene `unique_id`s are re-keyed** per gateway. A migration does this in place, so `entity_id`s, names and history are preserved and automations keep working. This fixes two gateways with a same-named scene, where the second scene simply never appeared.
- **Automatic device removal is more conservative**: ten missed polls instead of three, a warning naming the device, and you can now delete a stale device yourself from its device page.
- **The "live updates have stopped" repair issue** now clears about 30 s after the socket returns rather than the instant it connects — "connected" isn't the same as "recovered", and clearing on connect made a flapping gateway invisible.

## Release safety

Releases now run lint, tests and hassfest/HACS validation **against the tagged commit** before publishing. Previously a tag triggered none of them, because the other workflows only fire on branch pushes and pull requests.

## Verification

`358 passed`, coverage ~98 % (gate 95), `mypy --strict` and `ruff` clean.

---

**To publish after merging:**

```sh
git checkout main && git pull
git tag v1.5.0b3 && git push origin v1.5.0b3
```

The workflow verifies the tag matches the manifest, runs the full gate, then creates the pre-release.

> #172 (device-registry snapshots, tests-only) is still open — worth merging first if you want it in this beta, but it changes no shipped code either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)