### PR TITLE
Implement the maximum-effort review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,17 @@ JUNG HOME Gateway over its REST API and WebSocket.
 - `docs/` — reverse-engineered gateway reference (see below) plus
   `docs/example-button-automation.md` (user-facing guide).
 - `config/`, `docker-compose.yml`, `scripts/` — local test harness.
-- `disk_dump/` — gateway microSD image, **gitignored** (tokens + mesh keys;
-  never commit it). `jung/sdc2` is the **current** firmware (v2.1.x, API
-  1.5.0); `sdc3` is the older A/B partition — quote evidence from sdc2.
+- `disk_dump/` — gateway microSD dumps + live WS captures, **gitignored**
+  (tokens + mesh keys; never commit it). Two dumps of the same card:
+  `jung/` (2026-06-13, `sdc*`) and `jung-20260801/` (`sdb*`) — same builds
+  byte-for-byte, but the 2026-08-01 extraction is higher fidelity (see its
+  `NOTES.md`). **Quote evidence from `jung-20260801/sdb2`** (current
+  firmware, v2.1.3 build 2840, API 1.5.0; `jung/sdc2` is the same build);
+  `sdb3`/`sdc3` are the older v2.0.0 A/B partition — evidence found *only*
+  there is stale (v2.1.3 refactored the middleware into
+  `models/device_states/*State.js`). `ws-capture/` and `ws-capture-20260727/`
+  are live production WS sessions; the data partition's live mesh DB is
+  `sd?4/middleware/res_6/` (the unnumbered `res/` is empty factory state).
 
 ## Protocol facts the platforms encode (all firmware-verified)
 
@@ -51,6 +59,13 @@ JUNG HOME Gateway over its REST API and WebSocket.
   regulator has no on/off at all, so the climate entity is permanently
   `HVACMode.HEAT` and that datapoint only feeds `hvac_action`; never map it to
   `hvac_mode` again (issue #121; evidence in docs/gateway-websocket.md).
+- **Thermostat presets: the API descriptor's `none` is a lie.** Writes accept
+  exactly `frost`/`eco`/`comfort` (the firmware throws on anything else,
+  surfacing as an uncorrelated error → command timeout); "no preset" reads
+  back as the **empty string**, never `"none"` (a preset is derived — target
+  temperature == a configured threshold). climate.py maps `""` → PRESET_NONE
+  on read and treats selecting PRESET_NONE as a local no-op; never send
+  `"none"` (preset note in docs/gateway-websocket.md).
 - **Cover `level` is percent-closed**: close ⇒ BT-Mesh "down" (`0x7FFF`,
   level→100 %), open ⇒ "up" (`0x8000`, →0 %); HA position = `100 - level`.
   Correct for shutters/blinds; **awnings mount the motor the opposite way** and
@@ -234,13 +249,100 @@ them without new evidence wastes a session.
   fetch/parse handlers); narrowing these three trades crash-risk for no
   diagnostic gain.
 
+## Maximum-effort review protocol
+
+Run this whenever asked to review the repo or a PR ("run the review
+protocol", "review PR #N"). The bar: **only verified findings count**, and
+repeated runs must converge — an empty report is a success state, not a
+failure to try hard enough. Padding a clean run with nits poisons every
+future run.
+
+**Setup.** Record findings incrementally to `CLAUDE-fable.md` (kept out of
+git via `.git/info/exclude` — never commit it; a dead session must not lose
+progress). If the file exists from a previous run, first re-verify its open
+findings — fixed → mark fixed, still open → carry forward — before hunting
+new ones. PR scope = the diff plus every invariant it touches; repo scope =
+all passes below.
+
+**What counts as a finding.** A defect with (a) concrete evidence
+(file:line, firmware path, capture frame), (b) a failure scenario a real
+user or contributor can hit, and (c) a proposed fix. Actively try to
+*refute* every candidate before recording it — read the callers, trace the
+wire path, run the test. What does NOT count: style ruff doesn't enforce,
+speculative rewrites, unreachable hypotheticals, anything under "Settled
+decisions" without new evidence, anything already in the Backlog. A
+candidate that survives refutation but can't be fully proven goes in a
+separate, clearly-marked "unproven" list. Severity: P0 user-visible
+breakage · P1 correctness under race/edge conditions · P2 wrong or stale
+evidence in docs/comments · P3 polish worth doing while nearby.
+
+**Pass 1 — firmware-evidence accuracy.** The current build is v2.1.3
+(2840): `disk_dump/jung-20260801/sdb2` (highest-fidelity extraction;
+`jung/sdc2` is the same build). `sdb3`/`sdc3` are v2.0.0 — evidence found
+*only* there is stale (v2.1.3 refactored the middleware into
+`models/device_states/*State.js`; services the docs once cited exist only
+in v2.0.0). Every firmware citation in docs/, CLAUDE.md and code comments
+must resolve in the current build — file exists, behaviour matches.
+Descriptor files (`cdb_types_*.json`, `/apidoc`) are *promises*; the
+`dist/` implementation is the truth — when they disagree, the
+implementation wins and the disagreement is a finding (the preset-"none"
+bug shipped because the descriptor was trusted). Cross-check the live
+captures (`disk_dump/ws-capture*/`) whenever a claim concerns what the wire
+actually carries.
+
+**Pass 2 — wire contracts, both directions.** For every datapoint type the
+integration writes, trace the full path: HA service → coordinator command →
+`ip_event_handler` routing → state-class publish, and confirm every value
+sent is one the firmware accepts (it throws on anything else, which
+surfaces as an uncorrelated error → command timeout). For every read, trace
+state class → `composeDatapointByState` → the value set that can actually
+appear — including `""`, `"NaN"`, trailing-space labels and boundary
+numbers — and confirm the platform parses all of them.
+
+**Pass 3 — concurrency interleavings.** Enumerate the concurrent actors:
+60 s poll, unmatched-push debounced refresh, connect-time refresh,
+`functions` broadcast, per-datapoint pushes, command sends + correlated
+replies, the reconnect loop, entry reload/unload. For each documented
+invariant (push-overlay refcount, pending replies failed on session end, no
+poll starvation, the membership-race backlog note), pick the pairwise
+interleavings that could violate it and check the *code*, not the comment.
+
+**Pass 4 — identity & HA-contract invariants.** No unique_id or device
+identifier from a volatile gateway id, and none derived from
+`entry.unique_id` (only `entry_anchor`). Every map keyed by device slug is
+guarded with `duplicate_slugs`. Availability: `last_update_success` only;
+`ws_connected` may gate controllable entities, never grant availability.
+Optimistic entity writes happen only after the awaited command returns.
+Quantified claims in comments ("10 consecutive polls", "5 s", "60 s") must
+match what the code actually measures — same quantity, same unit, same
+trigger. When two sibling code paths handle the same untrusted input, their
+hardening must match — an asymmetry is a latent finding. `strings.json` and
+all 26 translations move together.
+
+**Pass 5 — tests.** Fixture and test wire values must be values the current
+firmware can emit (`"comfort"`-only coverage is how the `""` preset gap
+survived). Every P0/P1 fix gets a test that fails before and passes after.
+Respect the two test landmines (flow-manager auto-advance, bare-coordinator
+shutdown) and the 95 % branch gate.
+
+**Pass 6 — hygiene.** Secrets stay out of git (`disk_dump/` gitignored;
+diagnostics redact hosts/tokens/serials, including inside free-form text).
+CI pins consistent (ruff version, HA floor). `manifest.json`/`hacs.json`
+coherent.
+
+**Report.** Severity-ordered; each finding with evidence, failure scenario
+and proposed fix. Close with an explicit verdict: the list of open P0–P2s,
+or "clean — nothing above P3 survived verification."
+
 ## Backlog (open, in rough value order)
 
-- **Cover travel states** — blocked on evidence: the existing ws-capture
-  contains zero `level` push frames, so first capture a blind actually moving
-  to learn whether intermediate levels stream; if they do, report
-  `is_opening`/`is_closing` and let pushes drive position instead of jumping
-  to the target.
+- **Cover travel states** — half-unblocked by firmware evidence: every
+  composed `level` datapoint always carries a `level_move` value (−1/1/0)
+  derived from current-vs-target (`PositionState.fromMeshMessage` computes
+  mode opening/closing/stopped), so `is_opening`/`is_closing` could be read
+  from `level` pushes today. Still needed before building it: a capture of a
+  blind actually moving, to learn whether intermediate `level` pushes stream
+  during travel (drives whether position can track live or only jump).
 - **A `functions` broadcast racing an in-flight poll can be overwritten by
   the poll's older device list** (the per-datapoint overlay covers values,
   not membership). Rare — the broadcast only fires on membership change —

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -193,16 +193,23 @@ def _make_stale_device_pruner(
     reload) therefore no longer destroys a live device's entities.
     """
     missing_polls: dict[str, int] = {}
+    # The last device-list adoption this pruner has counted. Device membership
+    # only changes when the coordinator adopts a fresh list (a REST poll or a
+    # `functions` broadcast — `coordinator.data_generation`); every other
+    # dispatch that reaches this listener (per-datapoint pushes, scenes
+    # broadcasts, the WS-drop notification) re-presents the SAME list, so
+    # counting those as misses shrank the debounce below
+    # STALE_DEVICE_PRUNE_MISSES real polls — e.g. a WS flapping while a device
+    # was transiently absent from one poll burned several "misses" per minute
+    # from reconnect notifications alone.
+    last_generation: int | None = None
 
     @callback
     def _prune_stale_devices() -> None:
-        # Device membership only changes on a REST poll; a WebSocket push merges
-        # datapoint values into existing devices and never adds or removes one.
-        # Skip push dispatches so the miss counter below tracks poll cycles, not
-        # the (frequent) pushes — otherwise a device transiently absent from one
-        # poll would reach the miss threshold within seconds of pushes.
-        if coordinator.pushed_datapoint_id is not None:
-            return
+        nonlocal last_generation
+        if coordinator.data_generation == last_generation:
+            return  # same device list as last time; nothing new to count
+        last_generation = coordinator.data_generation
         if not coordinator.data:
             return  # don't prune on an empty/failed poll
         current = {device_slug(d) for d in coordinator.data}

--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -4,7 +4,11 @@ A ``Thermostat`` function exposes three datapoints (see
 ``cdb_types_datapoints.json`` / ``cdb_types_functions.json``):
 
 - ``temperature_ctrl`` — the target temperature in °C (range 5..30) plus a
-  ``temperature_ctrl_preset`` key (``none`` / ``frost`` / ``eco`` / ``comfort``).
+  ``temperature_ctrl_preset`` key. Writes accept exactly ``frost`` / ``eco`` /
+  ``comfort``; reads report the matching preset or ``""`` when the target
+  matches no threshold. (The gateway's API descriptor also advertises
+  ``none``, but the firmware rejects writing it and never reports it — see
+  the preset note in ``docs/gateway-websocket.md``.)
 - ``quantity`` — the room temperature reading, surfaced here as
   ``current_temperature``. (Sensor discovery does not turn a Thermostat's
   quantity into a standalone sensor entity; it is only the ambient reading.)
@@ -57,15 +61,31 @@ DEFAULT_MAX_TEMP = 30.0
 # "frost" (frost protection) has no standard HA preset constant; expose it under
 # its gateway name. The others map onto HA's well-known presets.
 PRESET_FROST = "frost"
-# HA preset <-> gateway preset value (they coincide, but keep the map explicit
+# HA preset -> gateway preset value (they coincide, but keep the map explicit
 # so a future HA constant rename doesn't silently desync the wire value).
+# PRESET_NONE is deliberately absent: the firmware accepts only these three
+# (`SetPointState.publishMode` throws "does not set a valid preset" for
+# anything else, including the `none` its own API descriptor advertises), and
+# a preset here is not a mode but a *derived* fact — "the target temperature
+# equals one of the three configured thresholds" — so there is no device
+# state a "none" write could set. `async_set_preset_mode` no-ops it instead.
 _HA_TO_DEVICE_PRESET = {
-    PRESET_NONE: "none",
     PRESET_FROST: "frost",
     PRESET_ECO: "eco",
     PRESET_COMFORT: "comfort",
 }
-_DEVICE_TO_HA_PRESET = {v: k for k, v in _HA_TO_DEVICE_PRESET.items()}
+# Gateway preset value -> HA preset. Not the inverse of the write map: the
+# gateway reports `""` when no threshold matches the target (the common steady
+# state — `getRTRTemperatureMode` returns the empty string, never "none"),
+# which reads as PRESET_NONE. "none" is kept for a future descriptor-faithful
+# firmware. Anything else is unknown and maps to None.
+_DEVICE_TO_HA_PRESET = {
+    "": PRESET_NONE,
+    "none": PRESET_NONE,
+    "frost": PRESET_FROST,
+    "eco": PRESET_ECO,
+    "comfort": PRESET_COMFORT,
+}
 
 # The Thermostat's ``switch`` datapoint value -> momentary HVAC action. Any other
 # value (notably the ``"NaN"`` the gateway sends for an offline device) leaves the
@@ -184,7 +204,23 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
         self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set a new preset."""
+        """Set a new preset.
+
+        PRESET_NONE is a local no-op: a preset on this device is the *derived*
+        fact that the target temperature equals one of the three configured
+        thresholds, so "no preset" is not a state that can be commanded — and
+        the firmware rejects the write (`SetPointState.publishMode` throws for
+        anything but frost/eco/comfort), which would surface here as a 5 s
+        command-confirmation timeout for a selection that cannot mean anything.
+        The displayed preset keeps tracking the device's own report.
+        """
+        if preset_mode == PRESET_NONE:
+            _LOGGER.debug(
+                "Thermostat %s: PRESET_NONE is display-only (a preset is "
+                "derived from the target temperature); nothing to send",
+                self._name,
+            )
+            return
         device_preset = _HA_TO_DEVICE_PRESET.get(preset_mode)
         if device_preset is None:
             _LOGGER.warning("Unknown thermostat preset %r", preset_mode)

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -69,10 +69,15 @@ WS_SEND_TIMEOUT = 10
 # itself gives up waiting on the BT-Mesh node after
 # `config.btmesh.response_timeout_ms` = 3000 ms (config.json) before the set
 # rejects and the reply never comes, so this leaves comfortable headroom above
-# that mesh-level bound for the WS round trip. A rejected set produces only an
-# uncorrelated `error:` message frame (no message_id to match against — see
-# `_dispatch_text_frame`), so a rejection surfaces here as a timeout rather than
-# the gateway's specific error text.
+# that mesh-level bound for the WS round trip. Waiting longer would buy
+# nothing: the api-server abandons its middleware IPC call at
+# `middleware.command_timeout_ms` = 6000 ms (api-server config.json), and the
+# middleware's own retry loop (3 attempts, 3 s apart) means a set that did not
+# succeed on the first mesh attempt cannot answer inside that bound either —
+# so every reply that will ever arrive does so within ~3.5 s. A rejected set
+# produces only an uncorrelated `error:` message frame (no message_id to match
+# against — see `_dispatch_text_frame`), so a rejection surfaces here as a
+# timeout rather than the gateway's specific error text.
 COMMAND_REPLY_TIMEOUT = 5
 # Repair-issue translation key for that "live push is dead" state.
 ISSUE_PUSH_FAILURE = "websocket_push_failure"
@@ -233,6 +238,15 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # (functions/groups/scenes/version) is always present in diagnostics even
         # when the rolling log above has churned past it on a busy gateway.
         self.ws_last_frame_by_type: dict[str, str] = {}
+        # Monotonic count of device-list adoptions: bumped by every successful
+        # REST poll and every `functions` broadcast — the only two events that
+        # can change device *membership*. Listeners that debounce on "consecutive
+        # polls" (the stale-device pruner) compare this instead of counting raw
+        # dispatches: pushes, scenes broadcasts and the WS-drop notification all
+        # call async_update_listeners too, and counting those shrank the
+        # pruner's 10-poll window during a WS flap or a scene-editing session
+        # while a device was transiently missing from one poll.
+        self.data_generation = 0
         # Stable-slug -> volatile device id, to detect firmware-update id changes.
         self._device_ids: dict[str, str] = {}
         # Per-platform (entity-domain -> unique_ids) sets shared with each
@@ -324,8 +338,27 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         if overlay:
             self._apply_push_overlay(response, overlay)
         self._reload_if_device_ids_changed(response)
+        # A fresh device list is about to be adopted (the base class stores the
+        # return value before notifying listeners, so the counter is consistent
+        # by dispatch time).
+        self.data_generation += 1
         # `async_set_updated_data` is automatically called with this.
         return response
+
+    @callback
+    def async_set_updated_data(self, data: list[Device]) -> None:
+        """Adopt a fresh device list and notify listeners.
+
+        Overridden to advance ``data_generation``: every caller of this method
+        is adopting a poll-equivalent device list (the ``functions`` broadcast
+        is the production caller; the per-datapoint push path deliberately
+        avoids it — see ``_handle_websocket_message``), and the stale-device
+        pruner debounces on that count rather than on raw dispatches. The REST
+        poll adopts via the base class's ``self.data`` assignment instead, so
+        ``_async_update_data`` advances the counter itself.
+        """
+        self.data_generation += 1
+        super().async_set_updated_data(data)
 
     @staticmethod
     def _apply_push_overlay(
@@ -489,15 +522,34 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         Resolves the device's ``parent_groups`` ids against the groups list and
         returns the first group name found (a device is normally in one room).
         Returns ``None`` when the device has no group or none resolve to a name.
+
+        Hardened exactly like ``color_temp_range_for_device`` below: groups and
+        parent ids are untrusted gateway JSON, and an unhashable id (a list, a
+        dict) must not raise ``TypeError`` out of the ``_assign_areas``
+        coordinator listener — that would also skip every listener queued after
+        it in the same dispatch.
         """
         parents = device.get("parent_groups") or []
-        if not parents:
+        if not isinstance(parents, (list, tuple)) or not parents:
             return None
-        by_id = {g.get("id"): (g.get("name") or g.get("label")) for g in self.groups}
-        for parent in parents:
-            name = by_id.get(parent)
+        by_id: dict[Any, str] = {}
+        for group in self.groups:
+            if not isinstance(group, dict):
+                continue
+            group_id = group.get("id")
+            if not isinstance(group_id, (str, int)) or isinstance(group_id, bool):
+                continue
+            name = group.get("name") or group.get("label")
             if name:
-                return str(name)
+                # First occurrence wins on a duplicated id, matching the
+                # documented order in color_temp_range_for_device.
+                by_id.setdefault(group_id, str(name))
+        for parent in parents:
+            if not isinstance(parent, (str, int)) or isinstance(parent, bool):
+                continue
+            name = by_id.get(parent)
+            if name is not None:
+                return name
         return None
 
     def color_temp_range_for_device(self, device: Device) -> tuple[int, int] | None:
@@ -1325,7 +1377,13 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         )
 
     async def set_temperature_preset(self, datapoint_id: str, preset: str) -> None:
-        """Set a thermostat preset (``none`` / ``frost`` / ``eco`` / ``comfort``)."""
+        """Set a thermostat preset (``frost`` / ``eco`` / ``comfort``).
+
+        These three are the only values the firmware accepts — it throws for
+        anything else, including the ``none`` its own API descriptor
+        advertises (``SetPointState.publishMode``), which would surface here
+        as an uncorrelated error and a command-confirmation timeout.
+        """
         await self._send_datapoint_command(
             datapoint_id,
             "temperature_ctrl",

--- a/docs/bt-mesh-direct.md
+++ b/docs/bt-mesh-direct.md
@@ -58,10 +58,15 @@ parameters use the **vendor model**.
 
 ## Sending commands
 
-The middleware sends every command **3×** (`publish_retransmissions`) at **15 ms**
-spacing (`publish_interval_ms`), with **50 ms** pause between datapoints
-(`request_pause_ms`), incrementing an 8-bit transaction id (`tid`) once per
-logical command.
+On current firmware (v2.1.3) the middleware sends each command **once, ACKed**
+(`flags = 1`), serialised through a publish mutex with a **50 ms** pause
+between datapoints (`request_pause_ms`), incrementing an 8-bit transaction id
+(`tid`) once per logical command (`util/device_state_helper.js`,
+`sendIntervalGenericClientSet`). Reliability lives one layer up: the command
+handler retries a failed publish up to 3 times, 3 s apart
+(`ip_event_handler.js`). The **previous** build (v2.0.0) instead blasted every
+command 3× at 15 ms spacing (`publish_retransmissions` /
+`publish_interval_ms` — those config keys no longer exist in v2.1.3).
 
 ### Generic / lighting (the common path)
 
@@ -74,7 +79,7 @@ model_id         = client model (e.g. 0x1001 OnOff, 0x1302 Lightness, 0x1003 Lev
 appkey_index     = 0
 tid              = transaction id (uint8, increments per command)
 transition_ms    = 0 (or 0xFFFE for "move")
-delay_ms         = staggered per retransmission
+delay_ms         = 0 (v2.0.0 staggered this per retransmission)
 flags            = 1
 type             = MeshModelSetKind (see table)
 parameters       = little-endian value, length bytes
@@ -133,7 +138,8 @@ Over the air this is a **vendor access message** (3-byte opcode = `0b11xxxxxx`
 | company `0x0527`) carrying the property id + value. On a non-Silabs stack you
 send/parse the vendor opcodes directly; the exact opcode bytes live in the EFR32
 NCP firmware, but the host-side framing above (from
-`btmesh_set_datapoint_service.js`) tells you the command/property/value fields.
+`util/device_state_helper.js`, `sendKeyStatus` — `commandId = 2` /
+`STATUS_LBC_PROP_SEND_ID`) tells you the command/property/value fields.
 
 Button **events** (`up_request`/`down_request`/`trigger_request`) are the device
 *publishing* vendor property status to a group; subscribe to that group to

--- a/docs/gateway-architecture.md
+++ b/docs/gateway-architecture.md
@@ -12,7 +12,13 @@ needed to use the integration.
 
 ## microSD partition layout
 
-The card has four partitions (seen in the dump as `sdc1`–`sdc4`):
+The card has four partitions (seen in the dump as `sdc1`–`sdc4`). There are
+two dumps of the same card: `disk_dump/jung/` (2026-06-13, `sdc*`) and
+`disk_dump/jung-20260801/` (`sdb*`) — the rootfs partitions are
+**byte-identical builds** in both, but the 2026-08-01 extraction is the
+higher-fidelity one (ext4, `rsync -aHAX`; the June one went through a
+case-insensitive filesystem and dropped device nodes and some symlinks — see
+its `NOTES.md`), so prefer `jung-20260801/sdb2` when quoting evidence:
 
 | Partition | Type | Role |
 |-----------|------|------|
@@ -93,8 +99,13 @@ The middleware persists the mesh state on the data partition under
 - `btmesh_iv_index`, `btmesh_iv_index_birthday`, `btmesh_sequence_number` — IV
   index and sequence-number state (mesh replay protection).
 
-Devices observed use `cid 0x0527` / `pid 0x000B`. (The dump's own copy was a
-factory/empty CDB; a live gateway's copy contains all provisioned nodes.)
+The live CDB on the data partition (`middleware/res_6/` — the schema-v6
+directory the middleware actually uses) contains the full provisioned mesh:
+~30 nodes with JUNG's `cid 0x0527` and per-product `pid`s (`0x0001`–`0x0004`,
+`0x000B`), plus the provisioning iPhone at `cid 0x004C` on unicast `0001`.
+Only the leftover *unnumbered* `middleware/res/` (untouched factory state
+from 2023) is near-empty — an earlier revision of this doc mistook that copy
+for "the" CDB and called the gateway reset/empty.
 
 > ⚠ The CDB contains the network's secret keys. Never commit a real
 > `bt_mesh_project.json` (or the whole `disk_dump/`, which is `.gitignore`d).

--- a/docs/gateway-rest-api.md
+++ b/docs/gateway-rest-api.md
@@ -96,7 +96,8 @@ the gateway's network-key password.
 | GET  | `/log/...` | Diagnostic snapshots (system, kernel, middleware, api-server, jungremote-client, bt_mesh_project, jung_home_project). |
 
 > Endpoint set grows with firmware. `products/*` and `project/*` exist on 1.5.0
-> but not on the 1.4.1 build seen on disk. Always confirm against `/apidoc`.
+> but not on the previous partition's 1.1.0 build (the api-server version that
+> ships with gateway firmware v2.0.0). Always confirm against `/apidoc`.
 
 ## `functions` payload (what the integration uses)
 

--- a/docs/gateway-system-analysis.md
+++ b/docs/gateway-system-analysis.md
@@ -320,7 +320,17 @@ This confirms the A/B update scheme: the bootloader flips between `sdc2`/`sdc3`,
 and `/data` (`sdc4`) is shared across both slots. `sdc4/update/history.txt`
 records a real update (2026-05-12) doing, in order: save `/data` → migrate →
 update `fstab` → flash boot partition → update bootloader config → mark slot
-active. The on-disk device DB in this image is empty (a reset/test gateway).
+active. The **live** device DB is `sdc4/middleware/res_6/` (the schema-v6
+directory the middleware uses) and holds the full ~30-node production mesh
+with its keys; only the leftover unnumbered `middleware/res/` (factory state,
+2023 mtimes) is near-empty — an earlier revision of this doc mistook it for
+the real CDB and called this a reset/test gateway.
+
+A second dump of the same card, `disk_dump/jung-20260801/` (`sdb1`–`sdb4`),
+was taken 2026-08-01: rootfs partitions byte-identical to this one, data
+partition further along (project export from app 2.2.0, RockerSwitch count
+8 → 21, a ~68 MB support snapshot). Its extraction is the higher-fidelity one
+— prefer `sdb2` when quoting firmware evidence (see its `NOTES.md`).
 
 ### Matter — provisioned but inactive
 
@@ -341,10 +351,12 @@ The data partition contains live secrets — handle the dump accordingly
 - Cloud token `jungremote-client/res/api_token.tk` and the per-user API token
   secrets in `api-server/res/tokens/*.tkn` (these sign the gateway's JWTs).
 
-### Live WebSocket capture (`disk_dump/ws-capture/`)
+### Live WebSocket captures (`disk_dump/ws-capture/`, `ws-capture-20260727/`)
 
-A real session from a **production** gateway (fw 1.5.0), separate from the disk
-image. It validates the protocol the integration depends on:
+Real sessions from a **production** gateway (API 1.5.0), separate from the
+disk image — the second capture is from 2026-07-27 and shows the same four
+function types with more rockers (OnOff 23, RockerSwitch 23, ColorLight 4,
+Socket 2). They validate the protocol the integration depends on:
 
 - Connect frame order: `message → version → functions → groups → scenes` — the
   gateway pushes the full `scenes` list on connect (what the scene platform

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -45,7 +45,7 @@ In order:
 | `scene` | object | A scene was recalled. |
 | `groups` / `groups-new` / `groups-deleted` | array | Full groups list / added / removed. |
 | `scenes` / `scenes-new` / `scenes-deleted` | array | Full scenes list / added / removed. |
-| `devices` / `devices-new` / `devices-deleted` | array | Lower-level device list / added / removed. |
+| `devices-new` / `devices-deleted` | array | Lower-level device ids added / removed. (A full `devices` list type exists in the server too, but its emit call is commented out on current firmware — only the deltas can arrive.) |
 | `config` | object | Configuration (currently not emitted). |
 
 The `*-new` / `*-deleted` variants are how the gateway signals that nodes,
@@ -120,12 +120,13 @@ Common `values` keys by device type:
 | Cover move / stop | `level_move` = `"1"` (closing/down) / `"-1"` (opening/up) / `"0"` (stop) |
 | Cover slat tilt | `angle` = `"0".."100"` |
 | Thermostat target | `temperature_ctrl` = °C, e.g. `"21.5"` (range 5..30) |
-| Thermostat preset | `temperature_ctrl_preset` = `none` / `frost` / `eco` / `comfort` |
+| Thermostat preset | `temperature_ctrl_preset` = `frost` / `eco` / `comfort` (write); reads report the matching preset or `""` — see note below |
 | Status LED (rocker) | `status_led` = `"0"` / `"1"` |
 | Rocker press (read-only events) | `up_request` / `down_request` / `trigger_request` = `"1"` |
 
 > **Cover `level` is percent-*closed* (confirmed from gateway firmware).** In the
-> middleware (`btmesh_set_datapoint_service.js` + `datapoint_helper_methods.js`) a
+> middleware (v2.1.3: `models/device_states/PositionState.js` `publishMode` —
+> the v2.0.0 build kept this in `btmesh_set_datapoint_service.js`) a
 > *close* maps to BT-Mesh "down" (`0x7FFF` ⇒ drives the Generic Level toward
 > 100 %) and an *open* to "up" (`0x8000` ⇒ toward 0 %). So `level` 100 = fully
 > closed, 0 = fully open, and the integration uses HA position = `100 - level`.
@@ -160,20 +161,43 @@ Common `values` keys by device type:
 > API as an ordinary `switch` = `"0"` / `"1"` datapoint with nothing to
 > distinguish it from a light's or a socket's. Internally it is a Generic OnOff
 > `0x1000` server state the gateway reads as `"manu"` (0) / `"auto"` (1)
-> (`btmesh_get_datapoint_service.js`), and the RTR scheduler property
+> (v2.1.3: `models/device_states/AutomaticModeState.js`; the v2.0.0 build's
+> `btmesh_get_datapoint_service.js`), and the RTR scheduler property
 > `LBC_PROP_RTR_SCHEDULER_ENABLE_ID` writes into that *same* state
-> (`handleThermostatAutomaticMode` in `btmesh_device_property_service.js`) — two
-> sources feeding one value. In the field it flips on its own several times an
-> hour, tracking the regulator's momentary heating output (these RTRs drive
-> heating with a ~15-minute PWM cycle) while setpoint, preset and ambient
+> (v2.1.3: `models/device_property_states/SchedulerEnableState.js`, bound
+> `scheduler_enable → automatic_mode`; v2.0.0's `handleThermostatAutomaticMode`)
+> — two sources feeding one value. In the field it flips on its own several
+> times an hour, tracking the regulator's momentary heating output (these RTRs
+> drive heating with a ~15-minute PWM cycle) while setpoint, preset and ambient
 > temperature stay unchanged — see
 > [issue #121](https://github.com/ernetas/junghome/issues/121). Nothing in the
-> state set switches a regulator off, either: `Property_RTR_SensorHVAC_Mode`
-> exists in the middleware but is commented out and never exposed, so the `frost`
-> preset is the closest equivalent. The integration therefore reads this datapoint
-> as HA's `hvac_action` (`heating` / `idle`) only, holds `hvac_mode` at `heat`, and
-> never writes it. Treating it as an on/off is what made every thermostat entity
-> flap between `off` and `heat`.
+> state set switches a regulator off, either: v2.1.3 carries an implemented
+> HVAC-mode property (`HvacModeState`, `LBC_PROP_RTR_HVACMODE_DISPLAY_ID`) but
+> it is read-only, display-oriented and category `manufacturer_property`, which
+> `getDatapointTypeByState` never maps to an API datapoint (v2.0.0's
+> `Property_RTR_SensorHVAC_Mode` was commented out entirely) — so the `frost`
+> preset remains the closest equivalent. The integration therefore reads this
+> datapoint as HA's `hvac_action` (`heating` / `idle`) only, holds `hvac_mode`
+> at `heat`, and never writes it. Treating it as an on/off is what made every
+> thermostat entity flap between `off` and `heat`.
+
+> **Thermostat presets: the API descriptor lies about `none`.**
+> `cdb_types_datapoints.json` (and `/apidoc`) advertise
+> `temperature_ctrl_preset` values `["none","frost","eco","comfort"]`, but the
+> implementation contradicts the descriptor in both directions. **Writes**: the
+> middleware routes any present `temperature_ctrl_preset` value to the preset
+> publisher, which throws "does not set a valid preset" for anything but
+> `frost`/`eco`/`comfort` — including `"none"` (`ip_event_handler.js` +
+> `SetPointState.publishMode`); the retry loop then re-throws after 3 attempts
+> and the client sees only an uncorrelated `error:` frame. **Reads**: a preset
+> is a *derived* fact — `getRTRTemperatureMode` compares the target temperature
+> against the device's three configured thresholds and returns the matching
+> name or the **empty string** (`property_helper_methods.js`; its own JSDoc
+> says "none" but the code returns `""`), which
+> `datapoint_helper_methods.js` forwards verbatim. So `""`, not `"none"`, is
+> what "no preset" looks like on the wire — it is the common steady state for
+> any manually chosen target. The integration maps `""` to HA's `PRESET_NONE`
+> on read and never writes `"none"` (selecting "None" in HA is a local no-op).
 
 ### Other command types
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -266,6 +266,49 @@ async def test_climate_unknown_preset_noops(hass: HomeAssistant) -> None:
     sp.assert_not_called()
 
 
+async def test_no_active_preset_reads_as_preset_none(hass: HomeAssistant) -> None:
+    """A target matching no threshold reads as PRESET_NONE, not unknown.
+
+    The wire value for that state is the EMPTY STRING — the firmware's
+    ``getRTRTemperatureMode`` returns ``""`` when the target temperature
+    matches none of the frost/eco/comfort thresholds, and never the ``none``
+    its API descriptor advertises. It is the common steady state (any manually
+    chosen target), so mapping it to unknown hid the preset attribute for most
+    real installations.
+    """
+    coordinator = bare_coordinator(hass)
+    assert _climate(coordinator, preset="").preset_mode == "none"
+    # A future descriptor-faithful firmware that reports "none" reads the same.
+    assert _climate(coordinator, preset="none").preset_mode == "none"
+
+
+async def test_set_preset_none_is_a_local_noop(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Selecting the "None" preset sends nothing and raises nothing.
+
+    A preset on this device is a *derived* fact (target temperature equals a
+    configured threshold), so there is no device state a "none" write could
+    set — and the firmware throws for any preset write other than
+    frost/eco/comfort (``SetPointState.publishMode``), which used to surface
+    as a guaranteed 5 s command-confirmation timeout every time a user picked
+    "None". The displayed preset keeps tracking the device's own report.
+    """
+    coordinator = init_integration.runtime_data
+    with patch.object(coordinator, "set_temperature_preset", AsyncMock()) as sp:
+        await hass.services.async_call(
+            "climate",
+            "set_preset_mode",
+            {"entity_id": "climate.living_room", "preset_mode": "none"},
+            blocking=True,
+        )
+    sp.assert_not_called()
+    # The device still reports comfort; the entity must not pretend otherwise.
+    state = hass.states.get("climate.living_room")
+    assert state is not None
+    assert state.attributes["preset_mode"] == "comfort"
+
+
 async def test_set_hvac_mode_never_writes_the_switch_datapoint(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -248,6 +248,62 @@ async def test_stale_device_pruned(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
+async def test_non_poll_dispatches_do_not_consume_the_prune_debounce(
+    hass: HomeAssistant,
+) -> None:
+    """Only real device-list adoptions count toward the prune threshold.
+
+    Scenes broadcasts and the WS-drop notification also run every coordinator
+    listener (``async_update_listeners`` with the SAME device list), and
+    counting those as "polls" shrank the documented
+    ``STALE_DEVICE_PRUNE_MISSES``-poll debounce — a WebSocket flapping while a
+    device was transiently absent from one poll could burn the whole window in
+    seconds. The miss counter must advance only when the coordinator adopts a
+    fresh list (``data_generation``), and pruning at the threshold must still
+    work.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    dev_reg = dr.async_get(hass)
+    stale = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "ghost_device")}
+    )
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=DEVICES),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        coordinator = entry.runtime_data
+
+        # Twice the threshold in bare re-dispatches — what a scene-editing
+        # session or a WS drop/reconnect cycle produces. The ghost is absent
+        # from every one of them, yet none may count as a missed poll.
+        for _ in range(2 * STALE_DEVICE_PRUNE_MISSES):
+            coordinator.async_update_listeners()
+            await hass.async_block_till_done()
+        assert dev_reg.async_get(stale.id) is not None
+
+        # Real adoptions still prune at the documented threshold.
+        for _ in range(STALE_DEVICE_PRUNE_MISSES):
+            coordinator.async_set_updated_data(coordinator.data)
+            await hass.async_block_till_done()
+        assert dev_reg.async_get(stale.id) is None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
 async def test_transiently_missing_device_survives_and_resets(
     hass: HomeAssistant,
 ) -> None:
@@ -1025,6 +1081,33 @@ async def test_area_for_device_resolves_group_name(hass: HomeAssistant) -> None:
     assert (
         coordinator.area_for_device({"id": "d", "parent_groups": ["g2"]}) == "Bathroom"
     )
+
+
+async def test_area_for_device_tolerates_malformed_gateway_json(
+    hass: HomeAssistant,
+) -> None:
+    """Malformed groups/parents must not raise out of the _assign_areas listener.
+
+    Same hardening contract as ``color_temp_range_for_device``: an unhashable
+    group id or parent entry (a list, a dict) raised ``TypeError`` from dict
+    construction/lookup inside a coordinator listener — which would also skip
+    every listener queued after it in the same dispatch.
+    """
+    coordinator = bare_coordinator(hass)
+    coordinator.groups = [
+        "not-a-dict",
+        {"id": ["unhashable"], "name": "Broken"},
+        {"id": True, "name": "Bool"},
+        {"id": "g1", "name": "Kitchen"},
+        {"id": "g1", "name": "Duplicate"},  # first occurrence wins
+        {"id": "g2"},  # no name/label -> unusable
+    ]
+    device = {"id": "d", "parent_groups": [["unhashable"], {"also": "bad"}, "g1"]}
+    assert coordinator.area_for_device(device) == "Kitchen"
+    # A non-list parent_groups is rejected wholesale, not iterated as chars.
+    assert coordinator.area_for_device({"id": "d", "parent_groups": "g1"}) is None
+    # A parent resolving to a nameless group keeps looking / returns None.
+    assert coordinator.area_for_device({"id": "d", "parent_groups": ["g2"]}) is None
 
 
 async def test_color_temp_range_for_device_reads_group_metadata(
@@ -1810,8 +1893,11 @@ async def test_pruning_a_device_is_logged(
         identifiers={(DOMAIN, "ghost_device")},
     )
     with caplog.at_level(logging.WARNING):
+        # Real device-list adoptions: bare async_update_listeners() dispatches
+        # deliberately no longer count toward the miss threshold (see
+        # test_non_poll_dispatches_do_not_consume_the_prune_debounce).
         for _ in range(STALE_DEVICE_PRUNE_MISSES):
-            coordinator.async_update_listeners()
+            coordinator.async_set_updated_data(coordinator.data)
             await hass.async_block_till_done()
 
     assert "removing device" in caplog.text


### PR DESCRIPTION
Implements everything actionable from the maximum-effort repository review (all firmware claims re-verified against the v2.1.3 build in `disk_dump/jung-20260801/sdb2`).

## Bugs fixed

**Thermostat preset \"none\" (climate.py, two bugs).** The gateway's API descriptor advertises `temperature_ctrl_preset ∈ {none, frost, eco, comfort}`, but the v2.1.3 implementation contradicts it in both directions:
- *Write*: `SetPointState.publishMode` throws \"does not set a valid preset\" for anything but frost/eco/comfort — so selecting **None** in HA sent `\"none\"`, the middleware retried 3× and rejected with an uncorrelated `error:` frame, and the user got a guaranteed 5 s \"gateway did not confirm the command\" every time. `PRESET_NONE` is now a local no-op (a preset is a *derived* fact — target temperature equals a configured threshold — so there is nothing a \"none\" write could set).
- *Read*: no-preset reports the **empty string** (`getRTRTemperatureMode` returns `\"\"`; its own JSDoc says \"none\" but the code disagrees), which mapped to unknown — hiding the preset attribute in the common steady state. `\"\"` (and `\"none\"`, for a descriptor-faithful future firmware) now reads as `PRESET_NONE`.

**Pruner debounce counted dispatches, not polls (`__init__.py`).** Scenes broadcasts and WS drop/reconnect notifications also run every coordinator listener with the *same* device list, so the documented 10-poll debounce could be consumed in seconds during a WS flap while a device was transiently absent — and removal is destructive. The pruner now debounces on `coordinator.data_generation`, advanced only by real device-list adoptions (REST poll, `functions` broadcast).

**`area_for_device` hardening (coordinator.py).** An unhashable group id or parent (untrusted gateway JSON) raised `TypeError` out of the `_assign_areas` listener, which would also skip every listener queued after it. Now guarded exactly like its sibling `color_temp_range_for_device`.

## Docs corrected against the current firmware

- gateway-websocket.md / bt-mesh-direct.md cited `btmesh_set_datapoint_service.js`, `btmesh_get_datapoint_service.js`, `btmesh_device_property_service.js` — all **v2.0.0-only**; v2.1.3 refactored into `models/device_states/*State.js`. Citations updated (behaviors themselves re-verified and unchanged); new preset note documents the descriptor-vs-implementation gap.
- bt-mesh-direct.md's \"3× at 15 ms\" retransmission model was v2.0.0; v2.1.3 sends once, ACKed, mutex-serialized, with the 3-attempt/3 s retry in `ip_event_handler`.
- SensorHVAC sentence rewritten: v2.1.3 has an *implemented* read-only `HvacModeState` that still never becomes an API datapoint.
- \"Empty/factory CDB\" claims corrected (the live schema-v6 `res_6/` holds the full ~30-node mesh; only the unnumbered `res/` is factory state), \"1.4.1 build\" → 1.1.0, per-product pid nuance, both dumps + both captures documented.
- CLAUDE.md: evidence root now `jung-20260801/sdb2`, new thermostat-preset protocol fact, cover-travel backlog half-unblocked (`level_move` carries direction in every `level` push), and the **maximum-effort review protocol** section.
- `COMMAND_REPLY_TIMEOUT` comment now also cites the api-server's 6 s IPC bound — new evidence that 5 s is exactly right.

## Tests

New: no-preset `\"\"` → `PRESET_NONE`; selecting None sends nothing and raises nothing (service-level); non-poll dispatches don't consume the prune debounce (2× threshold of bare dispatches, then real adoptions still prune); `area_for_device` malformed-JSON tolerance. `test_pruning_a_device_is_logged` updated — it was driving the pruner with bare dispatches, i.e. relying on the bug.

Gates: 408 passed, 98.64 % branch coverage, `mypy --strict` clean, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhL1ZASQbSzB1mGbBDxhd5