### PR TITLE
Skip state writes for other devices' pushes while shown available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,18 @@ instead of re-deriving:
   `ws_connected` (a stale-True socket flag froze energy readings — issue
   #120); controllable entities additionally require the live WS because
   commands only travel over it.
+- **Entities skip state writes for other devices' pushes — but only while
+  already shown available.** A per-datapoint push dispatch used to write
+  every entity of the entry; `JungHomeEntity._skip_foreign_device_push`
+  (fed by `coordinator.pushed_device_id`) skips entities of other devices.
+  Two load-bearing details: the scope is the *device*, not the entity's
+  stored datapoint ids (climate reads its ambient temperature from a sibling
+  `quantity` datapoint it holds no id for), and the skip is forbidden while
+  the state machine shows the entity unavailable — a push proves the gateway
+  alive, so it must be the thing that flips a post-failed-poll "unavailable"
+  back. Everything without a push marker fails open, and the connectivity
+  sensor/scenes (state not derived from device datapoints) don't inherit the
+  helper.
 - **Commands await the gateway's confirmation, not fire-and-forget.** Every
   datapoint set (`_send_datapoint_command` in `coordinator.py`) is tagged with
   a `message_id`; a successful set is answered with a `datapoint` reply

--- a/custom_components/junghome/binary_sensor.py
+++ b/custom_components/junghome/binary_sensor.py
@@ -116,6 +116,8 @@ class JungHomePresence(JungHomeEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this detector changed
         datapoint = self._find_datapoint(self._datapoint_id)
         if datapoint:
             self._is_on = self._get_state_from_datapoint(datapoint)

--- a/custom_components/junghome/climate.py
+++ b/custom_components/junghome/climate.py
@@ -245,6 +245,8 @@ class JungHomeClimate(JungHomeEntity, ClimateEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this thermostat changed
         device = self._current_device()
         if device is None:
             self.async_write_ha_state()

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -190,6 +190,13 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # set only for the duration of one synchronous `async_update_listeners`
         # dispatch, so REST re-reads (which leave it None) never fire events.
         self.pushed_datapoint_id: str | None = None
+        # The id of the device that owns that datapoint (same one-dispatch
+        # lifetime). Entities compare it against their own device to skip the
+        # state write for a push that cannot concern them — see
+        # ``JungHomeEntity._skip_foreign_device_push`` for the full contract.
+        # None when the owning device carries no id, which entities treat as
+        # "don't skip" (fail open).
+        self.pushed_device_id: str | None = None
         # Gateway firmware version, reported by the WebSocket "version" frame.
         self.gateway_version: str | None = None
         # Scene list, populated from the WebSocket `scenes` broadcasts (full list
@@ -1003,85 +1010,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 # spurious "no matching datapoint" warning.
                 self._handle_scene_recall(data)
                 return
-            datapoint_id = data.get("id")
-            if not datapoint_id:
-                _LOGGER.error(
-                    "Received WebSocket message without datapoint_id: %s", message
-                )
-                return
-            if self._poll_push_overlay is not None:
-                # A REST poll is in flight; record this push so the poll's
-                # (older) snapshot cannot revert it. Recorded before the match
-                # loop below on purpose: an unmatched push usually belongs to a
-                # device the in-flight poll is about to discover, and its
-                # snapshot values may predate this push just the same.
-                overlay = self._poll_push_overlay.setdefault(datapoint_id, {})
-                for key, value in data.items():
-                    if key != "id":
-                        overlay[key] = value
-            updated = False
-            for device in self.data or []:
-                for datapoint in device.get("datapoints", []):
-                    if datapoint.get("id") == datapoint_id:
-                        # Merge the pushed keys into the stored datapoint. The push
-                        # carries arbitrary keys (typically `values`), so mutate via
-                        # a dict view rather than the TypedDict.
-                        dp_dict = cast("dict[str, Any]", datapoint)
-                        for key, value in data.items():
-                            if key != "id":
-                                dp_dict[key] = value
-                        _LOGGER.debug(
-                            "Updated datapoint for device %s: %s",
-                            device.get("id"),
-                            datapoint,
-                        )
-                        updated = True
-                        break
-                if updated:
-                    break
-            if updated:
-                # Flag the pushed datapoint for the duration of this dispatch so
-                # event entities fire on the push itself. The dispatch below
-                # notifies listeners synchronously, so the flag is valid for
-                # exactly this push and is cleared immediately afterwards; REST
-                # polls never set it and therefore never fire phantom events.
-                self.pushed_datapoint_id = datapoint_id
-                try:
-                    # Deliberately NOT `async_set_updated_data`: that helper
-                    # cancels the scheduled refresh and re-arms it a full
-                    # `update_interval` from now, so a gateway that pushes more
-                    # often than once a minute would defer the REST poll forever.
-                    # The poll is the only thing that discovers new devices,
-                    # prunes removed ones, assigns areas and detects gateway id
-                    # churn, so starving it silently breaks all four.
-                    #
-                    # The merge above mutated the dicts already in `self.data`, so
-                    # there is no new object to store. Setting `last_update_success`
-                    # keeps the availability contract documented in `entity.py`
-                    # (a push counts as proof the gateway is alive), and
-                    # `async_update_listeners` gives the same synchronous
-                    # notification the helper would have.
-                    self.last_update_success = True
-                    self.async_update_listeners()
-                finally:
-                    self.pushed_datapoint_id = None
-            elif datapoint_id not in self._unmatched_push_ids:
-                # An unmatched push usually means a device was just added in
-                # the app and is pushing before the next poll has discovered
-                # it. Request a (debounced) refresh on the FIRST sighting of an
-                # unknown id — discovery then lands in seconds instead of up
-                # to a minute — and warn once per id rather than per frame (a
-                # new device pushing at 1 Hz used to warn 60 times before the
-                # poll caught up).
-                self._unmatched_push_ids.add(datapoint_id)
-                _LOGGER.warning(
-                    "No matching datapoint found for id %s; requesting a "
-                    "refresh (a device may have just been added)",
-                    datapoint_id,
-                )
-                self.hass.async_create_task(self.async_request_refresh())
-            else:
-                _LOGGER.debug("No matching datapoint found for id %s", datapoint_id)
+            self._handle_datapoint_push(message, data)
         elif isinstance(data, list):
             if msg_type in ("scenes", "scenes-new", "scenes-deleted"):
                 self._handle_scenes_broadcast(msg_type, data)
@@ -1098,6 +1027,100 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             _LOGGER.warning(
                 "Received WebSocket message with unknown data type: %s", message
             )
+
+    def _handle_datapoint_push(
+        self, message: dict[str, Any], data: dict[str, Any]
+    ) -> None:
+        """Merge one pushed datapoint into the stored data and notify listeners.
+
+        Split out of ``_handle_websocket_message`` so that method stays a pure
+        frame router; the behaviour is unchanged.
+        """
+        datapoint_id = data.get("id")
+        if not datapoint_id:
+            _LOGGER.error(
+                "Received WebSocket message without datapoint_id: %s", message
+            )
+            return
+        if self._poll_push_overlay is not None:
+            # A REST poll is in flight; record this push so the poll's
+            # (older) snapshot cannot revert it. Recorded before the match
+            # loop below on purpose: an unmatched push usually belongs to a
+            # device the in-flight poll is about to discover, and its
+            # snapshot values may predate this push just the same.
+            overlay = self._poll_push_overlay.setdefault(datapoint_id, {})
+            for key, value in data.items():
+                if key != "id":
+                    overlay[key] = value
+        updated = False
+        pushed_device_id: str | None = None
+        for device in self.data or []:
+            for datapoint in device.get("datapoints", []):
+                if datapoint.get("id") == datapoint_id:
+                    # Merge the pushed keys into the stored datapoint. The push
+                    # carries arbitrary keys (typically `values`), so mutate via
+                    # a dict view rather than the TypedDict.
+                    dp_dict = cast("dict[str, Any]", datapoint)
+                    for key, value in data.items():
+                        if key != "id":
+                            dp_dict[key] = value
+                    _LOGGER.debug(
+                        "Updated datapoint for device %s: %s",
+                        device.get("id"),
+                        datapoint,
+                    )
+                    pushed_device_id = device.get("id")
+                    updated = True
+                    break
+            if updated:
+                break
+        if updated:
+            # Flag the pushed datapoint (and the device that owns it) for
+            # the duration of this dispatch so event entities fire on the
+            # push itself and unrelated entities can skip their write. The
+            # dispatch below notifies listeners synchronously, so the flags
+            # are valid for exactly this push and are cleared immediately
+            # afterwards; REST polls never set them and therefore never
+            # fire phantom events or suppress a full re-read.
+            self.pushed_datapoint_id = datapoint_id
+            self.pushed_device_id = pushed_device_id
+            try:
+                # Deliberately NOT `async_set_updated_data`: that helper
+                # cancels the scheduled refresh and re-arms it a full
+                # `update_interval` from now, so a gateway that pushes more
+                # often than once a minute would defer the REST poll forever.
+                # The poll is the only thing that discovers new devices,
+                # prunes removed ones, assigns areas and detects gateway id
+                # churn, so starving it silently breaks all four.
+                #
+                # The merge above mutated the dicts already in `self.data`, so
+                # there is no new object to store. Setting `last_update_success`
+                # keeps the availability contract documented in `entity.py`
+                # (a push counts as proof the gateway is alive), and
+                # `async_update_listeners` gives the same synchronous
+                # notification the helper would have.
+                self.last_update_success = True
+                self.async_update_listeners()
+            finally:
+                self.pushed_datapoint_id = None
+                self.pushed_device_id = None
+        elif datapoint_id not in self._unmatched_push_ids:
+            # An unmatched push usually means a device was just added in
+            # the app and is pushing before the next poll has discovered
+            # it. Request a (debounced) refresh on the FIRST sighting of an
+            # unknown id — discovery then lands in seconds instead of up
+            # to a minute — and warn once per id rather than per frame (a
+            # new device pushing at 1 Hz used to warn 60 times before the
+            # poll caught up).
+            self._unmatched_push_ids.add(datapoint_id)
+            _LOGGER.warning(
+                "No matching datapoint found for id %s; requesting a "
+                "refresh (a device may have just been added)",
+                datapoint_id,
+            )
+            self.hass.async_create_task(self.async_request_refresh())
+        else:
+            _LOGGER.debug("No matching datapoint found for id %s", datapoint_id)
 
     def _handle_functions_broadcast(self, data: list[Any]) -> None:
         """Adopt a pushed ``functions`` list as if a REST poll had returned it.

--- a/custom_components/junghome/cover.py
+++ b/custom_components/junghome/cover.py
@@ -272,6 +272,8 @@ class JungHomeCover(JungHomeEntity, CoverEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this cover changed
         # Refresh position/tilt only from their own datapoint's push (see
         # JungHomeEntity._should_refresh) so a level echo can't momentarily reset
         # tilt to the stale snapshot value, and vice versa.

--- a/custom_components/junghome/entity.py
+++ b/custom_components/junghome/entity.py
@@ -13,6 +13,8 @@ their own ``_handle_coordinator_update`` write logic (which intentionally
 differs between platforms).
 """
 
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -151,3 +153,45 @@ class JungHomeEntity(CoordinatorEntity[JungHomeDataUpdateCoordinator]):
         """
         pushed = self.coordinator.pushed_datapoint_id
         return pushed is None or pushed == datapoint_id
+
+    @callback
+    def _skip_foreign_device_push(self) -> bool:
+        """Whether this dispatch is another device's push and the write can be skipped.
+
+        Every coordinator dispatch notifies every entity, so on a gateway with
+        chatty per-datapoint pushes (a socket reporting power once a second)
+        each frame used to trigger a state-machine write for EVERY entity of
+        the entry — N writes for one changed value. A per-datapoint push
+        mutates exactly one datapoint dict of exactly one device, so entities
+        of every *other* device can skip their write — under one guard:
+
+        **Availability.** During a push dispatch the coordinator has just set
+        ``last_update_success = True``, and ``ws_connected`` is necessarily
+        True (the push arrived on the live session, and the flag is only
+        cleared when that session ends) — so ``available`` computes True for
+        every entity of this entry, controllable or not. A push therefore can
+        never make an entity UNavailable, but it can make one available again
+        (a failed poll marked everything unavailable; the push proves the
+        gateway alive). The skip is allowed only while the state machine
+        already shows this entity as available; an entity currently
+        unavailable — or not yet written at all — always writes, so the
+        recovery propagates on this very dispatch instead of waiting for the
+        next poll.
+
+        Scoped to the *device*, not to a set of the entity's own datapoint
+        ids, on purpose: entities read sibling datapoints beyond the ones
+        whose ids they store (climate refreshes its ambient temperature from
+        the device's ``quantity`` datapoint on every update), so an id-set
+        scope would wrongly starve those. Everything else fails open: poll,
+        ``functions``-broadcast, scenes and WS-drop dispatches carry no push
+        marker, and a pushed device without an ``id`` sets no marker either —
+        in all those cases every entity writes exactly as before. Entities
+        whose state is NOT a pure function of their device's datapoints plus
+        availability (the gateway connectivity sensor, scenes) do not inherit
+        from this base and are untouched.
+        """
+        pushed_device = self.coordinator.pushed_device_id
+        if pushed_device is None or pushed_device == self._device.get("id"):
+            return False
+        state = self.hass.states.get(self.entity_id)
+        return state is not None and state.state != STATE_UNAVAILABLE

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -103,10 +103,16 @@ class JungHomeEventEntity(JungHomeEntity, EventEntity):
         edge fires exactly once — including rapid same-value taps that a level
         diff would coalesce — and a re-read never fires a phantom press.
         """
+        # Another device's push cannot be an edge on this button, and the write
+        # below would only re-publish the identical state (skipped while the
+        # entity is already shown available — see the base helper). Pushes for
+        # THIS device (its own edges, or its status LED) fall through.
+        if self._skip_foreign_device_push():
+            return
         # Fire only on a genuine WebSocket push for THIS datapoint. REST re-reads
-        # (marker is None) and pushes for other datapoints skip the fire but still
-        # write state below, so availability tracks the gateway connection without
-        # ever emitting a phantom press.
+        # (marker is None) and pushes for sibling datapoints skip the fire but
+        # still write state below, so availability tracks the gateway connection
+        # without ever emitting a phantom press.
         if self.coordinator.pushed_datapoint_id == self._datapoint["id"]:
             datapoint = self._find_datapoint(self._datapoint["id"])
             if datapoint:

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -187,6 +187,8 @@ class JungHomeLight(JungHomeEntity, LightEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this light changed
         _LOGGER.debug("Handling coordinator update for light %s", self._name)
         # Refresh each attribute only from its own datapoint's push, so a switch=on
         # echo arriving before the brightness echo can't momentarily reset the

--- a/custom_components/junghome/sensor.py
+++ b/custom_components/junghome/sensor.py
@@ -191,6 +191,8 @@ class JungHomeQuantity(JungHomeEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this quantity changed
         _LOGGER.debug("Handling coordinator update for quantity %s", self._name)
         datapoint = self._find_datapoint(self._datapoint["id"])
         if datapoint:

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -89,6 +89,8 @@ class JungHomeSocket(JungHomeEntity, SwitchEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this socket changed
         _LOGGER.debug("Handling coordinator update for socket %s", self._name)
         # Only re-read on a poll, or on a push for *this* datapoint (see
         # JungHomeEntity._should_refresh). Every push notifies every entity, so
@@ -179,6 +181,8 @@ class JungHomeSwitch(JungHomeEntity, SwitchEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
+        if self._skip_foreign_device_push():
+            return  # another device's push; nothing about this LED changed
         _LOGGER.debug("Updating switch for %s", self._attr_unique_id)
         # Same guard as the socket above: an unrelated push must not revert the
         # optimistic state written by turn_on/turn_off.

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -72,6 +72,36 @@ async def test_climate_created(hass: HomeAssistant, init_integration) -> None:
     assert state.attributes["hvac_action"] == "heating"
 
 
+async def test_ambient_temperature_push_updates_current_temperature(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A push for the thermostat's ambient quantity must update the entity.
+
+    The climate entity refreshes ``current_temperature`` device-wide (it holds
+    no id for the quantity datapoint), which is exactly why the foreign-push
+    write skip is scoped to the DEVICE rather than to the entity's stored
+    datapoint ids — an id-set scope would silently starve this attribute of
+    its own device's pushes until the next poll.
+    """
+    coordinator = init_integration.runtime_data
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idrtr1-010",
+                "values": [
+                    {"key": "quantity", "value": "22.5"},
+                    {"key": "quantity_label", "value": "Temperature "},
+                    {"key": "quantity_unit", "value": "°C"},
+                ],
+            },
+        }
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.living_room")
+    assert state.attributes["current_temperature"] == 22.5
+
+
 async def test_climate_hvac_off_is_rejected(
     hass: HomeAssistant, init_integration
 ) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -161,6 +161,140 @@ async def test_unrelated_push_does_not_revert_optimistic_socket_state(
     )
 
 
+def _two_device_coordinator(hass: HomeAssistant):
+    """A bare coordinator holding two sockets, plus an entity for the first."""
+    coordinator = bare_coordinator(hass)
+    mine = {
+        "id": "dev-a",
+        "type": "Socket",
+        "label": "Mine",
+        "datapoints": [
+            {
+                "id": "dp-a",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "1"}],
+            }
+        ],
+    }
+    other = {
+        "id": "dev-b",
+        "type": "Socket",
+        "label": "Other",
+        "datapoints": [
+            {
+                "id": "dp-b",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "1"}],
+            }
+        ],
+    }
+    coordinator.data = [mine, other]
+    entity = JungHomeSocket(coordinator, mine, mine["datapoints"][0])
+    entity.hass = hass
+    entity.entity_id = "switch.mine"
+    return coordinator, entity
+
+
+async def test_foreign_device_push_skips_the_state_write(hass: HomeAssistant) -> None:
+    """Another device's push must not cost this entity a state-machine write.
+
+    Every push notifies every entity; the write is skipped only when the push
+    belongs to a different device AND this entity is already shown available
+    (see ``JungHomeEntity._skip_foreign_device_push``). The push markers are
+    set directly here, exactly as the coordinator holds them for the duration
+    of one dispatch.
+    """
+    coordinator, entity = _two_device_coordinator(hass)
+    hass.states.async_set("switch.mine", "on")
+
+    # Foreign device's push while shown available -> skipped.
+    coordinator.pushed_datapoint_id = "dp-b"
+    coordinator.pushed_device_id = "dev-b"
+    with patch.object(entity, "async_write_ha_state") as write:
+        entity._handle_coordinator_update()
+    write.assert_not_called()
+
+    # Own device's push -> writes.
+    coordinator.pushed_datapoint_id = "dp-a"
+    coordinator.pushed_device_id = "dev-a"
+    with patch.object(entity, "async_write_ha_state") as write:
+        entity._handle_coordinator_update()
+    write.assert_called_once()
+
+    # No push marker (poll / broadcast / WS-drop dispatch) -> writes.
+    coordinator.pushed_datapoint_id = None
+    coordinator.pushed_device_id = None
+    with patch.object(entity, "async_write_ha_state") as write:
+        entity._handle_coordinator_update()
+    write.assert_called_once()
+
+
+async def test_foreign_push_never_skipped_while_unavailable_or_unwritten(
+    hass: HomeAssistant,
+) -> None:
+    """The skip must fail open whenever it could hide an availability change.
+
+    A push proves the gateway alive (`last_update_success` was just set True),
+    so an entity currently shown unavailable must write on this very dispatch
+    to become available again — and an entity never written at all must take
+    its first write. A pushed device without an id sets no device marker, so
+    that also writes.
+    """
+    coordinator, entity = _two_device_coordinator(hass)
+    coordinator.pushed_datapoint_id = "dp-b"
+    coordinator.pushed_device_id = "dev-b"
+
+    # Not yet in the state machine -> writes.
+    with patch.object(entity, "async_write_ha_state") as write:
+        entity._handle_coordinator_update()
+    write.assert_called_once()
+
+    # Currently unavailable -> writes (the availability recovery).
+    hass.states.async_set("switch.mine", "unavailable")
+    with patch.object(entity, "async_write_ha_state") as write:
+        entity._handle_coordinator_update()
+    write.assert_called_once()
+
+    # Pushed device carries no id -> no device marker -> writes.
+    hass.states.async_set("switch.mine", "on")
+    coordinator.pushed_device_id = None
+    with patch.object(entity, "async_write_ha_state") as write:
+        entity._handle_coordinator_update()
+    write.assert_called_once()
+
+
+async def test_push_restores_availability_of_other_devices_entities(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A push must make ALL entities available again, not just the pushed one.
+
+    After a failed poll every entity reads unavailable. The next push sets
+    ``last_update_success`` back to True for the whole entry, so entities of
+    OTHER devices must write on that same dispatch too — the foreign-push skip
+    is only allowed while an entity is already shown available. Skipping here
+    would freeze them on "unavailable" until the next successful poll.
+    """
+    coordinator = init_integration.runtime_data
+    coordinator.last_update_success = False
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+    assert hass.states.get("switch.boiler").state == "unavailable"
+    assert hass.states.get("sensor.boiler_power").state == "unavailable"
+
+    # A push for the LIGHT (a different device) arrives and proves the gateway
+    # alive again.
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": "idlight1-001", "values": [{"key": "switch", "value": "1"}]},
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.boiler").state != "unavailable"
+    assert hass.states.get("sensor.boiler_power").state != "unavailable"
+
+
 async def test_the_gateway_echo_still_updates_the_socket(
     hass: HomeAssistant, init_integration
 ) -> None:


### PR DESCRIPTION
A per-datapoint push dispatch notified every entity of the entry, so a chatty gateway (a socket reporting power once a second) cost N state-machine writes per frame for one changed value. The coordinator now records which DEVICE owns the pushed datapoint (pushed_device_id, same one-dispatch lifetime as pushed_datapoint_id), and every JungHomeEntity platform handler returns early when the push belongs to a different device.

Two guards keep this from repeating the PR #192 class of regression:

- The skip is scoped to the device, not to the entity's stored datapoint ids: climate refreshes its ambient temperature from the device's quantity datapoint it holds no id for, so an id-set scope would starve that attribute of its own device's pushes.
- The skip is forbidden while the state machine shows the entity as unavailable (or not yet written): during a push dispatch availability computes True for every entity (last_update_success was just set, the socket is live), so a push can only ever flip entities TO available — and it must, on that very dispatch, not a poll later.

Everything without a push marker (polls, functions/scenes broadcasts, the WS-drop notification, a pushed device without an id) fails open and writes exactly as before. The connectivity sensor and scenes do not inherit the helper — their state is not a pure function of a device's datapoints — and event entities keep firing on their own datapoint's edges (a foreign device's push can't be an edge on their button).

The datapoint-push branch moves out of _handle_websocket_message into _handle_datapoint_push unchanged (ruff statement limit).

Tests: foreign push skips the write / own push and markerless dispatches write; never skipped while unavailable, unwritten, or markerless (both verified to fail with the availability guard neutered); a failed-poll -> push sequence restores availability of OTHER devices' entities end-to-end; climate's ambient temperature updates from its own device's quantity push. 424 passed, 35 snapshots unchanged, coverage 98.5 %, mypy --strict and ruff clean.