### PR TITLE
Re-apply pushes that race an in-flight poll over its stale snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,9 @@ instead of re-deriving:
   poll-starvation P0). It sets `last_update_success` + `async_update_listeners`
   instead. The `functions`-broadcast path *does* use `async_set_updated_data`,
   correctly: it carries poll-equivalent data and only arrives on change.
+  Pushes that land while a poll is in flight are recorded and re-applied over
+  the poll's snapshot (`_poll_push_overlay`) — the snapshot predates them, so
+  adopting it as-is briefly reverted pushed/command-confirmed values.
 - **Availability**: entities key off `last_update_success` and never OR in
   `ws_connected` (a stale-True socket flag froze energy readings — issue
   #120); controllable entities additionally require the live WS because
@@ -228,20 +231,11 @@ them without new evidence wastes a session.
   to the target.
 - **Narrow the three broad excepts** in `coordinator.py` (#133): reconnect
   loop, frame-handler catch-all, WS send path.
-- **A REST poll in flight when a push lands can briefly revert the pushed
-  value** (poll snapshot predates the push). Small window, self-heals on the
-  next push/poll.
+- **A `functions` broadcast racing an in-flight poll can be overwritten by
+  the poll's older device list** (the per-datapoint overlay covers values,
+  not membership). Rare — the broadcast only fires on membership change —
+  and the next poll heals it.
 - **Reusable JSON device/API fixtures** (`tests/fixtures/`); tests build
   device dicts inline.
 - **Richer `zeroconf_confirm`** — show serial/model in the confirm dialog for
   multi-gateway networks.
-
-## History
-
-Two full audits (an 11-agent platinum review and a 2026-08-02 line-by-line
-review with disk-dump verification of every firmware claim — all of which
-held) produced the settled-decisions and backlog lists above. The audit
-documents themselves (`CLAUDE-review.md`, `CLAUDE-fable.md`) were local-only
-working files and have been deleted; everything durable from them lives in
-this file, in code comments at the relevant sites, and in the regression
-tests named after the bugs they pinned.

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -214,6 +214,19 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # COMMAND_REPLY_TIMEOUT), so this never accumulates stale entries.
         self._pending_replies: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self._next_message_id = 0
+        # While a REST poll is in flight, every pushed datapoint's merged keys
+        # are recorded here (datapoint id -> merged keys) and re-applied over
+        # the poll's snapshot before it is adopted — the snapshot was generated
+        # before the push, so adopting it as-is briefly reverted the pushed
+        # (or command-confirmed) value until the next push or poll healed it.
+        # None outside a poll, so the steady state records nothing. Polls CAN
+        # overlap (DataUpdateCoordinator holds no lock: the 60 s schedule, the
+        # unmatched-push request_refresh and the connect-time resync are
+        # independent), so the dict is shared and refcounted via
+        # `_polls_in_flight` — replacing it per-poll would clobber pushes
+        # recorded for a poll still in flight.
+        self._poll_push_overlay: dict[str, dict[str, Any]] | None = None
+        self._polls_in_flight = 0
         # Bounded log of recent raw WebSocket frames for diagnostics.
         self.ws_frame_log: deque[str] = deque(maxlen=WS_FRAME_LOG_SIZE)
         # Latest raw frame of each type, so the connect-time handshake
@@ -255,6 +268,13 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     async def _async_update_data(self) -> list[Device]:
         """Fetch data from the API."""
         _LOGGER.debug("Fetching new device data from Jung Home API")
+        # Open the push overlay for the duration of the fetch: the response's
+        # snapshot is generated before any push that races it, so those pushes
+        # must win over the snapshot (see _apply_push_overlay). Joined, not
+        # replaced, when another poll already opened it.
+        if self._poll_push_overlay is None:
+            self._poll_push_overlay = {}
+        self._polls_in_flight += 1
         try:
             response = await self._fetch_devices_from_api(
                 self.config["host"], self.config["token"]
@@ -285,11 +305,48 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 translation_key="cannot_connect",
                 translation_placeholders={"error": str(err)},
             ) from err
+        finally:
+            # Leave the overlay open while a concurrent poll is still fetching
+            # (this poll takes a snapshot copy — applied synchronously below,
+            # so the still-recording dict cannot mutate it mid-walk); the last
+            # poll out closes it. On the failure paths above the collected
+            # overlay is simply discarded: there is no snapshot to correct,
+            # and a failed poll leaves `self.data` (with the pushes already
+            # merged in) untouched.
+            self._polls_in_flight -= 1
+            if self._polls_in_flight == 0:
+                overlay = self._poll_push_overlay
+                self._poll_push_overlay = None
+            else:
+                overlay = dict(self._poll_push_overlay or {})
 
         _LOGGER.debug("API Response: %s", response)
+        if overlay:
+            self._apply_push_overlay(response, overlay)
         self._reload_if_device_ids_changed(response)
         # `async_set_updated_data` is automatically called with this.
         return response
+
+    @staticmethod
+    def _apply_push_overlay(
+        devices: list[Device], overlay: dict[str, dict[str, Any]]
+    ) -> None:
+        """Re-apply pushes that raced an in-flight poll over its snapshot.
+
+        A push reflects a state change the poll's snapshot may predate, and
+        every gateway-side change emits a push — so for the datapoints it
+        covers, the overlay always holds a value at least as fresh as the
+        snapshot's. Without this, adopting the snapshot briefly reverted a
+        value pushed (or confirmed back to a command) during the fetch, until
+        the next push or poll set it right again. The key-by-key update
+        mirrors the live merge in ``_handle_websocket_message`` exactly.
+        """
+        for device in devices:
+            for datapoint in device.get("datapoints", []):
+                dp_id = datapoint.get("id")
+                if not dp_id or dp_id not in overlay:
+                    continue
+                cast("dict[str, Any]", datapoint).update(overlay[dp_id])
 
     def _reload_if_device_ids_changed(self, devices: list[Device]) -> None:
         """Reload the entry if the gateway regenerated its device ids.
@@ -868,6 +925,16 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                     "Received WebSocket message without datapoint_id: %s", message
                 )
                 return
+            if self._poll_push_overlay is not None:
+                # A REST poll is in flight; record this push so the poll's
+                # (older) snapshot cannot revert it. Recorded before the match
+                # loop below on purpose: an unmatched push usually belongs to a
+                # device the in-flight poll is about to discover, and its
+                # snapshot values may predate this push just the same.
+                overlay = self._poll_push_overlay.setdefault(datapoint_id, {})
+                for key, value in data.items():
+                    if key != "id":
+                        overlay[key] = value
             updated = False
             for device in self.data or []:
                 for datapoint in device.get("datapoints", []):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -60,6 +60,124 @@ async def test_update_raises_update_failed_on_client_error(hass: HomeAssistant) 
         await coordinator._async_update_data()
 
 
+def _switch_device(value: str) -> dict:
+    """One device with a single switch datapoint at the given value."""
+    return {
+        "id": "dev1",
+        "label": "Lamp",
+        "datapoints": [
+            {
+                "id": "dp-1",
+                "type": "switch",
+                "values": [{"key": "switch", "value": value}],
+            },
+            # A malformed id-less datapoint: the overlay application must skip
+            # it rather than raise.
+            {"type": "switch", "values": []},
+        ],
+    }
+
+
+async def test_push_during_poll_wins_over_the_stale_snapshot(
+    hass: HomeAssistant,
+) -> None:
+    """A push landing mid-poll must not be reverted by the poll's snapshot.
+
+    The REST snapshot is generated before a push that races the response, so
+    adopting it as-is briefly rolled the pushed value back until the next
+    push or poll healed it (the switch visibly flicked off and on again).
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = [_switch_device("0")]
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def _slow_fetch(host: str, token: str) -> list[dict]:
+        fetch_started.set()
+        await release_fetch.wait()
+        return [_switch_device("0")]  # snapshot predating the push
+
+    with patch.object(coordinator, "_fetch_devices_from_api", _slow_fetch):
+        poll = asyncio.ensure_future(coordinator._async_update_data())
+        await fetch_started.wait()
+        # The light is switched on while the poll is in flight.
+        coordinator._handle_websocket_message(
+            {
+                "type": "datapoint",
+                "data": {"id": "dp-1", "values": [{"key": "switch", "value": "1"}]},
+            }
+        )
+        release_fetch.set()
+        result = await poll
+
+    assert result[0]["datapoints"][0]["values"] == [{"key": "switch", "value": "1"}]
+    # The overlay is closed once the poll completes; later pushes with no poll
+    # in flight are not recorded anywhere.
+    assert coordinator._poll_push_overlay is None
+
+
+async def test_push_for_a_device_the_poll_discovers_survives_it(
+    hass: HomeAssistant,
+) -> None:
+    """An unmatched push (brand-new device) still wins over the discovering poll.
+
+    The push arrives before the poll has ever seen the device, so there is no
+    stored datapoint to merge into — but the poll's snapshot of that new
+    device may predate the push just the same.
+
+    This doubles as the overlapping-polls regression: the unmatched push
+    immediately triggers a second refresh (request_refresh, immediate
+    debounce) while the first poll is still fetching. The overlay is shared
+    and refcounted across both; a naive per-poll dict was clobbered by the
+    second poll opening it, losing the recorded push.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = []  # the device is not known yet
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def _slow_fetch(host: str, token: str) -> list[dict]:
+        fetch_started.set()
+        await release_fetch.wait()
+        return [_switch_device("0")]
+
+    with patch.object(coordinator, "_fetch_devices_from_api", _slow_fetch):
+        poll = asyncio.ensure_future(coordinator._async_update_data())
+        await fetch_started.wait()
+        coordinator._handle_websocket_message(
+            {
+                "type": "datapoint",
+                "data": {"id": "dp-1", "values": [{"key": "switch", "value": "1"}]},
+            }
+        )
+        release_fetch.set()
+        result = await poll
+
+    assert result[0]["datapoints"][0]["values"] == [{"key": "switch", "value": "1"}]
+    # Let the push-triggered second refresh finish, then drain the debouncer
+    # so its timer doesn't linger into teardown. The second refresh is the
+    # last poll out, so it closes the shared overlay.
+    await hass.async_block_till_done()
+    assert coordinator._poll_push_overlay is None
+    assert coordinator._polls_in_flight == 0
+    await coordinator.async_shutdown()
+
+
+async def test_poll_failure_discards_the_push_overlay(hass: HomeAssistant) -> None:
+    """A failed poll closes the overlay: nothing to re-apply, nothing leaks."""
+    coordinator = _coordinator(hass)
+    with (
+        patch.object(
+            coordinator,
+            "_fetch_devices_from_api",
+            side_effect=aiohttp.ClientError("boom"),
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+    assert coordinator._poll_push_overlay is None
+
+
 async def test_reload_scheduled_when_device_ids_change(hass: HomeAssistant) -> None:
     coordinator = _coordinator(hass)
     coordinator._device_ids = {"katilas": "idOLD"}


### PR DESCRIPTION
## Summary

Fixes the poll-vs-push revert race from CLAUDE.md's backlog.

- A REST poll's snapshot is generated before any push that races the response, so adopting it as-is briefly reverted the pushed (or command-confirmed, since #178) value until the next push or poll healed it — visible as a switch flicking back and forth after a command.
- While a poll is fetching, every pushed datapoint's merged keys are recorded in `_poll_push_overlay` and re-applied over the snapshot before it is adopted. Last-push-wins is safe because every gateway-side change emits a push, so the overlay always holds a value at least as fresh as the snapshot's. The key-by-key application mirrors the live push merge exactly.
- Unmatched pushes are recorded too: a brand-new device's push races the very poll that discovers it.
- Polls can overlap — `DataUpdateCoordinator` holds no lock, and the unmatched-push `request_refresh` (immediate debounce) races the 60 s schedule and the connect-time resync — so the overlay is shared and refcounted via `_polls_in_flight`, not per-poll. A naive per-poll dict was clobbered by the second poll opening it; the new-device test caught exactly that and now pins it.
- Residual (rare, self-healing) race recorded in the backlog: a `functions` broadcast racing a poll can still be overwritten by the poll's older *device list* — the overlay covers values, not membership.
- Also removes the History section from CLAUDE.md (requested).

## Test plan

- [x] `pytest tests/` — 403 passed (3 new), 35 snapshots
- [x] `mypy --strict` clean, `ruff check` + `ruff format --check` clean
- [x] Coverage 98.62% branch (gate 95%)
- [x] New tests: push mid-poll wins over the stale snapshot; unmatched push survives the discovering poll under genuine poll overlap; failed poll discards the overlay without leaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhL1ZASQbSzB1mGbBDxhd5