### PR TITLE
Let a functions broadcast supersede a racing poll's stale membership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,13 @@ instead of re-deriving:
   Pushes that land while a poll is in flight are recorded and re-applied over
   the poll's snapshot (`_poll_push_overlay`) — the snapshot predates them, so
   adopting it as-is briefly reverted pushed/command-confirmed values.
+  Membership is covered separately: a `functions` broadcast adopted while a
+  poll's fetch is in flight supersedes that poll — the poll discards its
+  older snapshot (`_functions_broadcasts_seen` in `_async_update_data`),
+  skipping the overlay re-apply, the id-churn check and the
+  `data_generation` bump with it (the broadcast already ran all three on the
+  fresher list; bumping again would double-count one membership change in
+  the pruner's poll-based debounce).
 - **Availability**: entities key off `last_update_success` and never OR in
   `ws_connected` (a stale-True socket flag froze energy readings — issue
   #120); controllable entities additionally require the live WS because
@@ -345,7 +352,7 @@ numbers — and confirm the platform parses all of them.
 `functions` broadcast, per-datapoint pushes, command sends + correlated
 replies, the reconnect loop, entry reload/unload. For each documented
 invariant (push-overlay refcount, pending replies failed on session end, no
-poll starvation, the membership-race backlog note), pick the pairwise
+poll starvation, broadcast-supersedes-racing-poll), pick the pairwise
 interleavings that could violate it and check the *code*, not the comment.
 
 **Pass 4 — identity & HA-contract invariants.** No unique_id or device
@@ -402,7 +409,3 @@ or "clean — nothing above P3 survived verification."
   change and reports the regression upstream — a config fix at source
   beats all of this. Verify any change on a second rocker before shipping
   (all measurements so far are one button).
-- **A `functions` broadcast racing an in-flight poll can be overwritten by
-  the poll's older device list** (the per-datapoint overlay covers values,
-  not membership). Rare — the broadcast only fires on membership change —
-  and the next poll heals it.

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -257,6 +257,15 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         # one poll — and re-running the assigner/watcher's O(devices) walks on
         # every push was steady waste on a chatty gateway.
         self.data_generation = 0
+        # Monotonic count of adopted `functions` broadcasts, bumped only by
+        # `_handle_functions_broadcast`. A poll snapshots it when its fetch
+        # starts; a change by the time the fetch returns means a fresher,
+        # authoritative membership was adopted mid-flight and the poll's older
+        # snapshot is discarded (see `_async_update_data`). Deliberately a
+        # separate counter from `data_generation`: polls bump that too, so
+        # comparing generations would make overlapping polls discard each
+        # other's (equally fresh) snapshots.
+        self._functions_broadcasts_seen = 0
         # Stable-slug -> volatile device id, to detect firmware-update id changes.
         self._device_ids: dict[str, str] = {}
         # Per-platform (entity-domain -> unique_ids) sets shared with each
@@ -292,6 +301,11 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
     async def _async_update_data(self) -> list[Device]:
         """Fetch data from the API."""
         _LOGGER.debug("Fetching new device data from Jung Home API")
+        # Snapshot the broadcast counter at fetch start: if it moves while the
+        # HTTP request is in flight, a `functions` broadcast adopted a fresher
+        # authoritative device list mid-poll and this poll's older snapshot
+        # must not overwrite its membership (checked after the fetch below).
+        broadcasts_seen = self._functions_broadcasts_seen
         # Open the push overlay for the duration of the fetch: the response's
         # snapshot is generated before any push that races it, so those pushes
         # must win over the snapshot (see _apply_push_overlay). Joined, not
@@ -349,6 +363,36 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 overlay = dict(self._poll_push_overlay or {})
 
         _LOGGER.debug("API Response: %s", response)
+        if self._functions_broadcasts_seen != broadcasts_seen and self.data is not None:
+            # A `functions` broadcast adopted a fresher, authoritative device
+            # list while this fetch was in flight. The fetch started before
+            # the broadcast, so its snapshot predates the membership change —
+            # adopting it would resurrect removed devices and drop just-added
+            # ones until the next poll healed it (the per-datapoint overlay
+            # only covers *values*, not membership). Keep the broadcast's
+            # list instead: every value change since the snapshot was pushed,
+            # and the live merge path writes pushes into `self.data` (the
+            # broadcast's dicts) directly, so discarding the snapshot loses
+            # nothing. No `await` sits between the fetch completing and this
+            # check, so the counter comparison exactly covers the fetch
+            # window.
+            #
+            # Everything derived from the stale snapshot is skipped with it:
+            # the overlay re-apply (its targets are already current in
+            # `self.data`), the id-churn check (`_handle_functions_broadcast`
+            # already ran it against the broadcast list — running it on the
+            # OLD list here would false-flag the pre-broadcast ids as churn
+            # and schedule a needless reload), and the `data_generation`
+            # bump (listeners already counted this membership when the
+            # broadcast adopted it; advancing again would double-count one
+            # change as two polls in the pruner's miss debounce, and the
+            # no-op dispatch that follows is cheap because the
+            # generation-guarded listeners skip an unchanged generation).
+            _LOGGER.debug(
+                "A functions broadcast superseded this poll's snapshot; "
+                "keeping the broadcast's device list"
+            )
+            return self.data
         if overlay:
             self._apply_push_overlay(response, overlay)
         self._reload_if_device_ids_changed(response)
@@ -1120,6 +1164,13 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         """
         devices = cast("list[Device]", [d for d in data if isinstance(d, dict)])
         _LOGGER.debug("Adopting functions broadcast (%d devices)", len(devices))
+        # Counted BEFORE the adoption so a poll returning between these lines
+        # cannot slip through: everything here runs synchronously on the event
+        # loop, but the ordering keeps the invariant obvious — by the time any
+        # poll can compare its snapshot, the broadcast is already counted. A
+        # poll whose fetch was in flight across this point discards its older
+        # snapshot in favour of this list (see `_async_update_data`).
+        self._functions_broadcasts_seen += 1
         self._unmatched_push_ids.clear()
         self._reload_if_device_ids_changed(devices)
         self.async_set_updated_data(devices)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -184,6 +184,97 @@ async def test_poll_failure_discards_the_push_overlay(hass: HomeAssistant) -> No
     assert coordinator._poll_push_overlay is None
 
 
+async def test_functions_broadcast_supersedes_a_racing_polls_membership(
+    hass: HomeAssistant,
+) -> None:
+    """A `functions` broadcast mid-poll must not be overwritten by the poll.
+
+    The broadcast is the authoritative device list, sent on membership change;
+    a poll whose fetch was already in flight carries an OLDER snapshot. The
+    per-datapoint overlay only re-applies *values*, so adopting that snapshot
+    used to resurrect removed devices and drop just-added ones until the next
+    poll healed it. The poll must discard its snapshot in favour of the
+    broadcast's list — including a value pushed for the new device after the
+    broadcast — and must not advance `data_generation` a second time for the
+    membership change listeners already counted.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = [_switch_device("0")]
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def _slow_fetch(host: str, token: str) -> list[dict]:
+        fetch_started.set()
+        await release_fetch.wait()
+        return [_switch_device("0")]  # snapshot without the new device
+
+    added_device = {
+        "id": "dev2",
+        "label": "New Socket",
+        "datapoints": [
+            {
+                "id": "dp-2",
+                "type": "switch",
+                "values": [{"key": "switch", "value": "0"}],
+            }
+        ],
+    }
+    with patch.object(coordinator, "_fetch_devices_from_api", _slow_fetch):
+        poll = asyncio.ensure_future(coordinator._async_update_data())
+        await fetch_started.wait()
+        # Membership changes mid-poll: the gateway broadcasts the full list.
+        coordinator._handle_websocket_message(
+            {"type": "functions", "data": [_switch_device("0"), added_device]}
+        )
+        generation_after_broadcast = coordinator.data_generation
+        # The new device pushes a value before the poll returns.
+        coordinator._handle_websocket_message(
+            {
+                "type": "datapoint",
+                "data": {"id": "dp-2", "values": [{"key": "switch", "value": "1"}]},
+            }
+        )
+        release_fetch.set()
+        result = await poll
+
+    # The poll's stale snapshot was discarded: the broadcast's membership (and
+    # the value pushed onto it) survive, and the generation did not advance a
+    # second time for the same membership change.
+    assert [d["id"] for d in result] == ["dev1", "dev2"]
+    assert result[1]["datapoints"][0]["values"] == [{"key": "switch", "value": "1"}]
+    assert coordinator.data_generation == generation_after_broadcast
+    # The overlay closed normally despite the discarded snapshot.
+    assert coordinator._poll_push_overlay is None
+
+
+async def test_a_broadcast_before_the_fetch_does_not_discard_the_poll(
+    hass: HomeAssistant,
+) -> None:
+    """Only a broadcast DURING the fetch supersedes it.
+
+    A broadcast that was fully adopted before the poll's fetch even started is
+    older than the fetch's snapshot, so the poll must adopt normally — the
+    counter is snapshotted at fetch start, not at scheduling time.
+    """
+    coordinator = _coordinator(hass)
+    coordinator.data = [_switch_device("0")]
+    coordinator._handle_websocket_message(
+        {"type": "functions", "data": [_switch_device("0")]}
+    )
+    generation_after_broadcast = coordinator.data_generation
+
+    with patch.object(
+        coordinator,
+        "_fetch_devices_from_api",
+        AsyncMock(return_value=[_switch_device("1")]),
+    ):
+        result = await coordinator._async_update_data()
+
+    # The poll adopted its own (fresher) snapshot and advanced the generation.
+    assert result[0]["datapoints"][0]["values"] == [{"key": "switch", "value": "1"}]
+    assert coordinator.data_generation == generation_after_broadcast + 1
+
+
 async def test_reload_scheduled_when_device_ids_change(hass: HomeAssistant) -> None:
     coordinator = _coordinator(hass)
     coordinator._device_ids = {"katilas": "idOLD"}


### PR DESCRIPTION
Backlog item: a `functions` broadcast adopted while a REST poll's fetch was in flight could be overwritten by the poll's OLDER device list — the per-datapoint push overlay re-applies values, not membership, so a device removed (or added) by the broadcast was resurrected (or dropped) until the next poll healed it.

The coordinator now counts adopted broadcasts in a dedicated _functions_broadcasts_seen counter (bumped only by _handle_functions_broadcast, deliberately separate from data_generation — polls bump that too, so comparing generations would make overlapping polls discard each other's equally-fresh snapshots). A poll snapshots the counter when its fetch starts; if it moved by the time the fetch returns, the poll keeps `self.data` (the broadcast's list, with every since-pushed value already merged in by the live push path) and discards its own snapshot. No await sits between the fetch completing and the check, so the comparison exactly covers the fetch window.

Everything derived from the stale snapshot is skipped with it: the overlay re-apply (targets already current), the id-churn check (running it on the OLD list against the ids the broadcast recorded would false-flag churn and schedule a needless reload), and the data_generation bump (listeners already counted this membership when the broadcast adopted it; advancing again would double-count one change as two polls in the pruner's miss debounce — the follow-up dispatch is a cheap no-op for the generation-guarded listeners instead).

The fetch-start anchor is the best available ordering point: a broadcast fully adopted BEFORE the fetch starts does not discard the poll (tested) — that poll's snapshot is the fresher one.

CLAUDE.md: backlog entry resolved; the push-handling invariant now documents the membership half next to the value overlay.

Tests: broadcast-mid-poll keeps the broadcast's membership, a value pushed onto the new device, and the unadvanced generation (verified to fail with the supersede check neutered); broadcast-before-poll still adopts the poll normally. 422 passed, 35 snapshots unchanged, coverage 98.55 %, mypy --strict and ruff clean.