### PR TITLE
Move the shared gateway payload to tests/fixtures and dedupe test helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,10 @@ instead of re-deriving:
   translations/device-trigger files; new platform behaviour goes in that
   platform's file. Uses `pytest_homeassistant_custom_component` (`hass`
   fixture, `MockConfigEntry`, `aioclient_mock`); Python 3.14, pinned HA.
+  The shared gateway payload is `tests/fixtures/functions.json` (wire-shaped,
+  loaded by conftest as `DEVICES`; `bare_coordinator` is the shared bare
+  setup). One-off device dicts stay inline in the test that uses them —
+  visible inputs beat indirection for single-use data.
 - **Snapshot tests** pin every entity's registry entry (`unique_id` included),
   state and attributes (`tests/snapshots/*.ambr`). Regenerate with
   `pytest --snapshot-update` and **review the diff** — a `unique_id` change is
@@ -221,6 +225,14 @@ them without new evidence wastes a session.
 - **The group `color_temperature_range` parser stays unwired** — no captured
   firmware sends the field (`disk_dump/ws-capture*/groups.json`); the gateway
   clamps CT to 2000–6000 K anyway.
+- **The three broad excepts in `coordinator.py` stay broad** (reconnect loop,
+  frame-handler catch-all, WS send path) — wontfix. Each is load-bearing
+  containment: the reconnect loop must retry through *any* failure class, a
+  malformed frame must never tear down a healthy session, and every send
+  failure must surface as `cannot_send` to the calling service. The
+  narrowing that mattered was already done in PR #133 (best-effort
+  fetch/parse handlers); narrowing these three trades crash-risk for no
+  diagnostic gain.
 
 ## Backlog (open, in rough value order)
 
@@ -229,11 +241,7 @@ them without new evidence wastes a session.
   to learn whether intermediate levels stream; if they do, report
   `is_opening`/`is_closing` and let pushes drive position instead of jumping
   to the target.
-- **Narrow the three broad excepts** in `coordinator.py` (#133): reconnect
-  loop, frame-handler catch-all, WS send path.
 - **A `functions` broadcast racing an in-flight poll can be overwritten by
   the poll's older device list** (the per-datapoint overlay covers values,
   not membership). Rare — the broadcast only fires on membership change —
   and the next poll heals it.
-- **Reusable JSON device/API fixtures** (`tests/fixtures/`); tests build
-  device dicts inline.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from copy import deepcopy
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -18,186 +20,21 @@ from syrupy.assertion import SnapshotAssertion
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 
-DEVICES = [
-    {
-        "id": "idlight1",
-        "type": "OnOff",
-        "label": "Hall Light",
-        "datapoints": [
-            {
-                "id": "idlight1-001",
-                "type": "switch",
-                "values": [{"key": "switch", "value": "0"}],
-            }
-        ],
-    },
-    {
-        "id": "idcolor1",
-        "type": "ColorLight",
-        "label": "Strip",
-        "datapoints": [
-            {
-                "id": "idcolor1-001",
-                "type": "switch",
-                "values": [{"key": "switch", "value": "1"}],
-            },
-            {
-                "id": "idcolor1-002",
-                "type": "brightness",
-                "values": [{"key": "brightness", "value": "50"}],
-            },
-            {
-                "id": "idcolor1-004",
-                "type": "color_temperature",
-                "values": [{"key": "color_temperature", "value": "2700"}],
-            },
-        ],
-    },
-    {
-        "id": "iddim1",
-        "type": "DimmerLight",
-        "label": "Dimmer",
-        "datapoints": [
-            {
-                "id": "iddim1-001",
-                "type": "switch",
-                "values": [{"key": "switch", "value": "0"}],
-            },
-            {
-                "id": "iddim1-002",
-                "type": "brightness",
-                "values": [{"key": "brightness", "value": "30"}],
-            },
-        ],
-    },
-    {
-        "id": "idblind1",
-        "type": "PositionAndAngle",
-        "label": "Bedroom Blind",
-        "datapoints": [
-            {
-                "id": "idblind1-001",
-                "type": "level",
-                # device level 30% closed -> HA position 70 (open)
-                "values": [{"key": "level", "value": "30"}],
-            },
-            {
-                "id": "idblind1-002",
-                "type": "angle",
-                "values": [{"key": "angle", "value": "40"}],
-            },
-        ],
-    },
-    {
-        "id": "idblind2",
-        "type": "Position",
-        "label": "Kitchen Shade",
-        "datapoints": [
-            {
-                "id": "idblind2-001",
-                "type": "level",
-                "values": [{"key": "level", "value": "0"}],
-            },
-        ],
-    },
-    {
-        "id": "idrtr1",
-        "type": "Thermostat",
-        "label": "Living Room",
-        "datapoints": [
-            {
-                "id": "idrtr1-000",
-                "type": "switch",
-                "values": [{"key": "switch", "value": "1"}],
-            },
-            {
-                "id": "idrtr1-001",
-                "type": "temperature_ctrl",
-                "values": [
-                    {"key": "temperature_ctrl", "value": "21.5"},
-                    {"key": "temperature_ctrl_preset", "value": "comfort"},
-                ],
-            },
-            {
-                "id": "idrtr1-010",
-                "type": "quantity",
-                "values": [
-                    {"key": "quantity", "value": "20.0"},
-                    {"key": "quantity_label", "value": "Temperature "},
-                    {"key": "quantity_unit", "value": "°C"},
-                ],
-            },
-        ],
-    },
-    {
-        "id": "idsock1",
-        "type": "Socket",
-        "label": "Boiler",
-        "datapoints": [
-            {
-                "id": "idsock1-001",
-                "type": "switch",
-                "values": [{"key": "switch", "value": "1"}],
-            },
-            {
-                "id": "idsock1-010",
-                "type": "quantity",
-                "values": [
-                    {"key": "quantity", "value": "5"},
-                    {"key": "quantity_label", "value": "Power "},
-                    {"key": "quantity_unit", "value": "W"},
-                ],
-            },
-            {
-                "id": "idsock1-099",
-                "type": "quantity",
-                "values": [
-                    {"key": "quantity", "value": "42"},
-                    {"key": "quantity_label", "value": "Status "},
-                    {"key": "quantity_unit", "value": "?"},
-                ],
-            },
-        ],
-    },
-    {
-        "id": "idmeas1",
-        "type": "Measurement",
-        "label": "Hallway Sensor",
-        "datapoints": [
-            {
-                "id": "idmeas1-010",
-                "type": "quantity",
-                "values": [
-                    {"key": "quantity", "value": "120"},
-                    {"key": "quantity_label", "value": "Illuminance "},
-                    {"key": "quantity_unit", "value": "lux"},
-                ],
-            },
-        ],
-    },
-    {
-        "id": "idrock1",
-        "type": "RockerSwitch",
-        "label": "Button A",
-        "datapoints": [
-            {
-                "id": "idrock1-00c",
-                "type": "up_request",
-                "values": [{"key": "up_request", "value": "0"}],
-            },
-            {
-                "id": "idrock1-00d",
-                "type": "down_request",
-                "values": [{"key": "down_request", "value": "0"}],
-            },
-            {
-                "id": "idrock1-00e",
-                "type": "status_led",
-                "values": [{"key": "status_led", "value": "0"}],
-            },
-        ],
-    },
-]
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_json_fixture(name: str) -> Any:
+    """Load a JSON document from ``tests/fixtures/``."""
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+# The shared gateway payload, shaped exactly like ``GET /functions/`` returns
+# it (and like the WS ``functions`` broadcast carries it). Kept as a JSON
+# document so it reads as what it is — wire data, not Python — and can be
+# diffed against real captures. Notable values: the Bedroom Blind's level is
+# 30 (percent-closed, so HA position 70) and the Boiler's third quantity
+# carries the unmapped unit "?" that pins the unmapped-unit warning.
+DEVICES: list[dict] = load_json_fixture("functions.json")
 
 
 # A deep copy of ``DEVICES`` taken at import time, before any test has run.
@@ -210,6 +47,24 @@ DEVICES = [
 # otherwise pass or fail depending on execution order. Snapshot setups start
 # from this pristine copy instead.
 PRISTINE_DEVICES: list[dict] = deepcopy(DEVICES)
+
+
+def bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
+    """Build a coordinator with an entry but no gateway data or WebSocket.
+
+    The unit-level entity tests construct entities directly against this and
+    hand-pick their device dicts; it replaces the identical private copy every
+    platform test file used to carry. ``data`` starts as an empty list (not
+    None) so lookups against ``coordinator.data`` see "gateway answered,
+    device absent" rather than "never refreshed".
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
+    entry.add_to_hass(hass)
+    coordinator = JungHomeDataUpdateCoordinator(
+        hass, {"host": "h", "token": "t"}, entry
+    )
+    coordinator.data = []
+    return coordinator
 
 
 def _auto_reply_to_datapoint_commands(

--- a/tests/fixtures/functions.json
+++ b/tests/fixtures/functions.json
@@ -1,0 +1,291 @@
+[
+  {
+    "id": "idlight1",
+    "type": "OnOff",
+    "label": "Hall Light",
+    "datapoints": [
+      {
+        "id": "idlight1-001",
+        "type": "switch",
+        "values": [
+          {
+            "key": "switch",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idcolor1",
+    "type": "ColorLight",
+    "label": "Strip",
+    "datapoints": [
+      {
+        "id": "idcolor1-001",
+        "type": "switch",
+        "values": [
+          {
+            "key": "switch",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "id": "idcolor1-002",
+        "type": "brightness",
+        "values": [
+          {
+            "key": "brightness",
+            "value": "50"
+          }
+        ]
+      },
+      {
+        "id": "idcolor1-004",
+        "type": "color_temperature",
+        "values": [
+          {
+            "key": "color_temperature",
+            "value": "2700"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "iddim1",
+    "type": "DimmerLight",
+    "label": "Dimmer",
+    "datapoints": [
+      {
+        "id": "iddim1-001",
+        "type": "switch",
+        "values": [
+          {
+            "key": "switch",
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "id": "iddim1-002",
+        "type": "brightness",
+        "values": [
+          {
+            "key": "brightness",
+            "value": "30"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idblind1",
+    "type": "PositionAndAngle",
+    "label": "Bedroom Blind",
+    "datapoints": [
+      {
+        "id": "idblind1-001",
+        "type": "level",
+        "values": [
+          {
+            "key": "level",
+            "value": "30"
+          }
+        ]
+      },
+      {
+        "id": "idblind1-002",
+        "type": "angle",
+        "values": [
+          {
+            "key": "angle",
+            "value": "40"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idblind2",
+    "type": "Position",
+    "label": "Kitchen Shade",
+    "datapoints": [
+      {
+        "id": "idblind2-001",
+        "type": "level",
+        "values": [
+          {
+            "key": "level",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idrtr1",
+    "type": "Thermostat",
+    "label": "Living Room",
+    "datapoints": [
+      {
+        "id": "idrtr1-000",
+        "type": "switch",
+        "values": [
+          {
+            "key": "switch",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "id": "idrtr1-001",
+        "type": "temperature_ctrl",
+        "values": [
+          {
+            "key": "temperature_ctrl",
+            "value": "21.5"
+          },
+          {
+            "key": "temperature_ctrl_preset",
+            "value": "comfort"
+          }
+        ]
+      },
+      {
+        "id": "idrtr1-010",
+        "type": "quantity",
+        "values": [
+          {
+            "key": "quantity",
+            "value": "20.0"
+          },
+          {
+            "key": "quantity_label",
+            "value": "Temperature "
+          },
+          {
+            "key": "quantity_unit",
+            "value": "°C"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idsock1",
+    "type": "Socket",
+    "label": "Boiler",
+    "datapoints": [
+      {
+        "id": "idsock1-001",
+        "type": "switch",
+        "values": [
+          {
+            "key": "switch",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "id": "idsock1-010",
+        "type": "quantity",
+        "values": [
+          {
+            "key": "quantity",
+            "value": "5"
+          },
+          {
+            "key": "quantity_label",
+            "value": "Power "
+          },
+          {
+            "key": "quantity_unit",
+            "value": "W"
+          }
+        ]
+      },
+      {
+        "id": "idsock1-099",
+        "type": "quantity",
+        "values": [
+          {
+            "key": "quantity",
+            "value": "42"
+          },
+          {
+            "key": "quantity_label",
+            "value": "Status "
+          },
+          {
+            "key": "quantity_unit",
+            "value": "?"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idmeas1",
+    "type": "Measurement",
+    "label": "Hallway Sensor",
+    "datapoints": [
+      {
+        "id": "idmeas1-010",
+        "type": "quantity",
+        "values": [
+          {
+            "key": "quantity",
+            "value": "120"
+          },
+          {
+            "key": "quantity_label",
+            "value": "Illuminance "
+          },
+          {
+            "key": "quantity_unit",
+            "value": "lux"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "idrock1",
+    "type": "RockerSwitch",
+    "label": "Button A",
+    "datapoints": [
+      {
+        "id": "idrock1-00c",
+        "type": "up_request",
+        "values": [
+          {
+            "key": "up_request",
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "id": "idrock1-00d",
+        "type": "down_request",
+        "values": [
+          {
+            "key": "down_request",
+            "value": "0"
+          }
+        ]
+      },
+      {
+        "id": "idrock1-00e",
+        "type": "status_led",
+        "values": [
+          {
+            "key": "status_led",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,7 +15,7 @@ from syrupy.assertion import SnapshotAssertion
 from custom_components.junghome.binary_sensor import JungHomePresence
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
-from tests.conftest import PRISTINE_DEVICES, _fake_run_websocket
+from tests.conftest import PRISTINE_DEVICES, _fake_run_websocket, bare_coordinator
 
 # A presence detector to hang off the shared device list for the snapshot
 # test. Presence is reported as a quantity datapoint with an *empty* unit (the
@@ -37,16 +37,6 @@ PRESENCE_DEVICE = {
         },
     ],
 }
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
 
 
 def _presence_device(value: str) -> dict:
@@ -71,7 +61,7 @@ def _presence_device(value: str) -> dict:
 
 async def test_presence_binary_sensor_states(hass: HomeAssistant) -> None:
     """Presence maps 1->on, 0->off, and NaN/missing to unknown (None)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = _presence_device("1")
     dp = device["datapoints"][0]
     sensor = JungHomePresence(coordinator, device, dp, "Presence Detected")
@@ -90,7 +80,7 @@ async def test_presence_binary_sensor_states(hass: HomeAssistant) -> None:
 
 async def test_presence_binary_sensor_updates_on_push(hass: HomeAssistant) -> None:
     """A coordinator update re-reads the presence state from stored data."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = _presence_device("0")
     dp = device["datapoints"][0]
     coordinator.data = [device]
@@ -147,7 +137,7 @@ async def test_presence_binary_sensor_keeps_state_when_datapoint_gone(
     entity's availability tracks the gateway on every update (matching the
     switch platform).
     """
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = _presence_device("1")
     dp = device["datapoints"][0]
     sensor = JungHomePresence(coordinator, device, dp, "Presence Detected")

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -4,29 +4,18 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.components.climate.const import HVACAction, HVACMode
-from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
     snapshot_platform,
 )
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.junghome.climate import JungHomeClimate
-from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import bare_coordinator
 
 
 def _climate(
@@ -178,7 +167,7 @@ async def test_climate_commands(hass: HomeAssistant, init_integration) -> None:
 
 async def test_climate_hvac_action_from_switch_value(hass: HomeAssistant) -> None:
     """Switch 1/0 maps to HEATING/IDLE; anything else leaves the action unknown."""
-    coord = _bare_coordinator(hass)
+    coord = bare_coordinator(hass)
     heating = _climate(coord, switch="1")
     assert heating.hvac_action == HVACAction.HEATING
     assert heating.hvac_mode == HVACMode.HEAT
@@ -196,7 +185,7 @@ async def test_climate_hvac_action_from_switch_value(hass: HomeAssistant) -> Non
 
 async def test_climate_extractors_defensive(hass: HomeAssistant) -> None:
     """Climate target/preset extractors tolerate missing/garbage datapoints."""
-    climate = _climate(_bare_coordinator(hass))
+    climate = _climate(bare_coordinator(hass))
     assert climate._get_target_from_datapoint(None) is None
     assert (
         climate._get_target_from_datapoint(
@@ -236,7 +225,7 @@ async def test_climate_extractors_defensive(hass: HomeAssistant) -> None:
 
 async def test_climate_current_temperature_paths(hass: HomeAssistant) -> None:
     """current_temperature ignores non-°C siblings and unparseable values."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     # A "%" sibling is not a temperature -> None.
     assert _climate(coordinator, current_unit="%").current_temperature is None
     # No sibling quantity at all -> None.
@@ -262,7 +251,7 @@ async def test_climate_current_temperature_paths(hass: HomeAssistant) -> None:
 
 
 async def test_climate_set_temperature_without_value_noops(hass: HomeAssistant) -> None:
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     climate = _climate(coordinator)
     with patch.object(coordinator, "set_temperature", AsyncMock()) as st:
         await climate.async_set_temperature()
@@ -270,7 +259,7 @@ async def test_climate_set_temperature_without_value_noops(hass: HomeAssistant) 
 
 
 async def test_climate_unknown_preset_noops(hass: HomeAssistant) -> None:
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     climate = _climate(coordinator)
     with patch.object(coordinator, "set_temperature_preset", AsyncMock()) as sp:
         await climate.async_set_preset_mode("nonsense")
@@ -281,7 +270,7 @@ async def test_set_hvac_mode_never_writes_the_switch_datapoint(
     hass: HomeAssistant,
 ) -> None:
     """set_hvac_mode is inert: the regulator has no on/off to command."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     climate = _climate(coordinator, switch="1")
     with patch.object(coordinator, "send_websocket_message", AsyncMock()) as send:
         await climate.async_set_hvac_mode(HVACMode.HEAT)  # must not raise
@@ -291,7 +280,7 @@ async def test_set_hvac_mode_never_writes_the_switch_datapoint(
 
 async def test_climate_poll_refreshes_hvac_action(hass: HomeAssistant) -> None:
     """A REST poll (no pushed datapoint) re-reads the action from the device data."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     climate = _climate(coordinator, switch="1")
     coordinator.data = [climate._device]
     assert climate.hvac_action == HVACAction.HEATING
@@ -305,7 +294,7 @@ async def test_climate_poll_refreshes_hvac_action(hass: HomeAssistant) -> None:
 
 
 async def test_climate_handle_update_missing_device_noops(hass: HomeAssistant) -> None:
-    climate = _climate(_bare_coordinator(hass))  # coordinator.data is []
+    climate = _climate(bare_coordinator(hass))  # coordinator.data is []
     with patch.object(climate, "async_write_ha_state") as write_state:
         climate._handle_coordinator_update()
     write_state.assert_called_once()
@@ -315,7 +304,7 @@ async def test_climate_current_temp_skips_valueless_quantity(
     hass: HomeAssistant,
 ) -> None:
     """A °C quantity datapoint with no value is skipped (current_temperature None)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {
         "id": "t",
         "type": "Thermostat",

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -16,17 +16,7 @@ from syrupy.assertion import SnapshotAssertion
 from custom_components.junghome.const import CONF_INVERTED_COVERS, DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.cover import JungHomeCover
-from tests.conftest import DEVICES, _fake_run_websocket
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import DEVICES, _fake_run_websocket, bare_coordinator
 
 
 def _cover(
@@ -98,7 +88,7 @@ async def test_cover_inverted_awning_position(hass: HomeAssistant) -> None:
     100 when extended ("open"). Inverted, HA reads those as 0/closed and 100/open
     instead of the shutter convention's 100/open and 0/closed.
     """
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
 
     def _awning(level: str) -> JungHomeCover:
         dps = [
@@ -120,7 +110,7 @@ async def test_cover_inverted_awning_position(hass: HomeAssistant) -> None:
 
 async def test_cover_normal_device_class_is_blind(hass: HomeAssistant) -> None:
     """A non-inverted cover keeps the blind device class."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     dps = [{"id": "b-1", "type": "level", "values": [{"key": "level", "value": "0"}]}]
     device = {"id": "b", "type": "Position", "label": "Shutter", "datapoints": dps}
     cover = JungHomeCover(coordinator, device, dps[0])
@@ -129,7 +119,7 @@ async def test_cover_normal_device_class_is_blind(hass: HomeAssistant) -> None:
 
 async def test_cover_inverted_commands_pass_through(hass: HomeAssistant) -> None:
     """Inverted covers send the HA position to the gateway unchanged (no 100-x)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     dps = [{"id": "a-1", "type": "level", "values": [{"key": "level", "value": "0"}]}]
     device = {"id": "a", "type": "Position", "label": "Awning", "datapoints": dps}
     cover = JungHomeCover(coordinator, device, dps[0], inverted=True)
@@ -207,7 +197,7 @@ async def test_cover_position_only_has_no_tilt(hass: HomeAssistant, init_integra
 
 async def test_cover_extractors_defensive(hass: HomeAssistant) -> None:
     """Cover value extractors tolerate missing/garbage datapoints."""
-    cover = _cover(_bare_coordinator(hass))
+    cover = _cover(bare_coordinator(hass))
     assert cover._get_position_from_datapoint(None) is None
     assert cover._get_tilt_from_datapoint(None) is None
     assert (
@@ -255,14 +245,14 @@ async def test_cover_extractors_defensive(hass: HomeAssistant) -> None:
 
 async def test_cover_is_closed_none_when_position_unknown(hass: HomeAssistant) -> None:
     """is_closed is None when the level can't be read."""
-    cover = _cover(_bare_coordinator(hass))
+    cover = _cover(bare_coordinator(hass))
     cover._position = None
     assert cover.is_closed is None
 
 
 async def test_cover_tilt_commands(hass: HomeAssistant) -> None:
     """open/close tilt drive the angle command to 100/0."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     cover = _cover(coordinator)
     with (
         patch.object(coordinator, "set_angle", AsyncMock()) as sa,
@@ -275,7 +265,7 @@ async def test_cover_tilt_commands(hass: HomeAssistant) -> None:
 
 async def test_cover_stop_requests_refresh(hass: HomeAssistant) -> None:
     """Stop sends level_move 0 and re-reads the real position."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     cover = _cover(coordinator)
     with (
         patch.object(coordinator, "move_level", AsyncMock()) as ml,
@@ -288,7 +278,7 @@ async def test_cover_stop_requests_refresh(hass: HomeAssistant) -> None:
 
 async def test_cover_handle_update_missing_device_noops(hass: HomeAssistant) -> None:
     """Cover update writes state even when the device is gone."""
-    cover = _cover(_bare_coordinator(hass))  # coordinator.data is []
+    cover = _cover(bare_coordinator(hass))  # coordinator.data is []
     with patch.object(cover, "async_write_ha_state") as write_state:
         cover._handle_coordinator_update()
     write_state.assert_called_once()
@@ -296,7 +286,7 @@ async def test_cover_handle_update_missing_device_noops(hass: HomeAssistant) -> 
 
 async def test_cover_set_tilt_without_angle_noops(hass: HomeAssistant) -> None:
     """_set_tilt is a no-op on a position-only cover (no angle datapoint)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     cover = _cover(coordinator, with_angle=False)
     assert cover._angle_datapoint_id is None
     with patch.object(coordinator, "set_angle", AsyncMock()) as set_angle:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -2,28 +2,16 @@
 
 from unittest.mock import patch
 
-from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
     snapshot_platform,
 )
 from syrupy.assertion import SnapshotAssertion
 
-from custom_components.junghome.const import DOMAIN
-from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.event import JungHomeEventEntity
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import bare_coordinator
 
 
 async def test_event_pressed_and_depressed(
@@ -84,7 +72,7 @@ async def test_event_fires_on_each_push_not_on_rest_reread(
 
 async def test_event_unknown_datapoint_type_uses_name(hass: HomeAssistant) -> None:
     """A datapoint type with no translation key falls back to a plain name."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "d", "type": "RockerSwitch", "label": "Btn", "datapoints": []}
     datapoint = {"id": "d-x", "type": "weird_request", "values": []}
     entity = JungHomeEventEntity(coordinator, device, datapoint)
@@ -94,7 +82,7 @@ async def test_event_unknown_datapoint_type_uses_name(hass: HomeAssistant) -> No
 
 async def test_event_handle_update_missing_device_noops(hass: HomeAssistant) -> None:
     """_handle_coordinator_update returns early when the device is gone."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "gone", "type": "RockerSwitch", "label": "G", "datapoints": []}
     datapoint = {"id": "gone-c", "type": "up_request", "values": []}
     entity = JungHomeEventEntity(coordinator, device, datapoint)
@@ -112,7 +100,7 @@ async def test_fire_bus_event_skipped_without_device_entry(
     A device trigger is keyed on the registry device id, so an event without
     one would match nothing; the early return must not raise either.
     """
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "d", "type": "RockerSwitch", "label": "Btn", "datapoints": []}
     datapoint = {"id": "d-c", "type": "up_request", "values": []}
     entity = JungHomeEventEntity(coordinator, device, datapoint)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -47,17 +47,12 @@ from custom_components.junghome.diagnostics import (
     async_get_device_diagnostics,
 )
 from custom_components.junghome.event import JungHomeEventEntity
-from tests.conftest import DEVICES, PRISTINE_DEVICES, _fake_run_websocket
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import (
+    DEVICES,
+    PRISTINE_DEVICES,
+    _fake_run_websocket,
+    bare_coordinator,
+)
 
 
 async def test_all_entity_types_created(hass: HomeAssistant, init_integration) -> None:
@@ -1017,7 +1012,7 @@ async def test_migration_device_repoint_error_isolated(hass: HomeAssistant) -> N
 
 async def test_area_for_device_resolves_group_name(hass: HomeAssistant) -> None:
     """area_for_device maps parent_groups ids to the group's name (or label)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator.groups = [{"id": "g1", "name": "Kitchen"}]
     assert (
         coordinator.area_for_device({"id": "d", "parent_groups": ["g1"]}) == "Kitchen"
@@ -1036,7 +1031,7 @@ async def test_color_temp_range_for_device_reads_group_metadata(
     hass: HomeAssistant,
 ) -> None:
     """color_temp_range_for_device resolves the group's advertised Kelvin range."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "d", "parent_groups": ["g1"]}
     # Both plausible encodings are accepted, and values may be strings.
     coordinator.groups = [
@@ -1176,7 +1171,7 @@ def test_color_temp_range_for_device_first_group_wins(hass: HomeAssistant) -> No
 
 async def test_async_fetch_groups_is_best_effort(hass: HomeAssistant) -> None:
     """A gateway-side groups failure leaves groups empty and never raises."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     with patch.object(
         coordinator,
         "_fetch_groups_from_api",
@@ -1201,7 +1196,7 @@ async def test_async_fetch_groups_lets_unexpected_errors_surface(
     A RuntimeError here is not the gateway being unreachable; it is a defect,
     and swallowing it would hide it behind a debug-level log line forever.
     """
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     with (
         patch.object(
             coordinator, "_fetch_groups_from_api", AsyncMock(side_effect=RuntimeError)
@@ -1558,7 +1553,7 @@ async def test_notify_websocket_closed_skips_during_teardown(
     hass: HomeAssistant,
 ) -> None:
     """The disconnect notify fires on a live drop but is muted while stopping."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     with patch.object(coordinator, "async_update_listeners") as notify:
         # A genuine drop notifies listeners so the connectivity sensor flips off.
         coordinator._notify_websocket_closed()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -3,32 +3,21 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
     snapshot_platform,
 )
 from syrupy.assertion import SnapshotAssertion
 
-from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.light import (
     DEFAULT_MAX_KELVIN,
     DEFAULT_MIN_KELVIN,
     JungHomeLight,
 )
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import bare_coordinator
 
 
 def _color_light(
@@ -263,7 +252,7 @@ async def test_light_external_change_applied(
 
 async def test_light_value_extractors_are_defensive(hass: HomeAssistant) -> None:
     """The light value extractors tolerate missing/garbage datapoints."""
-    light = _color_light(_bare_coordinator(hass))
+    light = _color_light(bare_coordinator(hass))
     # Missing datapoint -> safe defaults (0 / None), never an exception.
     assert light._get_brightness_from_datapoint(None) == 0
     assert light._get_color_temp_from_datapoint(None) is None
@@ -291,7 +280,7 @@ async def test_light_set_without_datapoints_warns_and_noops(
     hass: HomeAssistant,
 ) -> None:
     """Setting brightness/colour-temp on a light lacking those datapoints no-ops."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {
         "id": "o",
         "type": "OnOff",
@@ -316,7 +305,7 @@ async def test_light_set_without_datapoints_warns_and_noops(
 
 async def test_brightness_floor_keeps_dim_on(hass: HomeAssistant) -> None:
     """A non-zero HA brightness never rounds to device raw 0 (which reads as off)."""
-    light = _color_light(_bare_coordinator(hass))
+    light = _color_light(bare_coordinator(hass))
     assert light._ha_to_raw_brightness(0) == 0
     # round(1 * 100 / 255) == 0 without the floor; the floor keeps it on at 1.
     assert light._ha_to_raw_brightness(1) == 1
@@ -347,7 +336,7 @@ async def test_dimmer_brightness_command(hass: HomeAssistant, init_integration) 
 
 async def test_light_brightness_and_color_temp_are_clamped(hass: HomeAssistant) -> None:
     """Out-of-range gateway values are clamped to HA's contracts."""
-    light = _color_light(_bare_coordinator(hass))
+    light = _color_light(bare_coordinator(hass))
     # Device brightness 150 (>100) would scale to 383; clamp to 255.
     assert (
         light._get_brightness_from_datapoint(
@@ -389,7 +378,7 @@ async def test_light_ignores_any_gateway_advertised_color_temp_range(
     disconnected, so wiring it up has to be a deliberate change with a capture
     behind it rather than something that drifts in.
     """
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator.groups = [
         {
             "id": "g1",
@@ -412,7 +401,7 @@ async def test_light_color_temp_range_uses_module_defaults(
     hass: HomeAssistant,
 ) -> None:
     """Every group shape leaves the module defaults in place, valid or not."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     for groups in (
         [],  # no groups known yet
         [{"id": "g1", "name": "Living room"}],  # group without the capability
@@ -435,7 +424,7 @@ async def test_light_color_temp_range_uses_module_defaults(
 
 async def test_light_clamps_reads_to_the_module_defaults(hass: HomeAssistant) -> None:
     """Reads clamp to the module defaults, which is the only range in play."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     light = _color_light(coordinator, color_temp="9000")
     assert light.color_temp_kelvin == DEFAULT_MAX_KELVIN
     assert (
@@ -458,7 +447,7 @@ async def test_colortemp_light_without_brightness(hass: HomeAssistant) -> None:
     Regression guard: the color_temp init used to be gated on _has_brightness, so
     such a device advertised COLOR_TEMP yet reported color_temp_kelvin == None.
     """
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {
         "id": "ct",
         "type": "ColorLight",
@@ -513,7 +502,7 @@ async def test_decimal_brightness_is_parsed(
     through to brightness 0, showing the lamp at 0 % with nothing logged. Cover,
     climate and sensor all parse via float(); this brings light into line.
     """
-    light = _color_light(_bare_coordinator(hass), brightness=raw)
+    light = _color_light(bare_coordinator(hass), brightness=raw)
     assert light.brightness == round(expected_pct * 255 / 100)
 
 
@@ -522,7 +511,7 @@ async def test_unparseable_brightness_falls_back_to_zero(
     hass: HomeAssistant, raw: str
 ) -> None:
     """Genuinely unusable values still degrade safely rather than raise."""
-    assert _color_light(_bare_coordinator(hass), brightness=raw).brightness == 0
+    assert _color_light(bare_coordinator(hass), brightness=raw).brightness == 0
 
 
 @pytest.mark.parametrize(("raw", "expected"), [("2700", 2700), ("2700.0", 2700)])
@@ -530,12 +519,12 @@ async def test_decimal_color_temp_is_parsed(
     hass: HomeAssistant, raw: str, expected: int
 ) -> None:
     """A decimal-formatted Kelvin value must not blank the colour temperature."""
-    light = _color_light(_bare_coordinator(hass), color_temp=raw)
+    light = _color_light(bare_coordinator(hass), color_temp=raw)
     assert light.color_temp_kelvin == expected
 
 
 @pytest.mark.parametrize("raw", ["nan", "inf", "abc"])
 async def test_unparseable_color_temp_is_none(hass: HomeAssistant, raw: str) -> None:
     """An unusable Kelvin value yields None rather than raising."""
-    light = _color_light(_bare_coordinator(hass), color_temp=raw)
+    light = _color_light(bare_coordinator(hass), color_temp=raw)
     assert light.color_temp_kelvin is None

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -19,17 +19,7 @@ from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.const import scene_slug as _scene_slug
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.scene import JungHomeScene
-from tests.conftest import _fake_run_websocket
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import _fake_run_websocket, bare_coordinator
 
 
 def test_scene_slug_fallback() -> None:
@@ -107,7 +97,7 @@ async def test_scene_removed_when_deleted(
 
 async def test_scene_activate_raises_when_missing(hass: HomeAssistant) -> None:
     """Activating a scene absent from the coordinator raises a translated error."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator.scenes = []
     scene = JungHomeScene(coordinator, "Ghost", "ghost_scene")
     with pytest.raises(HomeAssistantError):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,17 +15,7 @@ from syrupy.assertion import SnapshotAssertion
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.sensor import JungHomeQuantity
-from tests.conftest import _fake_run_websocket
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import _fake_run_websocket, bare_coordinator
 
 
 async def test_sensor_native_value_non_numeric_returns_none(
@@ -50,7 +40,7 @@ async def test_sensor_native_value_non_numeric_returns_none(
 
 async def test_sensor_value_extractor_defensive(hass: HomeAssistant) -> None:
     """Sensor helpers return None for a missing value / None state."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "s", "type": "Socket", "label": "S", "datapoints": []}
     dp = {
         "id": "s-1",
@@ -85,7 +75,7 @@ async def test_measurement_sensor_created(
 
 async def test_sensor_native_value_rejects_nan(hass: HomeAssistant) -> None:
     """A NaN reading on a numeric sensor yields None (never pollutes statistics)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "s", "type": "Socket", "label": "S", "datapoints": []}
     dp = {"id": "s-1", "values": [{"key": "quantity", "value": "nan"}]}
     # An unknown unit makes a numeric MEASUREMENT sensor; NaN must read as None.

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4,29 +4,17 @@ import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.const import CONF_HOST, CONF_TOKEN, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
     snapshot_platform,
 )
 from syrupy.assertion import SnapshotAssertion
 
-from custom_components.junghome.const import DOMAIN
-from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
 from custom_components.junghome.switch import JungHomeSocket, JungHomeSwitch
-
-
-def _bare_coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
+from tests.conftest import bare_coordinator
 
 
 async def test_switch_and_socket_commands(
@@ -59,7 +47,7 @@ async def test_status_led_update(hass: HomeAssistant, init_integration) -> None:
 
 async def test_socket_state_helper_defaults_off(hass: HomeAssistant) -> None:
     """A socket datapoint without a switch value reads as off (helper fallback)."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "d", "type": "Socket", "label": "Sock", "datapoints": []}
     # No "switch" key in values -> _get_state_from_datapoint returns False.
     socket = JungHomeSocket(coordinator, device, {"id": "d-1", "values": []})
@@ -75,7 +63,7 @@ async def test_switch_led_handle_update_missing_device_noops(
     hass: HomeAssistant,
 ) -> None:
     """JungHomeSwitch._handle_coordinator_update returns early when device is gone."""
-    coordinator = _bare_coordinator(hass)
+    coordinator = bare_coordinator(hass)
     device = {"id": "gone", "type": "RockerSwitch", "label": "G", "datapoints": []}
     datapoint = {"id": "gone-e", "type": "status_led", "values": []}
     entity = JungHomeSwitch(coordinator, device, datapoint)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -7,16 +7,14 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
-from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.junghome.const import DOMAIN
 from custom_components.junghome.coordinator import JungHomeDataUpdateCoordinator
-from tests.conftest import _auto_reply_to_datapoint_commands
+from tests.conftest import _auto_reply_to_datapoint_commands, bare_coordinator
 
 
 class _FakeMsg:
@@ -52,18 +50,8 @@ class _FakeWS:
             yield frame
 
 
-def _coordinator(hass: HomeAssistant) -> JungHomeDataUpdateCoordinator:
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "h", CONF_TOKEN: "t"})
-    entry.add_to_hass(hass)
-    coordinator = JungHomeDataUpdateCoordinator(
-        hass, {"host": "h", "token": "t"}, entry
-    )
-    coordinator.data = []
-    return coordinator
-
-
 async def test_run_websocket_processes_all_frame_types(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     text = aiohttp.WSMsgType.TEXT
     frames = [
         _FakeMsg(text, '{"type":"message","data":"hi"}'),
@@ -110,7 +98,7 @@ async def test_session_end_fails_pending_command_replies(hass: HomeAssistant) ->
     must fail the pending future immediately rather than leaving the command
     to sit out COMMAND_REPLY_TIMEOUT.
     """
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     pending: asyncio.Future[dict] = hass.loop.create_future()
     coordinator._pending_replies["ha1"] = pending
 
@@ -134,7 +122,7 @@ async def test_ws_error_message_frame_logged(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A gateway `error:` message frame is surfaced at WARNING, not swallowed."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     frames = [
         _FakeMsg(
             aiohttp.WSMsgType.TEXT,
@@ -158,7 +146,7 @@ async def test_ws_error_message_frame_logged(
 
 async def test_ws_handshake_auth_failure_triggers_reauth(hass: HomeAssistant) -> None:
     """A 401 at the WS upgrade starts reauth and stops the reconnect loop."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     err = aiohttp.WSServerHandshakeError(Mock(), (), status=401, message="unauthorized")
     with (
         patch.object(
@@ -175,7 +163,7 @@ async def test_ws_handshake_auth_failure_triggers_reauth(hass: HomeAssistant) ->
 
 
 async def test_apply_gateway_version_updates_registry(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     registry = dr.async_get(hass)
     device = registry.async_get_or_create(
         config_entry_id=coordinator.config_entry.entry_id,
@@ -198,7 +186,7 @@ async def test_apply_gateway_version_keeps_per_device_sw_version(
     version, making the registry disagree with ``device_info`` — this pins the
     fix (the branch was previously untested).
     """
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator.data = [
         {"id": "d1", "label": "Versioned", "sw_version": "9.9-device"},
         {"id": "d2", "label": "Unversioned"},
@@ -221,7 +209,7 @@ async def test_apply_gateway_version_keeps_per_device_sw_version(
 
 
 async def test_apply_gateway_version_noop_without_version(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     registry = dr.async_get(hass)
     device = registry.async_get_or_create(
         config_entry_id=coordinator.config_entry.entry_id,
@@ -233,7 +221,7 @@ async def test_apply_gateway_version_noop_without_version(hass: HomeAssistant) -
 
 
 async def test_send_raises_when_disconnected(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator.websocket = None
     # A dropped command must surface as an error, not a silent success.
     with pytest.raises(HomeAssistantError):
@@ -244,13 +232,13 @@ async def test_fetch_rejects_non_list_response(
     hass: HomeAssistant, aioclient_mock
 ) -> None:
     aioclient_mock.get("https://gw/api/junghome/functions", json={"error": "boom"})
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     with pytest.raises(UpdateFailed):
         await coordinator._fetch_devices_from_api("gw", "tok")
 
 
 async def test_stop_cancels_task_and_closes_socket(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     ws = AsyncMock()
     ws.closed = False
     coordinator.websocket = ws
@@ -260,7 +248,7 @@ async def test_stop_cancels_task_and_closes_socket(hass: HomeAssistant) -> None:
 
 
 async def test_websocket_loop_reconnects_with_backoff(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     calls: list[int] = []
 
     async def flaky(self: JungHomeDataUpdateCoordinator) -> None:
@@ -282,7 +270,7 @@ async def test_fetch_devices_from_api(hass: HomeAssistant, aioclient_mock) -> No
     aioclient_mock.get(
         "https://gw/api/junghome/functions", json=[{"id": "x", "datapoints": []}]
     )
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     data = await coordinator._fetch_devices_from_api("gw", "tok")
     assert data == [{"id": "x", "datapoints": []}]
 
@@ -293,7 +281,7 @@ async def test_fetch_groups_from_api(hass: HomeAssistant, aioclient_mock) -> Non
         "https://gw/api/junghome/groups",
         json=[{"id": "g1", "name": "Kitchen"}, "not-a-dict"],
     )
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     # Dict groups are kept; non-dict entries in the array are dropped.
     data = await coordinator._fetch_groups_from_api("gw", "tok")
     assert data == [{"id": "g1", "name": "Kitchen"}]
@@ -305,7 +293,7 @@ async def test_fetch_groups_from_api_ignores_non_list(
 ) -> None:
     # A non-list response (e.g. an error object) yields no groups, never raises.
     aioclient_mock.get("https://gw/api/junghome/groups", json={"error": "boom"})
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     assert await coordinator._fetch_groups_from_api("gw", "tok") == []
 
 
@@ -323,13 +311,13 @@ async def test_update_data_rejects_json_null_body(
         text="null",
         headers={"Content-Type": "application/json"},
     )
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     with pytest.raises(UpdateFailed):
         await coordinator._fetch_devices_from_api("gw", "tok")
 
 
 async def test_all_command_methods_send(hass: HomeAssistant) -> None:
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     ws = _auto_reply_to_datapoint_commands(coordinator)
     coordinator.websocket = ws
     # A matching stub datapoint so the confirmed reply merges instead of
@@ -379,7 +367,7 @@ async def test_all_command_methods_send(hass: HomeAssistant) -> None:
 
 async def test_status_led_off_sends_zero(hass: HomeAssistant) -> None:
     """set_status_led(False) sends the LED value field as "0"."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     ws = _auto_reply_to_datapoint_commands(coordinator)
     coordinator.websocket = ws
     coordinator.data = [
@@ -398,7 +386,7 @@ async def test_update_data_raises_update_failed_on_timeout(
     hass: HomeAssistant,
 ) -> None:
     """A fetch TimeoutError surfaces as UpdateFailed (not a bare TimeoutError)."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     with (
         patch.object(
             coordinator, "_fetch_devices_from_api", AsyncMock(side_effect=TimeoutError)
@@ -410,7 +398,7 @@ async def test_update_data_raises_update_failed_on_timeout(
 
 async def test_update_data_5xx_maps_to_update_failed(hass: HomeAssistant) -> None:
     """A non-auth ClientResponseError (e.g. 500) surfaces as UpdateFailed."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     err = aiohttp.ClientResponseError(Mock(), (), status=500)
     with (
         patch.object(
@@ -423,7 +411,7 @@ async def test_update_data_5xx_maps_to_update_failed(hass: HomeAssistant) -> Non
 
 async def test_ws_handshake_non_auth_error_reconnects(hass: HomeAssistant) -> None:
     """A non-401/403 handshake error reconnects with backoff (not reauth)."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     err = aiohttp.WSServerHandshakeError(Mock(), (), status=500, message="x")
     calls: list[int] = []
 
@@ -443,7 +431,7 @@ async def test_ws_handshake_non_auth_error_reconnects(hass: HomeAssistant) -> No
 
 async def test_send_raises_when_send_str_fails(hass: HomeAssistant) -> None:
     """A send failure on a live socket surfaces as HomeAssistantError."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     ws = AsyncMock()
     ws.closed = False
     ws.send_str = AsyncMock(side_effect=RuntimeError("boom"))
@@ -454,7 +442,7 @@ async def test_send_raises_when_send_str_fails(hass: HomeAssistant) -> None:
 
 async def test_ws_message_without_datapoint_id_is_ignored(hass: HomeAssistant) -> None:
     """A datapoint frame with a dict payload but no id is logged and ignored."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator._handle_websocket_message(  # must not raise
         {"type": "datapoint", "data": {"values": []}}
     )
@@ -462,13 +450,13 @@ async def test_ws_message_without_datapoint_id_is_ignored(hass: HomeAssistant) -
 
 async def test_handle_message_non_dict_is_ignored(hass: HomeAssistant) -> None:
     """A non-dict message payload hits the defensive guard and is ignored."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator._handle_websocket_message(["not-a-dict"])  # type: ignore[arg-type]
 
 
 async def test_groups_broadcast_is_stored(hass: HomeAssistant) -> None:
     """A `groups` broadcast is cached for diagnostics (not consumed by entities)."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator._handle_websocket_message(
         {"type": "groups", "data": [{"id": "g1", "name": "Living room"}, "junk"]}
     )
@@ -481,7 +469,7 @@ async def test_groups_broadcast_is_stored(hass: HomeAssistant) -> None:
 
 async def test_ws_frame_log_truncates_large_frames(hass: HomeAssistant) -> None:
     """The diagnostics frame log keeps recent frames and truncates large ones."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     coordinator._log_ws_frame("x" * 5000)
     coordinator._log_ws_frame("short")
     assert coordinator.ws_frame_log[-1] == "short"
@@ -491,7 +479,7 @@ async def test_ws_frame_log_truncates_large_frames(hass: HomeAssistant) -> None:
 
 async def test_ws_frame_log_keeps_latest_per_type(hass: HomeAssistant) -> None:
     """The latest frame of each type is kept IN FULL (handshake survives churn)."""
-    coordinator = _coordinator(hass)
+    coordinator = bare_coordinator(hass)
     # A large functions handshake frame: it exceeds the rolling-log truncation
     # cap, but the per-type store keeps it complete for direct wire comparison.
     big = '{"type":"functions","data":[' + ",".join(['{"id":"x"}'] * 500) + "]}"


### PR DESCRIPTION
## Summary

Implements the reusable-fixtures backlog item and settles the broad-excepts one.

- **`tests/fixtures/functions.json`** now holds the shared gateway payload, generated byte-for-byte from the old 180-line Python literal in `conftest.py`. It is wire-shaped (exactly what `GET /functions/` and the WS `functions` broadcast carry), so it reads as what it is and can be diffed against real gateway captures. Loaded via a new `load_json_fixture` helper.
- **Ten byte-identical private `_bare_coordinator` copies** (nine platform test files + `test_websocket.py`) collapse into one shared `conftest.bare_coordinator`.
- **Scoping decision, recorded in CLAUDE.md:** one-off device dicts stay inline in the tests that use them — visible inputs beat indirection for single-use data. The fixture file is for the *shared* payload only.
- **Broad excepts settled as wontfix** (per review decision): all three remaining catch-alls in `coordinator.py` (reconnect loop, frame-handler containment, WS send path) are load-bearing; the narrowing that mattered was already done in PR #133. Moved from the backlog to "Settled decisions" with the rationale.

Backlog now contains only the two deferred/blocked items: cover travel states (needs a capture of a moving blind) and the rare self-healing functions-broadcast-vs-poll membership race.

## Test plan

- [x] `pytest tests/` — 404 passed, 35 snapshots (zero behavioral change; same assertions against the same data)
- [x] Coverage 98.62% branch (gate 95%)
- [x] `mypy --strict` clean, `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhL1ZASQbSzB1mGbBDxhd5