### PR TITLE
Back-port the blueprint's availability guards to the recipe docs

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -342,7 +342,9 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # return value before notifying listeners, so the counter is consistent
         # by dispatch time).
         self.data_generation += 1
-        # `async_set_updated_data` is automatically called with this.
+        # The base class adopts this return value as `self.data` directly (it
+        # does NOT route through `async_set_updated_data`) and then notifies
+        # listeners.
         return response
 
     @callback

--- a/docs/example-button-automation.md
+++ b/docs/example-button-automation.md
@@ -85,7 +85,11 @@ triggers:
     entity_id: event.living_room_r1_b_up
 conditions:
   - condition: template
-    value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
+    value_template: >
+      {{ trigger is defined and trigger.to_state is not none
+         and trigger.from_state is not none
+         and trigger.from_state.state not in ('unavailable', 'unknown')
+         and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 actions:
   - action: light.toggle
     target:
@@ -105,6 +109,15 @@ The `trigger is defined` guard keeps Home Assistant from logging a
 *"'trigger' is undefined"* warning when it renders the condition outside a
 trigger context (e.g. when you save the automation or run it manually).
 
+The `from_state` guard matters just as much: an event entity **restores its
+last state** across a Home Assistant restart, an integration reload and a
+connection loss, so the `unavailable → <restored timestamp>` transition
+re-presents the stored `event_type` — and a button whose last recorded edge
+was `pressed` would toggle your lamp **on its own on every recovery**.
+Requiring a real previous state costs nothing: the first genuine press after
+a recovery still transitions timestamp → timestamp and fires normally. (The
+bundled blueprint applies the same guard.)
+
 > Want it to react to **either** side of the rocker? List both entities under
 > `entity_id:`.
 
@@ -122,8 +135,13 @@ triggers:
   - trigger: state
     entity_id: event.living_room_r1_b_up
 conditions:
+  # Same guards as Recipe 1: a press edge, from a real previous state.
   - condition: template
-    value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
+    value_template: >
+      {{ trigger is defined and trigger.to_state is not none
+         and trigger.from_state is not none
+         and trigger.from_state.state not in ('unavailable', 'unknown')
+         and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 actions:
   - if:
       - condition: state
@@ -179,9 +197,15 @@ triggers:
       - event.living_room_r1_b_up
       - event.living_room_r1_b_down
 conditions:
-  # Only start on a press edge; ignore release ('depressed') state changes.
+  # Only start on a press edge — a real one. The from_state guard stops the
+  # restored-state transition after a restart/reload/connection loss from
+  # firing a phantom gesture (see Recipe 1).
   - condition: template
-    value_template: "{{ trigger is defined and trigger.to_state.attributes.event_type == 'pressed' }}"
+    value_template: >
+      {{ trigger is defined and trigger.to_state is not none
+         and trigger.from_state is not none
+         and trigger.from_state.state not in ('unavailable', 'unknown')
+         and trigger.to_state.attributes.get('event_type') == 'pressed' }}
 actions:
   # Wait up to 2 s for the NEXT event of any kind:
   #   nothing      → still held        → HOLD
@@ -195,11 +219,28 @@ actions:
     timeout: "00:00:02"
     continue_on_timeout: true
   - variables:
+      # Same guard as the trigger condition: a recovery landing inside the
+      # hold window must not read as the second press of a double-click.
       evt: >-
-        {{ wait.trigger.to_state.attributes.event_type
-           if wait.trigger is not none else none }}
+        {{ wait.trigger.to_state.attributes.get('event_type')
+           if (wait.trigger is not none and wait.trigger.to_state is not none
+               and wait.trigger.from_state is not none
+               and wait.trigger.from_state.state not in ('unavailable', 'unknown'))
+           else none }}
+      # The entity dropped mid-gesture (connection loss, reload): the press
+      # was never released as far as we can see, so any gesture is a guess.
+      aborted: >-
+        {{ wait.trigger is not none
+           and (wait.trigger.to_state is none
+                or wait.trigger.to_state.state in ('unavailable', 'unknown')) }}
 
   - choose:
+      # ---- ABORT: the entity went unavailable mid-gesture → do nothing ----
+      - conditions:
+          - "{{ aborted }}"
+        sequence:
+          - stop: Button entity became unavailable mid-gesture
+
       # ---- HOLD: nothing arrived in time → still held ----
       - conditions:
           - "{{ wait.trigger is none }}"
@@ -227,11 +268,15 @@ actions:
         timeout: "00:00:00.4"
         continue_on_timeout: true
       - choose:
-          # A second press arrived → DOUBLE
+          # A second press arrived → DOUBLE (same real-previous-state guard,
+          # so a recovery inside the window can't fake it)
           - conditions:
               - >
                 {{ wait.trigger is not none
-                   and wait.trigger.to_state.attributes.event_type == 'pressed' }}
+                   and wait.trigger.to_state is not none
+                   and wait.trigger.from_state is not none
+                   and wait.trigger.from_state.state not in ('unavailable', 'unknown')
+                   and wait.trigger.to_state.attributes.get('event_type') == 'pressed' }}
             sequence:
               - action: notify.pushover
                 data:


### PR DESCRIPTION
Second run of the maximum-effort review protocol (first convergence run after #183). Two findings survived verification; both are fixed here.

**Recipes 1–3 taught the phantom-press bug the blueprint already fixed.** An event entity restores its last state across a restart, an integration reload and a connection loss, so the `unavailable → <restored timestamp>` transition re-presents the stored `event_type` — and a recipe gating only on `event_type == 'pressed'` fires the user's action on its own on every recovery (worst on a button whose last recorded edge was `pressed`). The blueprint gained `from_state` guards, an `evt` guard and an abort branch for exactly this; the copy-paste recipes in `docs/example-button-automation.md` were never back-ported. They now mirror the blueprint: guarded entry conditions (Recipes 1–3), and for Recipe 3 the guarded `evt` variable, the mid-gesture abort branch, and the guarded double-click window check — plus an explanation paragraph after Recipe 1.

**One stale comment.** `_async_update_data`'s return comment claimed "`async_set_updated_data` is automatically called with this", which the override added in #183 directly contradicts (the base class adopts the return value by direct `self.data` assignment). Corrected.

**Verified clean this run** (details in the review log): all #183 findings confirmed fixed on main; adversarial self-review of the #183 diff; the remaining firmware write paths (switch/brightness/angle/status_led ranges + `Number(values[0].value)` routing); the blueprint itself; all five CI workflows (pinned SHAs, `permissions: {}`, real coverage gate); every checkable README claim; strings.json key coverage; `tools/`, `scripts/`, docker-compose.

Gates: 408 passed, branch coverage gate met, `mypy --strict` clean, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhL1ZASQbSzB1mGbBDxhd5