### PR TITLE
Correct the poll-overlap claim against HA source; add adversarial tests

### DIFF
--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -224,12 +224,19 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # the poll's snapshot before it is adopted — the snapshot was generated
         # before the push, so adopting it as-is briefly reverted the pushed
         # (or command-confirmed) value until the next push or poll healed it.
-        # None outside a poll, so the steady state records nothing. Polls CAN
-        # overlap (DataUpdateCoordinator holds no lock: the 60 s schedule, the
-        # unmatched-push request_refresh and the connect-time resync are
-        # independent), so the dict is shared and refcounted via
-        # `_polls_in_flight` — replacing it per-poll would clobber pushes
-        # recorded for a poll still in flight.
+        # None outside a poll, so the steady state records nothing.
+        #
+        # On the pinned HA, polls can NOT actually overlap: every refresh path
+        # — the 60 s schedule (`_handle_refresh_interval`), a manual
+        # `async_refresh`, and the debounced `async_request_refresh` — takes
+        # the same `_debounced_refresh.async_lock()` before calling
+        # `_async_refresh` (verified in helpers/update_coordinator.py; an
+        # earlier revision of this comment claimed the opposite from reading
+        # `_async_refresh` alone and missing the lock in its callers). The
+        # `_polls_in_flight` refcount and the shared-dict join below are kept
+        # anyway as cheap insurance: the lock is a *private* HA implementation
+        # detail, and if it ever changes, a replaced-per-poll overlay would
+        # silently clobber pushes recorded for a still-running poll.
         self._poll_push_overlay: dict[str, dict[str, Any]] | None = None
         self._polls_in_flight = 0
         # Bounded log of recent raw WebSocket frames for diagnostics.
@@ -320,10 +327,14 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 translation_placeholders={"error": str(err)},
             ) from err
         finally:
-            # Leave the overlay open while a concurrent poll is still fetching
-            # (this poll takes a snapshot copy — applied synchronously below,
-            # so the still-recording dict cannot mutate it mid-walk); the last
-            # poll out closes it. On the failure paths above the collected
+            # Insurance path (see the `_poll_push_overlay` comment in
+            # `__init__`: on the pinned HA every refresh path serializes on
+            # the debouncer lock, so `_polls_in_flight` never actually
+            # exceeds 1): should polls ever overlap again, leave the overlay
+            # open while another poll is still fetching (this poll takes a
+            # snapshot copy — applied synchronously below, so the
+            # still-recording dict cannot mutate it mid-walk); the last poll
+            # out closes it. On the failure paths above the collected
             # overlay is simply discarded: there is no snapshot to correct,
             # and a failed poll leaves `self.data` (with the pushes already
             # merged in) untouched.
@@ -528,8 +539,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         Hardened exactly like ``color_temp_range_for_device`` below: groups and
         parent ids are untrusted gateway JSON, and an unhashable id (a list, a
         dict) must not raise ``TypeError`` out of the ``_assign_areas``
-        coordinator listener — that would also skip every listener queued after
-        it in the same dispatch.
+        coordinator listener. (HA's ``async_update_listeners`` does contain a
+        raising listener — each callback runs in its own try/except and the
+        rest still dispatch — but that containment logs a full traceback for
+        what is merely malformed gateway data, on every refresh, and area
+        assignment for the device silently stops happening.)
         """
         parents = device.get("parent_groups") or []
         if not isinstance(parents, (list, tuple)) or not parents:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import random
 from datetime import timedelta
 from typing import Self
 from unittest.mock import AsyncMock, Mock, patch
@@ -125,11 +126,16 @@ async def test_push_for_a_device_the_poll_discovers_survives_it(
     stored datapoint to merge into — but the poll's snapshot of that new
     device may predate the push just the same.
 
-    This doubles as the overlapping-polls regression: the unmatched push
-    immediately triggers a second refresh (request_refresh, immediate
-    debounce) while the first poll is still fetching. The overlay is shared
-    and refcounted across both; a naive per-poll dict was clobbered by the
-    second poll opening it, losing the recorded push.
+    This also exercises the overlap-insurance path: the unmatched push
+    immediately requests a second refresh (request_refresh, immediate
+    debounce) while the first poll is still fetching. On the pinned HA that
+    second refresh SERIALIZES behind the first (every refresh path takes the
+    coordinator's debouncer lock — see the `_poll_push_overlay` comment), so
+    true overlap cannot occur in production; the shared, refcounted overlay
+    is retained as insurance against that private HA detail changing, and
+    this test drives `_async_update_data` directly enough to keep the join
+    logic honest (a naive per-poll dict was clobbered by the second poll
+    opening it, losing the recorded push).
     """
     coordinator = _coordinator(hass)
     coordinator.data = []  # the device is not known yet
@@ -1022,3 +1028,164 @@ async def test_connect_is_bounded_by_a_timeout(hass: HomeAssistant) -> None:
         pytest.raises(TimeoutError),
     ):
         await coordinator._run_websocket()
+
+
+def _fuzz_frames(rng: random.Random, count: int) -> list[str]:
+    """Adversarial frames: valid JSON of hostile shapes, plus raw junk.
+
+    Deterministic (seeded) so a failure is reproducible. Shapes chosen to bait
+    every parsing hazard the coordinator guards: huge integers (``float()``
+    raises OverflowError on them), NaN/Infinity literals, wrong-typed ids and
+    values (dict/list/bool where strings are expected), unhashable group ids,
+    deep nesting, and non-JSON byte junk.
+    """
+
+    def junk_value(depth: int = 0) -> object:
+        choices = [
+            lambda: rng.randint(-(10**400), 10**400),
+            lambda: rng.random() * 10**308,
+            lambda: "x" * rng.randint(0, 500),
+            lambda: None,
+            lambda: rng.choice([True, False]),
+            lambda: "\x00\U000107ff\U0001f600"[: rng.randint(0, 4)],
+        ]
+        if depth < 3:
+            choices += [
+                lambda: [junk_value(depth + 1) for _ in range(rng.randint(0, 4))],
+                lambda: {
+                    str(junk_value(depth + 1))[:20]: junk_value(depth + 1)
+                    for _ in range(rng.randint(0, 4))
+                },
+            ]
+        return rng.choice(choices)()
+
+    frame_types = [
+        "datapoint",
+        "scene",
+        "scenes",
+        "scenes-new",
+        "scenes-deleted",
+        "groups",
+        "functions",
+        "message",
+        "version",
+        "devices-new",
+        None,
+        junk_value,
+    ]
+    frames: list[str] = []
+    for _ in range(count):
+        kind = rng.choice(frame_types)
+        if callable(kind):
+            kind = kind()
+        frame: dict = {"type": kind, "data": junk_value()}
+        if rng.random() < 0.5:
+            frame["message_id"] = junk_value()
+        if kind == "datapoint" and rng.random() < 0.7:
+            frame["data"] = {
+                "id": rng.choice(["dp1", "", None, 42, ["x"], {"a": 1}]),
+                "type": junk_value(),
+                "values": rng.choice(
+                    [[{"key": junk_value(), "value": junk_value()}], junk_value(), []]
+                ),
+            }
+        try:
+            frames.append(json.dumps(frame, ensure_ascii=False))
+        except (TypeError, ValueError):
+            continue
+    frames += ["", "{", "null", "[1,", '"str"', "\x00\x01", "NaN", "Infinity"]
+    return frames
+
+
+async def test_fuzz_dispatch_never_raises_or_corrupts(hass: HomeAssistant) -> None:
+    """1 500 seeded adversarial frames: dispatch must never raise or corrupt.
+
+    ``_dispatch_text_frame`` is the containment boundary for everything the
+    wire can carry — this drives it with hostile shapes end to end, then
+    checks the coordinator's structural invariants and that the group/area
+    resolvers still cope with whatever the storm stored. The refresh paths
+    are stubbed: unmatched fuzz ids would otherwise fan out thousands of
+    debounced refresh tasks against a real socket.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = [
+        {
+            "id": "dev1",
+            "type": "OnOff",
+            "label": "Dev",
+            "datapoints": [
+                {
+                    "id": "dp1",
+                    "type": "switch",
+                    "values": [{"key": "switch", "value": "0"}],
+                }
+            ],
+        }
+    ]
+    rng = random.Random(20260803)  # noqa: S311 - deterministic fuzz seed
+    with (
+        patch.object(coordinator, "async_request_refresh", AsyncMock()),
+        patch.object(
+            coordinator, "_fetch_devices_from_api", AsyncMock(return_value=[])
+        ),
+    ):
+        for raw in _fuzz_frames(rng, 1500):
+            coordinator._dispatch_text_frame(raw)  # must never raise
+
+    assert coordinator._polls_in_flight == 0
+    assert coordinator._poll_push_overlay is None
+    assert coordinator._pending_replies == {}
+    # The storm may have stored arbitrary garbage in groups/scenes; the
+    # resolvers must still tolerate it together with malformed devices.
+    for device in (
+        {"id": "d", "parent_groups": ["g1", ["x"], {"y": 1}, True]},
+        {"id": "d", "parent_groups": "not-a-list"},
+        {"id": "d"},
+    ):
+        coordinator.area_for_device(device)
+        coordinator.color_temp_range_for_device(device)
+    await coordinator.async_shutdown()
+
+
+async def test_command_futures_race_replies_and_session_drop(
+    hass: HomeAssistant,
+) -> None:
+    """Eight concurrent commands, half confirmed, half killed by a drop.
+
+    Every await must complete promptly with the truthful outcome — no command
+    may hang toward COMMAND_REPLY_TIMEOUT once the session is gone, and the
+    pending-reply registry must end empty either way.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = [
+        {
+            "id": "dev1",
+            "label": "Dev",
+            "datapoints": [{"id": "dp1", "type": "switch", "values": []}],
+        }
+    ]
+    ws = AsyncMock()
+    ws.closed = False
+    coordinator.websocket = ws
+
+    async def run_one() -> str:
+        try:
+            await coordinator.turn_on_switch("dp1")
+        except HomeAssistantError:
+            return "failed"
+        return "ok"
+
+    tasks = [hass.async_create_task(run_one()) for _ in range(8)]
+    await asyncio.sleep(0)
+    for message_id in list(coordinator._pending_replies)[:4]:
+        coordinator._dispatch_text_frame(
+            json.dumps(
+                {"type": "datapoint", "data": {"id": "dp1"}, "message_id": message_id}
+            )
+        )
+    coordinator._fail_pending_replies()
+    outcomes = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+    assert outcomes.count("ok") == 4
+    assert outcomes.count("failed") == 4
+    assert coordinator._pending_replies == {}
+    await coordinator.async_shutdown()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1090,8 +1090,10 @@ async def test_area_for_device_tolerates_malformed_gateway_json(
 
     Same hardening contract as ``color_temp_range_for_device``: an unhashable
     group id or parent entry (a list, a dict) raised ``TypeError`` from dict
-    construction/lookup inside a coordinator listener — which would also skip
-    every listener queued after it in the same dispatch.
+    construction/lookup inside a coordinator listener. HA contains a raising
+    listener (each callback runs in its own try/except; the rest still
+    dispatch), but that logs a full traceback for merely-malformed gateway
+    data on every refresh, and area assignment silently stops for the device.
     """
     coordinator = bare_coordinator(hass)
     coordinator.groups = [


### PR DESCRIPTION
Run 7 of the review protocol, per the "dig deeper into code" request — with a method change: instead of more reading, this run verified the HA-core contracts the coordinator silently relies on against the installed 2026.7.4 source, and **executed** adversarial probes against the coordinator. Both findings are corrections to claims *this repo* made about Home Assistant.

## Finding 1: "Polls CAN overlap" is false on the pinned HA

The coordinator's overlay comment (from #179) claimed `DataUpdateCoordinator` holds no lock, so the 60 s schedule, the unmatched-push `request_refresh` and the connect-time resync could overlap. Reading the installed source shows **every refresh path serializes on the same `_debounced_refresh.async_lock()`**: `_handle_refresh_interval` takes it, `async_refresh` takes it, and the debouncer executes its function under the very same `_execute_lock`. The earlier verification read `_async_refresh` (which is indeed lockless) and missed that every caller locks. It was discovered honestly: this run's interleaving probe **deadlocked** waiting for parallel fetches that can never start.

Consequences, precisely scoped:
- The **push overlay stays fully necessary** — pushes racing the single in-flight poll are real and unchanged.
- The `_polls_in_flight` refcount/join is an **insurance path that cannot run in production**. It is kept — the lock is a private HA implementation detail, and removing tested defensive code buys nothing — but the `__init__` comment, the `finally` comment and the overlap test's docstring now state the truth and label it insurance.
- The backlog's functions-broadcast-vs-poll race is **unaffected**: `async_set_updated_data` is not a refresh path and takes no lock.

## Finding 2: the listener-blast-radius rationale was false

`area_for_device`'s hardening docstring (from #183) claimed a raising listener "would also skip every listener queued after it". HA's `async_update_listeners` runs each callback in its own `try/except` over a copied list — nothing downstream is skipped. The hardening itself stays right for better reasons (a full traceback logged on every refresh for merely-malformed gateway data, and area assignment silently dying for that device); the docstring and its test twin now say that.

## New permanent tests (the probes that earned their keep)

- **`test_fuzz_dispatch_never_raises_or_corrupts`** — 1 500 seeded adversarial frames through `_dispatch_text_frame`: huge integers (`float()` OverflowError bait), `NaN`/`Infinity` literals, wrong-typed ids/values, unhashable group ids, deep nesting, raw non-JSON junk. Must never raise; coordinator invariants and the group/area resolvers must survive whatever the storm stored. Deterministic seed, ~0.1 s.
- **`test_command_futures_race_replies_and_session_drop`** — 8 concurrent commands, 4 confirmed by correlated replies, 4 killed by `_fail_pending_replies`; every await completes promptly with the truthful outcome and the pending registry ends empty.

A third probe (randomized poll/push interleavings) was dropped: its premise — parallel polls — is impossible on the pinned HA, and the committed tests already cover the insurance join.

Gates: 410 passed (35 snapshots), branch-coverage gate met, `mypy --strict` clean, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhL1ZASQbSzB1mGbBDxhd5