### PR TITLE
Address PR #192 review leftovers: placement retry, slug guard, parse containment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,10 +161,11 @@ instead of re-deriving:
   by slug* does not — the second overwrites the first each pass and looks like
   a changed device. This exact bug produced endless reload loops twice (the
   capability watcher, then `_reload_if_device_ids_changed` on list-order
-  changes). Guard every such map with `duplicate_slugs()`; its two current
-  users are `_register_capability_reload` and `_reload_if_device_ids_changed`
-  (the device-identifier migration guards the same hazard differently — a
-  registry `async_get_device` clash check before each write).
+  changes). Guard every such map with `duplicate_slugs()`; its three current
+  users are `_register_capability_reload`, `_reload_if_device_ids_changed`
+  and `_make_area_assigner` (the device-identifier migration guards the same
+  hazard differently — a registry `async_get_device` clash check before each
+  write).
 - **Entity naming.** `_attr_has_entity_name = True` with a short `_attr_name`
   (`None` for the device's main feature). The **device** carries the label;
   baking it into the entity name makes HA compose it twice (the old

--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -286,6 +286,14 @@ def _make_area_assigner(
     # devices on the next adoption — the connect-time refresh or, worst case,
     # the next 60 s poll — instead of on the next unrelated push.
     last_generation: int | None = None
+    # Adoptions granted their one follow-up walk (see the retry note at the
+    # end of `_assign_areas`): a device that arrives *in* an adoption has no
+    # registry entry during any walk the adoption itself can trigger — not
+    # this listener's (discovery has only *scheduled* entity creation), and
+    # not the one from the refresh HA core requests while adding the entity
+    # either (`update_before_add` runs that BEFORE registering the device) —
+    # so without a retry the placement would wait out the next 60 s poll.
+    retried_generation: int | None = None
 
     @callback
     def _assign_areas() -> None:
@@ -304,27 +312,40 @@ def _make_area_assigner(
         Area lookup is by name, so a group matching an existing area links to
         it rather than creating a duplicate.
         """
-        nonlocal last_generation
-        if coordinator.data_generation == last_generation:
+        nonlocal last_generation, retried_generation
+        generation = coordinator.data_generation
+        if generation == last_generation:
             return  # same device list as last time; nothing new to place
-        last_generation = coordinator.data_generation
         if not coordinator.data:
+            last_generation = generation
             return  # nothing to place on an empty/failed poll
+        # Two labels that slug identically share ONE registry device ("the
+        # second loses"), so which room such a slug would map to below depends
+        # on list order — meaningless either way. Skip colliding slugs rather
+        # than place the shared device in an arbitrary one of the two rooms;
+        # the capability watcher already warns the user about the collision.
+        collisions = duplicate_slugs(coordinator.data)
         area_by_slug = {
-            device_slug(device): room
+            slug: room
             for device in coordinator.data
             if (room := coordinator.area_for_device(device))
+            and (slug := device_slug(device)) not in collisions
         }
         if not area_by_slug:
+            last_generation = generation
             return  # gateway reports no rooms (or none could be resolved)
 
         considered = set(entry.data.get(DATA_AREA_ASSIGNED, []))
         dev_reg = dr.async_get(hass)
         area_reg = ar.async_get(hass)
         newly_considered: set[str] = set()
+        registered_slugs: set[str] = set()
         for device_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
             for domain, slug in device_entry.identifiers:
-                if domain != DOMAIN or slug in considered:
+                if domain != DOMAIN:
+                    continue
+                registered_slugs.add(slug)
+                if slug in considered:
                     continue
                 area_name = area_by_slug.get(slug)
                 if area_name is None:
@@ -335,6 +356,22 @@ def _make_area_assigner(
                 # Recorded either way: a device the user had already placed is
                 # settled too, and must not be auto-placed if later cleared.
                 newly_considered.add(slug)
+
+        # A placeable device with no registry entry yet is one that arrived in
+        # this very adoption: no walk the adoption itself can trigger sees it
+        # registered (see the factory comment above). Leave the generation
+        # unrecorded once, so the next dispatch — typically the new device's
+        # own first pushes, seconds away — retries the walk instead of waiting
+        # out the 60 s poll. Only once, though: a grouped device no platform
+        # supports never gets a registry entry, and retrying it forever would
+        # re-open the per-push walk this guard exists to close.
+        if (
+            set(area_by_slug) - considered - registered_slugs
+            and generation != retried_generation
+        ):
+            retried_generation = generation
+        else:
+            last_generation = generation
 
         if newly_considered:
             # A data-only update; the entry's update listener ignores it (it
@@ -372,8 +409,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> 
     # Expose the coordinator as runtime data for the platforms.
     entry.runtime_data = coordinator
 
-    # Fetch room groups before the platforms create entities, so each device can
-    # suggest its area at creation time. Best-effort: never blocks setup.
+    # Fetch room groups before the platforms create entities, so the area
+    # assigner's first pass (right after the platforms are set up below) can
+    # place devices immediately. Best-effort: never blocks setup.
     await coordinator.async_fetch_groups()
     # Same reasoning for scenes: they otherwise arrive only in the WebSocket
     # handshake, which happens after the platforms are set up.

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -827,7 +827,12 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # runs for every frame a chatty gateway pushes).
         try:
             data = json.loads(raw)
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, RecursionError) as e:
+            # RecursionError included: the C parser overflows the stack on
+            # absurdly nested input (~1M brackets on CPython 3.14), and this
+            # except is all that stands between the parse and the receive
+            # loop — "a malformed frame must never tear down a healthy
+            # session" has to hold for that frame too.
             # Still recorded for diagnostics — the rolling log should show
             # exactly what the gateway sent — just never keyed by type.
             self._log_ws_frame(raw, None)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1661,6 +1661,190 @@ async def test_area_placement_runs_only_on_device_list_adoptions(
         await hass.async_block_till_done()
 
 
+async def test_runtime_added_device_is_placed_on_the_next_dispatch(
+    hass: HomeAssistant,
+) -> None:
+    """A device arriving in an adoption is placed on the NEXT dispatch.
+
+    No walk the adoption itself triggers can place the new device, because its
+    registry entry does not exist yet during any of them: the adoption
+    dispatch runs the assigner before the platforms' scheduled entity-add task,
+    and the refresh HA core requests while adding the entity
+    (``update_before_add`` → ``async_device_update`` →
+    ``async_request_refresh``) runs BEFORE the device is registered. The
+    assigner therefore leaves the generation unrecorded once, so the very next
+    dispatch — typically the new device's own first value pushes, seconds
+    away — retries the walk and places it, instead of waiting out the 60 s
+    poll.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    devices_mock = AsyncMock(return_value=[])
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_fetch_devices_from_api", devices_mock
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=[{"id": "grp-living", "name": "Living Room"}]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        coordinator = entry.runtime_data
+
+        # The gateway now reports a new device: a `functions` broadcast adopts
+        # it, and the entity-add-triggered refresh (which polls) agrees. Both
+        # of those adoptions walk before the device's registry entry exists —
+        # only the armed retry, consumed by a later dispatch, can place it.
+        devices_mock.return_value = [_grouped_lamp()]
+        coordinator.async_set_updated_data([_grouped_lamp()])
+        await hass.async_block_till_done()
+
+        # A push-style dispatch (no new adoption) is all it takes.
+        coordinator.async_update_listeners()
+        await hass.async_block_till_done()
+        dev_reg = dr.async_get(hass)
+        device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+        assert device_entry is not None
+        assert device_entry.area_id is not None
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_area_placement_retry_is_bounded_for_unplaceable_devices(
+    hass: HomeAssistant,
+) -> None:
+    """The follow-up walk happens exactly once per adoption.
+
+    A grouped device no platform supports never gets a registry entry, so its
+    placement can never succeed. The retry must not keep the per-push walk
+    open for it: one follow-up dispatch re-walks, then the guard settles until
+    the next adoption.
+    """
+    unsupported = {
+        "id": "idmyst",
+        "type": "Mystery",
+        "label": "Mystery Box",
+        "parent_groups": ["grp-living"],
+        "datapoints": [],
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(return_value=[{"id": "grp-living", "name": "Living Room"}]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        coordinator = entry.runtime_data
+
+        # No platform claims a "Mystery" device, so no entity-add refresh
+        # follows this adoption and the retry stays armed for the next
+        # dispatch.
+        coordinator.async_set_updated_data([unsupported])
+        await hass.async_block_till_done()
+
+        # The walk calls `area_for_device` once per device, so counting those
+        # calls counts the walks.
+        with patch.object(
+            coordinator, "area_for_device", wraps=coordinator.area_for_device
+        ) as walked:
+            coordinator.async_update_listeners()  # the one follow-up walk
+            await hass.async_block_till_done()
+            assert walked.call_count == 1
+            coordinator.async_update_listeners()  # settled: no walk
+            coordinator.async_update_listeners()
+            await hass.async_block_till_done()
+            assert walked.call_count == 1
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_area_placement_skips_colliding_slugs(
+    hass: HomeAssistant,
+) -> None:
+    """A slug shared by two devices is never placed; unique slugs still are.
+
+    Two labels that slug identically share ONE registry device, so which room
+    the shared slug would map to depends on device-list order — an arbitrary
+    choice between the two devices' rooms. The assigner skips colliding slugs
+    (mirroring the capability watcher's `duplicate_slugs` guard) instead of
+    placing the shared device in whichever room happened to come last.
+    """
+    lamp_a = _grouped_lamp()
+    lamp_b = _grouped_lamp()
+    lamp_b["id"] = "idlamp2"
+    lamp_b["label"] = "Sofa-Lamp"  # slugify -> sofa_lamp, same as lamp_a
+    lamp_b["parent_groups"] = ["grp-kitchen"]
+    desk = _grouped_lamp()
+    desk["id"] = "idlamp3"
+    desk["label"] = "Desk Lamp"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.2.3.4",
+        data={CONF_HOST: "1.2.3.4", CONF_TOKEN: "tok"},
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_devices_from_api",
+            AsyncMock(return_value=[lamp_a, lamp_b, desk]),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator,
+            "_fetch_groups_from_api",
+            AsyncMock(
+                return_value=[
+                    {"id": "grp-living", "name": "Living Room"},
+                    {"id": "grp-kitchen", "name": "Kitchen"},
+                ]
+            ),
+        ),
+        patch.object(
+            JungHomeDataUpdateCoordinator, "_run_websocket", _fake_run_websocket
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        dev_reg = dr.async_get(hass)
+        shared = dev_reg.async_get_device(identifiers={(DOMAIN, "sofa_lamp")})
+        assert shared is not None
+        assert shared.area_id is None  # ambiguous room: never auto-placed
+        placed = dev_reg.async_get_device(identifiers={(DOMAIN, "desk_lamp")})
+        assert placed.area_id is not None  # unique slugs are unaffected
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+
 async def test_gateway_connectivity_sensor(
     hass: HomeAssistant, init_integration
 ) -> None:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -531,3 +531,22 @@ async def test_dispatch_logs_unparseable_and_untyped_frames(
     coordinator._dispatch_text_frame('{"type": 42, "data": {}}')
     assert list(coordinator.ws_frame_log) == ["not json", '{"type": 42, "data": {}}']
     assert coordinator.ws_last_frame_by_type == {}
+
+
+async def test_dispatch_contains_absurdly_nested_frames(
+    hass: HomeAssistant,
+) -> None:
+    """A frame that overflows the JSON parser's stack must not escape dispatch.
+
+    CPython's C parser raises ``RecursionError`` (not ``JSONDecodeError``) on
+    absurdly nested input — around a million brackets on 3.14. An uncaught
+    escape here would propagate into the receive loop and tear down a healthy
+    session, violating "a malformed frame must never tear down a healthy
+    session"; the frame must instead land (truncated) in the rolling
+    diagnostics log like any other unparseable frame.
+    """
+    coordinator = bare_coordinator(hass)
+    depth = 5_000_000  # far beyond any thread's stack, so it overflows everywhere
+    coordinator._dispatch_text_frame("[" * depth + "]" * depth)  # must not raise
+    assert coordinator.ws_frame_log[-1].endswith("…[truncated]")
+    assert coordinator.ws_last_frame_by_type == {}


### PR DESCRIPTION
Follow-ups from the maximum-effort review of #192 (merged). Three small behavioral fixes and a comment correction, each pinned by a test that fails with its guard removed.

## Changes

**Runtime-added devices get their area back in seconds, not minutes.** With the generation guard from #192, no walk a device-adding adoption can trigger ever sees the new device registered: the adoption dispatch runs the assigner before the platforms' *scheduled* entity-add task, and the refresh HA core requests while adding the entity (`update_before_add` → `async_device_update` → `async_request_refresh`) polls **before** the device registry entry is written — verified by stack-trace probe against the pinned HA 2026.7.4. So placement silently waited out the next 60 s poll (pre-#192, any push placed it within seconds). The assigner now leaves an adoption's generation unrecorded once when it saw a placeable-but-unregistered slug, so the next dispatch — typically the new device's own first value pushes — retries the walk and places it. Bounded to one follow-up walk per adoption: a grouped device no platform supports (never registered) cannot re-open the per-push walk the guard exists to close.

**`duplicate_slugs` guard on the assigner's room map.** `area_by_slug` is keyed by device slug; two labels that slug identically share one registry device, so which room the shared slug mapped to depended on device-list order. Colliding slugs are now skipped — no arbitrary placement — mirroring the capability watcher's guard (which already warns the user about the collision). CLAUDE.md's guard-users list updated to three.

**`RecursionError` contained in the frame parse.** CPython's C JSON parser raises `RecursionError`, not `JSONDecodeError`, on absurdly nested input (~1M brackets on 3.14.7, verified by probe). It escaped `_dispatch_text_frame` into the receive loop — tearing down a healthy session for a malformed frame, violating the documented containment invariant. (Pre-existing before #192 too, via the old frame logger's equally narrow except.) Such a frame now lands truncated in the rolling diagnostics log like any other unparseable frame.

**Stale comment fixed.** The setup comment claimed groups are fetched early "so each device can suggest its area at creation time" — no `suggested_area` mechanism exists; the early fetch feeds the area assigner's first pass right after platform setup.

## Tests

Four new tests (runtime-added placement via retry, retry boundedness, colliding-slug skip, nested-frame containment) — each verified to FAIL with its corresponding guard neutered and pass with it in place.

420 passed, 35 snapshots unchanged, coverage 99 % (gate 95 %), `mypy --strict` and ruff clean on Python 3.14.7 / HA 2026.7.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)