### PR TITLE
Show position-only covers as roller shutters, not blinds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,13 @@ JUNG HOME Gateway over its REST API and WebSocket.
   (`CONF_INVERTED_COVERS`), which switches that cover to an identity mapping.
   The single inversion point is `_to_ha`/`_to_device` in `cover.py`. Changing
   the flagged set reloads the entry (options snapshot in the coordinator).
+- **A cover's HA device class comes from its datapoints, not its function type**
+  (`_device_class` in `cover.py`): an `angle` datapoint means slats, so `blind`;
+  position only means a roller shutter, so `shutter`; a cover the user flagged
+  as inverted is an `awning` (that flag wins — an awning has no slats). The
+  gateway calls every cover a `WindowCover`, so there is nothing else to key on.
+  Don't hard-code `blind` again: it gave every roller shutter slat-oriented
+  controls and icons.
 - **Colour temperature is 2000–6000 K, enforced by the gateway**: the
   middleware hard-codes that range and clamps every tunable-white write (see
   the `DEFAULT_MAX_KELVIN` comment in `light.py`). Do not widen it.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ is required.
   gateway.
 - **Sockets** — on/off plus their live meter readings (power, current, …).
 - **Blinds / shutters (covers)** — open/close/stop, position, and slat tilt.
+  Covers that expose slat tilt show up as blinds; position-only ones as roller
+  shutters, with the matching icons and controls.
   **Awnings** report position inverted (their motor mounts the opposite way);
   flag them under Settings → Devices & Services → Jung Home → **Configure**
   and they read correctly, with an awning icon.

--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -6,6 +6,14 @@ Two function types map here:
 - ``PositionAndAngle`` — a ``level`` datapoint plus an ``angle`` datapoint
   (slat tilt).
 
+## Device class
+
+The gateway reports every cover as the same ``WindowCover``, so the HA device
+class is derived from the datapoints present (``_device_class``): an ``angle``
+datapoint means slats — a venetian blind (``blind``) — and position-only means a
+roller shutter (``shutter``). A cover the user flagged as inverted is an awning
+(``awning``); see below.
+
 ## Position convention (confirmed against gateway firmware)
 
 The gateway's ``level`` datapoint is a 0-100 ``%`` value (Generic Level model).
@@ -72,6 +80,26 @@ def _to_ha(device_level: int, *, inverted: bool = False) -> int:
 def _to_device(ha_position: int, *, inverted: bool = False) -> int:
     """Convert a Home Assistant position (% open) to a device level."""
     return ha_position if inverted else 100 - ha_position
+
+
+def _device_class(*, inverted: bool, has_tilt: bool) -> CoverDeviceClass:
+    """Pick the Home Assistant device class for a cover.
+
+    Gated on the datapoints present, never on the function-type name:
+
+    - ``inverted`` — the user flagged this cover as reading percent-*open*,
+      which is the awning (Markise) mounting (see the module docstring). An
+      awning has no slats, so this wins over the tilt check.
+    - ``has_tilt`` — an ``angle`` datapoint means the actuator drives slats, i.e.
+      a venetian blind (Jalousie): ``blind``.
+    - otherwise — position only, which is a roller shutter (Rollladen):
+      ``shutter``. This is the common JUNG case, and the reason the class is not
+      simply hard-coded to ``blind``: HA renders a ``blind`` with slat-oriented
+      controls and icons, so a roller shutter looked like something it is not.
+    """
+    if inverted:
+        return CoverDeviceClass.AWNING
+    return CoverDeviceClass.BLIND if has_tilt else CoverDeviceClass.SHUTTER
 
 
 async def async_setup_entry(
@@ -141,21 +169,15 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
         self._level_datapoint_id = level_datapoint["id"]
         # Awning-style cover whose level is reported percent-open, not -closed.
         self._inverted = inverted
-        # An inverted cover is, by the gateway's own reasoning (see the module
-        # docstring), a Markise/awning: the motor's "extended" is what the user
-        # calls open. Reflect that in the device class so the UI shows an awning
-        # icon and the correct open/close semantics; every other cover stays a
-        # blind. (This is the same per-device flag users already set for the
-        # position inversion, so no extra configuration is introduced.)
-        self._attr_device_class = (
-            CoverDeviceClass.AWNING if inverted else CoverDeviceClass.BLIND
-        )
         self._angle_datapoint = next(
             (dp for dp in device.get("datapoints", []) if dp.get("type") == "angle"),
             None,
         )
         self._angle_datapoint_id = (
             self._angle_datapoint.get("id") if self._angle_datapoint else None
+        )
+        self._attr_device_class = _device_class(
+            inverted=inverted, has_tilt=self._angle_datapoint_id is not None
         )
         self._name = device.get("label", "Jung Cover")
         self._attr_unique_id = stable_unique_id(device, level_datapoint)

--- a/docs/gateway-websocket.md
+++ b/docs/gateway-websocket.md
@@ -151,6 +151,15 @@ Common `values` keys by device type:
 > toggled in the JUNG HOME app. The integration gates HA's tilt features on that
 > datapoint and reloads the entry when a device's datapoint set changes so the
 > capability is rebuilt (see `_register_capability_reload` in `__init__.py`).
+>
+> That datapoint is also the only thing the gateway offers to tell a venetian
+> blind from a roller shutter — the middleware calls both a `WindowCover`, and
+> neither the function `type` nor any datapoint carries a product hint. So the
+> integration derives HA's cover device class from it (`_device_class` in
+> `cover.py`): `angle` present ⇒ slats ⇒ `blind`; position only ⇒ `shutter`; and
+> a cover the user flagged as inverted ⇒ `awning` (that flag wins, an awning
+> having no slats). Hard-coding `blind`, as the integration first did, gave
+> every roller shutter slat-oriented controls and icons in the HA UI.
 
 > **A Thermostat's `switch` datapoint is *not* the regulator's on/off — and a room
 > regulator has no on/off at all.** The middleware builds a `Thermostat` from

--- a/tests/snapshots/test_cover.ambr
+++ b/tests/snapshots/test_cover.ambr
@@ -79,7 +79,7 @@
     'object_id_base': None,
     'options': dict({
     }),
-    'original_device_class': <CoverDeviceClass.BLIND: 'blind'>,
+    'original_device_class': <CoverDeviceClass.SHUTTER: 'shutter'>,
     'original_icon': None,
     'original_name': None,
     'platform': 'junghome',
@@ -95,7 +95,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'blind',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'shutter',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Shade',
       <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <CoverEntityFeature: 15>,

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -108,13 +108,53 @@ async def test_cover_inverted_awning_position(hass: HomeAssistant) -> None:
     assert extended.is_closed is False
 
 
-async def test_cover_normal_device_class_is_blind(hass: HomeAssistant) -> None:
-    """A non-inverted cover keeps the blind device class."""
+async def test_cover_position_only_device_class_is_shutter(
+    hass: HomeAssistant,
+) -> None:
+    """A position-only cover is a roller shutter, not a blind.
+
+    No ``angle`` datapoint means no slats, so HA must not render it with the
+    slat-oriented blind icon/controls.
+    """
     coordinator = bare_coordinator(hass)
     dps = [{"id": "b-1", "type": "level", "values": [{"key": "level", "value": "0"}]}]
     device = {"id": "b", "type": "Position", "label": "Shutter", "datapoints": dps}
     cover = JungHomeCover(coordinator, device, dps[0])
+    assert cover.device_class == CoverDeviceClass.SHUTTER
+
+
+async def test_cover_with_tilt_device_class_is_blind(hass: HomeAssistant) -> None:
+    """A cover with an ``angle`` datapoint drives slats, so it stays a blind."""
+    coordinator = bare_coordinator(hass)
+    dps = [
+        {"id": "b-1", "type": "level", "values": [{"key": "level", "value": "0"}]},
+        {"id": "b-2", "type": "angle", "values": [{"key": "angle", "value": "0"}]},
+    ]
+    device = {
+        "id": "b",
+        "type": "PositionAndAngle",
+        "label": "Venetian",
+        "datapoints": dps,
+    }
+    cover = JungHomeCover(coordinator, device, dps[0])
     assert cover.device_class == CoverDeviceClass.BLIND
+
+
+async def test_cover_inverted_with_tilt_is_still_awning(hass: HomeAssistant) -> None:
+    """The inverted (awning) flag wins over the tilt-derived blind class."""
+    coordinator = bare_coordinator(hass)
+    dps = [
+        {"id": "b-1", "type": "level", "values": [{"key": "level", "value": "0"}]},
+        {"id": "b-2", "type": "angle", "values": [{"key": "angle", "value": "0"}]},
+    ]
+    device = {
+        "id": "b",
+        "type": "PositionAndAngle",
+        "label": "Awning",
+        "datapoints": dps,
+    }
+    cover = JungHomeCover(coordinator, device, dps[0], inverted=True)
+    assert cover.device_class == CoverDeviceClass.AWNING
 
 
 async def test_cover_inverted_commands_pass_through(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## The bug

Every non-inverted cover was hard-coded to `CoverDeviceClass.BLIND`, so a roller shutter (Rollladen) showed up in the HA UI with the blind icon and slat-oriented controls.

## The fix

A new `_device_class()` in `cover.py` derives the class from the datapoints present — the same rule the platform already uses for its capabilities, rather than the function-type name:

| cover | device class |
|---|---|
| user-flagged inverted (awning) | `awning` — wins, an awning has no slats |
| has an `angle` datapoint | `blind` (venetian) |
| position only | `shutter` (roller shutter) |

That is the only signal available. Per `docs/gateway-websocket.md`, the middleware reports both kinds as the same `WindowCover`, and the `angle` datapoint appears only when the slat channel is visible (`device.states.angle?.profile.visible === true`) — nothing else on the wire distinguishes a shutter from a blind.

It also inherits the existing runtime-change handling: `_register_capability_reload` already reloads the entry when a device's datapoint set changes, so a slat channel toggled in the JUNG HOME app rebuilds the device class along with the tilt features.

Existing entities pick the new class up on the next start (HA refreshes `original_device_class` when the entity is added); a user's manual device-class override in the UI is unaffected.

## Verification

410 passed, 98.64 % coverage, `ruff` and `mypy --strict` clean.

Three new tests cover the shutter, blind and inverted-with-tilt cases. The snapshot diff is only the two `blind` → `shutter` lines for the position-only `cover.kitchen_shade` — `unique_id`s unchanged, and `cover.bedroom_blind` (which has an `angle` datapoint) stays a blind.

Note on the local run: the pinned CI env needs Python 3.14.2 and this container tops out at 3.13, so the suite ran on a 3.14.0rc2 venv, which needed a throwaway `typing.ByteString` shim for the pinned mashumaro. The shim was local to that venv and is not part of this diff.

## Docs

Updated the cover bullets in `README.md` and `CLAUDE.md`, and extended the slat-tilt note in `docs/gateway-websocket.md` to record that the `angle` datapoint is also the device-class discriminator.
