### PR TITLE
Fix "NaN" reading as off, and reauth's HA-2026.12 breakage

### DIFF
--- a/custom_components/junghome/__init__.py
+++ b/custom_components/junghome/__init__.py
@@ -9,7 +9,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     DATA_AREA_ASSIGNED,
@@ -389,11 +388,6 @@ def _make_area_assigner(
     return _assign_areas
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Jung Home integration."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> bool:
     """Set up Jung Home from a config entry."""
     host = entry.data.get("host")
@@ -706,18 +700,25 @@ async def async_unload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) ->
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: JungHomeConfigEntry) -> None:
-    """Reload when the stored host or the entry options change.
+    """Reload when the stored host, token or entry options change.
 
-    Registered as an update listener. The coordinator caches the host and an
-    options snapshot at construction, so a change to either only takes effect
-    after a reload (options drive the poll interval and cover inversion; the
-    host drives the API/WS target). Guard on an actual change so reauth's
-    token-only update (which already reloads via
-    ``async_update_reload_and_abort``) doesn't trigger a redundant second
-    reload.
+    Registered as an update listener. The coordinator caches the host, the
+    token and an options snapshot at construction, so a change to any of them
+    only takes effect after a reload (options drive the poll interval and cover
+    inversion; the host drives the API/WS target; the token authenticates
+    both). Guard on an actual change so an update that touches none of them
+    does not reload for nothing.
+
+    The token arm is what completes the reauth flow: that flow stores the fresh
+    token with ``async_update_and_abort`` and deliberately does NOT schedule its
+    own reload, because pairing a reloading flow helper with an update listener
+    is deprecated in HA 2026.6 and raises from 2026.12. Without this arm the new
+    token would sit in ``entry.data`` while the coordinator kept using the
+    rejected one it cached at construction — an endless reauth loop.
     """
     coordinator = entry.runtime_data
     host_changed = coordinator.config.get("host") != entry.data.get("host")
+    token_changed = coordinator.config.get("token") != entry.data.get("token")
     options_changed = coordinator.options_snapshot != dict(entry.options)
-    if host_changed or options_changed:
+    if host_changed or token_changed or options_changed:
         await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/junghome/config_flow.py
+++ b/custom_components/junghome/config_flow.py
@@ -501,8 +501,18 @@ class JungHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_finish(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Store the fresh token on the existing entry and reload it."""
-        return self.async_update_reload_and_abort(
+        """Store the fresh token on the existing entry and let the listener reload.
+
+        Deliberately ``async_update_and_abort``, not the ``..._reload_...``
+        variant: the entry always carries an update listener (``__init__``
+        registers one on every setup), and combining the two is deprecated
+        since HA 2026.6 and raises from 2026.12 — the raise lands *before* the
+        scheduled reload, so the fresh token would be stored while the
+        coordinator kept the rejected one, looping reauth until a restart. The
+        reconfigure and zeroconf paths already update-and-let-the-listener-
+        reload; this was the last one that did not.
+        """
+        return self.async_update_and_abort(
             self._get_reauth_entry(),
             data_updates={CONF_TOKEN: self._token},
         )

--- a/custom_components/junghome/const.py
+++ b/custom_components/junghome/const.py
@@ -232,6 +232,12 @@ def gateway_device_info(entry: "ConfigEntry", sw_version: str | None) -> DeviceI
         manufacturer=GATEWAY_MANUFACTURER,
         model=GATEWAY_MODEL,
         sw_version=sw_version,
+        # The hardware serial the entry already learned (mDNS TXT, or the
+        # gateway's own `config/parameter/system_serial`). Shown on the device
+        # page so a user with two gateways can tell them apart; it is not an
+        # identity field, so adding it never re-keys the device. Absent on a
+        # legacy entry that predates serial discovery.
+        serial_number=entry.data.get(CONF_SERIAL),
     )
 
 
@@ -247,6 +253,36 @@ def datapoint_value(datapoint: Datapoint | None, key: str) -> str | None:
     for value in datapoint.get("values", []):
         if value.get("key") == key:
             return value.get("value")
+    return None
+
+
+def datapoint_bool(datapoint: Datapoint | None, key: str) -> bool | None:
+    """Return a boolean datapoint's value, or ``None`` when the gateway has none.
+
+    ``"1"`` -> True, ``"0"`` -> False, **anything else -> None (unknown)**.
+
+    The "anything else" that matters is ``"NaN"``. After
+    ``btmesh.state_acceptable_request_fails`` (3) failed reads of a BT-Mesh node,
+    the middleware's ``onResponseFail`` sets ``state.value = NaN`` and pushes it;
+    ``composeDatapointByState`` stringifies every value, so the literal
+    ``"NaN"`` lands on the wire, and ``/functions`` keeps serving it (the
+    firmware's function assembly has no reachability filter). It appears on a
+    mesh outage and, briefly, on every gateway reboot before each node has been
+    read for the first time.
+
+    A plain ``== "1"`` collapses that to False, which for a light or a socket is
+    indistinguishable from someone having switched it off — history, logbook and
+    every ``to: "off"`` automation see an off that never happened. The numeric
+    readers in every other platform already degrade to unknown on ``"NaN"``
+    (``cover``, ``sensor``, ``binary_sensor``, the brightness/colour-temperature
+    parsers, and ``climate``'s map of this very ``switch`` key); this is the same
+    contract for the boolean ones.
+    """
+    value = datapoint_value(datapoint, key)
+    if value == "1":
+        return True
+    if value == "0":
+        return False
     return None
 
 

--- a/custom_components/junghome/coordinator.py
+++ b/custom_components/junghome/coordinator.py
@@ -1039,7 +1039,7 @@ class JungHomeDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
         if self._unavailable_logged:
             # Pair the single WARNING above with a matching recovery line, so an
             # outage has a visible end without trawling debug logs.
-            _LOGGER.warning("Jung Home WebSocket reconnected")
+            _LOGGER.info("Jung Home WebSocket reconnected")
             self._unavailable_logged = False
         ir.async_delete_issue(self.hass, DOMAIN, self._push_failure_issue_id)
 

--- a/custom_components/junghome/event.py
+++ b/custom_components/junghome/event.py
@@ -11,7 +11,7 @@ from .const import (
     BUTTON_DATAPOINT_TYPES,
     CONF_SUBTYPE,
     EVENT_BUTTON_ACTION,
-    datapoint_value,
+    datapoint_bool,
     stable_unique_id,
 )
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
@@ -115,12 +115,9 @@ class JungHomeEventEntity(JungHomeEntity, EventEntity):
         # without ever emitting a phantom press.
         if self.coordinator.pushed_datapoint_id == self._datapoint["id"]:
             datapoint = self._find_datapoint(self._datapoint["id"])
-            if datapoint:
-                event_type = (
-                    "pressed"
-                    if self._get_state_from_datapoint(datapoint)
-                    else "depressed"
-                )
+            pressed = self._get_state_from_datapoint(datapoint)
+            if pressed is not None:
+                event_type = "pressed" if pressed else "depressed"
                 _LOGGER.debug("Triggering %s event for %s", event_type, self.entity_id)
                 self._trigger_event(event_type)
                 self._fire_bus_event(event_type)
@@ -151,9 +148,14 @@ class JungHomeEventEntity(JungHomeEntity, EventEntity):
             },
         )
 
-    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
-        """Extract state from datapoint values. Returns True if pressed.
+    def _get_state_from_datapoint(self, datapoint: Datapoint | None) -> bool | None:
+        """Extract the edge from datapoint values. True if pressed.
 
         Scoped to this datapoint's own type so bundled request keys don't merge.
+        ``None`` when the datapoint is missing or the gateway reports ``"NaN"``
+        — it gave up reading the button after three failed requests, which is
+        not an edge. Firing ``depressed`` for it would be a phantom release,
+        and these states are ``POLL_ONCE``: a button that never answers is
+        re-polled every cycle, so it would repeat indefinitely.
         """
-        return datapoint_value(datapoint, self._datapoint.get("type", "")) == "1"
+        return datapoint_bool(datapoint, self._datapoint.get("type", ""))

--- a/custom_components/junghome/light.py
+++ b/custom_components/junghome/light.py
@@ -9,7 +9,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import datapoint_value, stable_unique_id
+from .const import datapoint_bool, datapoint_value, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 from .entity import JungHomeEntity, claim_new_entity
 from .models import Datapoint, Device
@@ -252,9 +252,13 @@ class JungHomeLight(JungHomeEntity, LightEntity):
         self._is_on = False
         self.async_write_ha_state()
 
-    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
-        """Extract the state of the light from its datapoint."""
-        return datapoint_value(datapoint, "switch") == "1"
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool | None:
+        """Extract the state of the light from its datapoint.
+
+        ``None`` when the gateway reports ``"NaN"`` (it gave up reading the
+        node) — the light reads *unknown*, not off. See ``datapoint_bool``.
+        """
+        return datapoint_bool(datapoint, "switch")
 
     def _get_brightness_from_datapoint(self, datapoint: Datapoint | None) -> int:
         """Extract the brightness of the light from its datapoint."""

--- a/custom_components/junghome/quality_scale.yaml
+++ b/custom_components/junghome/quality_scale.yaml
@@ -37,8 +37,14 @@ rules:
 
   # Silver
   action-exceptions:
-    status: exempt
-    comment: The integration registers no service actions.
+    status: done
+    comment: >-
+      No custom service actions are registered, but the rule explicitly covers
+      PLATFORM actions too (turning a light/switch on, moving a cover, setting a
+      thermostat). Every one of those raises a translated HomeAssistantError:
+      `cannot_send` when the WebSocket cannot carry the command, and
+      `command_timeout` when the gateway never confirms it (see
+      `_send_datapoint_command`); scene recall raises `scene_not_found`.
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
@@ -105,8 +111,11 @@ rules:
       silently — states keep updating on the REST poll, so nothing looks
       broken, it just stops being live. After MAX_RECONNECT_FAILURES consecutive
       failed reconnects the coordinator raises a non-fixable warning issue
-      (`websocket_push_failure`) and deletes it again on the next successful
-      connect, since only the gateway or the network coming back resolves it.
+      (`websocket_push_failure`) and deletes it again on the next connect that
+      STAYS UP for STABLE_SESSION_SECONDS (a bare connect is not proof of
+      recovery — a flapping socket would clear and re-raise the issue forever),
+      and on unload. It is not user-fixable: only the gateway or the network
+      coming back resolves it.
   stale-devices: done
 
   # Platinum

--- a/custom_components/junghome/switch.py
+++ b/custom_components/junghome/switch.py
@@ -8,7 +8,7 @@ from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import datapoint_value, stable_unique_id
+from .const import datapoint_bool, stable_unique_id
 from .coordinator import JungHomeConfigEntry, JungHomeDataUpdateCoordinator
 from .entity import JungHomeEntity, claim_new_entity
 from .models import Datapoint, Device
@@ -126,9 +126,13 @@ class JungHomeSocket(JungHomeEntity, SwitchEntity):
         self._is_on = False
         self.async_write_ha_state()
 
-    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
-        """Extract the state of the socket from its datapoint."""
-        return datapoint_value(datapoint, "switch") == "1"
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool | None:
+        """Extract the state of the socket from its datapoint.
+
+        ``None`` when the gateway reports ``"NaN"`` (it gave up reading the
+        node) — the socket reads *unknown*, not off. See ``datapoint_bool``.
+        """
+        return datapoint_bool(datapoint, "switch")
 
 
 class JungHomeSwitch(JungHomeEntity, SwitchEntity):
@@ -156,8 +160,9 @@ class JungHomeSwitch(JungHomeEntity, SwitchEntity):
         self._attr_unique_id = stable_unique_id(device, datapoint, "switch")
         self._attr_is_on = self._get_state_from_datapoint(datapoint)
 
-    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool:
-        return datapoint_value(datapoint, "status_led") == "1"
+    def _get_state_from_datapoint(self, datapoint: Datapoint) -> bool | None:
+        """``None`` when the gateway reports ``"NaN"``. See ``datapoint_bool``."""
+        return datapoint_bool(datapoint, "status_led")
 
     @property
     def is_on(self) -> bool | None:

--- a/docs/gateway-system-analysis.md
+++ b/docs/gateway-system-analysis.md
@@ -4,8 +4,8 @@ Analysis of the root partition microSD image (`disk_dump/jung/sdc2/`).
 
 **Platform:** Raspberry Pi Zero (armhf), Raspberry Pi OS Debian 13 Trixie
 **Firmware:** v2.1.3 Release (build 2840), built 2026-04-28 from GitLab CI (`lb-connect-gateway/lbc-gw-integration`)
-**Device serial:** `0000000084fb4b1b` · **MAC:** `00:22:d1:05:96:02`
-**mDNS hostname:** `junghome-0022d1059602.local`
+**Device serial:** `<redacted>` · **MAC:** `00:22:d1:xx:xx:xx` (JUNG OUI)
+**mDNS hostname:** `junghome-<mac without separators>.local`
 
 ---
 
@@ -185,7 +185,7 @@ Internet/LAN → :443 (nginx TLS) → :3000 (api-server HTTP)
 | Rescue static IP | `192.168.178.115/24`, gw `192.168.178.1` |
 | IPv6 | Disabled kernel-wide (`net.ipv6.conf.all.disable_ipv6=1`) |
 | mDNS | Avahi, eth0 + IPv4 only |
-| mDNS hostname | `junghome-0022d1059602.local` |
+| mDNS hostname | `junghome-<mac without separators>.local` |
 | Advertised services | `_junghome._tcp:443` and `_workstation._tcp:443` with TXT: version, serial, mac, manufacturer=JUNG |
 | Firewall | No persistent rules; iptables managed at runtime by `firewall.sh` |
 | NetworkManager | Not installed |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from copy import deepcopy
 from pathlib import Path
@@ -231,6 +232,32 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "real_serial_fetch: let the test run the real _async_fetch_serial "
         "(pair with aioclient_mock); by default it is stubbed to avoid a socket.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def fail_on_home_assistant_deprecation_reports(caplog: pytest.LogCaptureFixture):
+    """Fail any test that trips a Home Assistant deprecation report.
+
+    ``homeassistant.helpers.frame.report_usage`` **logs**; it never calls
+    ``warnings.warn``. So ``-W error::DeprecationWarning`` cannot see it, and a
+    dated removal ("breaks in Home Assistant 2026.12") sits inside a fully green
+    suite until the day it starts raising. That is exactly how pairing a
+    reloading config-flow helper with an update listener — deprecated in HA
+    2026.6 — survived unnoticed in the reauth path.
+
+    The reports name the integration, so this catches ours and stays quiet for
+    anything HA reports about itself.
+    """
+    yield
+    offenders = [
+        record.getMessage()
+        for record in caplog.get_records("call")
+        if record.name == "homeassistant.helpers.frame"
+        and record.levelno >= logging.WARNING
+    ]
+    assert not offenders, "Home Assistant deprecation report(s): " + "; ".join(
+        offenders
     )
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1644,3 +1644,34 @@ async def test_fetch_serial_over_rest(hass: HomeAssistant, aioclient_mock) -> No
     aioclient_mock.clear_requests()
     aioclient_mock.get(url, exc=aiohttp.ClientError())
     assert await _flow(hass)._async_fetch_serial("gw", "tok") is None
+
+
+async def test_reauth_on_a_loaded_entry_reloads_via_the_listener(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """Reauth must store the token and reload without HA's deprecated helper.
+
+    Only a *loaded* entry has update listeners, and that is the exact condition
+    under which `async_update_reload_and_abort` reports "has an update listener
+    and should use it for scheduling a reload" — deprecated in HA 2026.6, an
+    error from 2026.12. Every other reauth test uses a bare `MockConfigEntry`
+    that was never set up, so none of them can see it.
+
+    The autouse `fail_on_home_assistant_deprecation_reports` fixture is what
+    turns that report into a failure; this test is what provokes it.
+    """
+    entry = init_integration
+    assert entry.update_listeners  # the precondition the deprecation keys on
+
+    with patch(_REGISTER, AsyncMock(return_value="fresh-tok")):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await _advance_progress(hass, result)
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_TOKEN] == "fresh-tok"
+    # The listener owns the reload, so the rebuilt coordinator carries the new
+    # token — otherwise the next poll re-auth-fails in a loop.
+    assert entry.runtime_data.config["token"] == "fresh-tok"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -128,3 +128,34 @@ async def test_all_event_entities(
     """
     entry = await init_platform(Platform.EVENT)
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+async def test_nan_button_state_is_not_an_edge(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A `"NaN"` button value must fire nothing at all.
+
+    The gateway sends it once it has given up reading the node. Treated as a
+    falsy value it became a `depressed` edge — a phantom release, on the entity
+    AND on the bus event that device triggers listen to. These states are
+    `POLL_ONCE`, and an empty value keeps them dirty, so a button that never
+    answers is re-polled every cycle: the phantom would repeat indefinitely.
+    """
+    coordinator = init_integration.runtime_data
+    events: list = []
+    hass.bus.async_listen("junghome_button_action", events.append)
+
+    before = hass.states.get("event.button_a_up").state
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idrock1-00c",
+                "values": [{"key": "up_request", "value": "NaN"}],
+            },
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert events == []
+    assert hass.states.get("event.button_a_up").state == before

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -549,15 +549,34 @@ async def test_host_change_triggers_reload(
     reload.assert_called_once_with(entry.entry_id)
 
 
-async def test_token_only_change_no_reload(
+async def test_token_only_change_reloads_entry(
     hass: HomeAssistant, init_integration
 ) -> None:
-    """A token-only update (host unchanged) must not trigger a reload."""
+    """A token-only update MUST reload — it is how reauth takes effect.
+
+    The reauth flow stores the fresh token with ``async_update_and_abort`` and
+    deliberately schedules no reload of its own (pairing a reloading flow helper
+    with an update listener is deprecated in HA 2026.6 and raises from 2026.12).
+    The coordinator caches its credentials at construction, so without this arm
+    the new token would sit in ``entry.data`` while the coordinator kept using
+    the rejected one — an endless reauth loop.
+    """
     entry = init_integration
     with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload:
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_TOKEN: "newtok"}
         )
+        await hass.async_block_till_done()
+    reload.assert_called_once()
+
+
+async def test_unchanged_update_does_not_reload(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """An update that changes nothing the coordinator cached must not reload."""
+    entry = init_integration
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload:
+        hass.config_entries.async_update_entry(entry, data={**entry.data})
         await hass.async_block_till_done()
     reload.assert_not_called()
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -272,8 +272,8 @@ async def test_light_value_extractors_are_defensive(hass: HomeAssistant) -> None
     # No matching key -> defaults.
     assert light._get_brightness_from_datapoint({"id": "x", "values": []}) == 0
     assert light._get_color_temp_from_datapoint({"id": "x", "values": []}) is None
-    # State helper with no switch key -> off.
-    assert light._get_state_from_datapoint({"id": "x", "values": []}) is False
+    # State helper with no switch key -> unknown, not off (see datapoint_bool).
+    assert light._get_state_from_datapoint({"id": "x", "values": []}) is None
 
 
 async def test_light_set_without_datapoints_warns_and_noops(
@@ -528,3 +528,36 @@ async def test_unparseable_color_temp_is_none(hass: HomeAssistant, raw: str) -> 
     """An unusable Kelvin value yields None rather than raising."""
     light = _color_light(bare_coordinator(hass), color_temp=raw)
     assert light.color_temp_kelvin is None
+
+
+async def test_nan_switch_reads_unknown_not_off(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A `"NaN"` switch value must leave the light unknown, never off.
+
+    Same contract as the socket (see `datapoint_bool`): the gateway sends
+    `"NaN"` once it has given up reading a node, and reading that as off puts a
+    state the user never caused into history.
+    """
+    coordinator = init_integration.runtime_data
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": "idlight1-001", "values": [{"key": "switch", "value": "1"}]},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("light.hall_light").state == "on"
+
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idlight1-001",
+                "values": [{"key": "switch", "value": "NaN"}],
+            },
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.hall_light").state == "unknown"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -45,18 +45,24 @@ async def test_status_led_update(hass: HomeAssistant, init_integration) -> None:
     assert hass.states.get("switch.button_a_status_led").state == "on"
 
 
-async def test_socket_state_helper_defaults_off(hass: HomeAssistant) -> None:
-    """A socket datapoint without a switch value reads as off (helper fallback)."""
+async def test_socket_state_helper_reads_unknown_without_a_value(
+    hass: HomeAssistant,
+) -> None:
+    """A socket datapoint with no switch value reads unknown, not off.
+
+    Absent information is not "off": asserting off would put a fabricated state
+    in history and fire every ``to: "off"`` automation. Same contract as the
+    ``"NaN"`` case (see ``datapoint_bool``).
+    """
     coordinator = bare_coordinator(hass)
     device = {"id": "d", "type": "Socket", "label": "Sock", "datapoints": []}
-    # No "switch" key in values -> _get_state_from_datapoint returns False.
     socket = JungHomeSocket(coordinator, device, {"id": "d-1", "values": []})
-    assert socket.is_on is False
+    assert socket.is_on is None
 
-    # And the status-LED helper likewise defaults off without a status_led value.
+    # And the status-LED helper likewise.
     led_dev = {"id": "r", "type": "RockerSwitch", "label": "R", "datapoints": []}
     led = JungHomeSwitch(coordinator, led_dev, {"id": "r-1", "values": []})
-    assert led.is_on is False
+    assert led.is_on is None
 
 
 async def test_switch_led_handle_update_missing_device_noops(
@@ -406,3 +412,60 @@ async def test_a_sibling_datapoints_push_does_not_revert_the_socket(
     await hass.async_block_till_done()
 
     assert hass.states.get("switch.boiler").state == "off"
+
+
+async def test_nan_switch_reads_unknown_not_off(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A `"NaN"` switch value must read unknown, never off.
+
+    After three failed BT-Mesh reads the middleware's `onResponseFail` sets the
+    state's value to `NaN`, and `composeDatapointByState` stringifies every
+    value — so the literal `"NaN"` lands on the wire, and `/functions` keeps
+    serving it (the firmware's function assembly has no reachability filter).
+    Field-observed on a real gateway: a mesh outage produced summary lines
+    naming up to 24 unreachable devices at once, and every reboot leaves a
+    window before each node has been read for the first time.
+
+    Read as off, that is indistinguishable from someone switching the load off:
+    history and logbook record an off that never happened and every
+    `to: "off"` automation fires.
+    """
+    coordinator = init_integration.runtime_data
+    assert hass.states.get("switch.boiler").state == "on"
+
+    socket_dp = next(
+        dp["id"]
+        for d in coordinator.data
+        if d["label"] == "Boiler"
+        for dp in d["datapoints"]
+        if dp["type"] == "switch"
+    )
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {"id": socket_dp, "values": [{"key": "switch", "value": "NaN"}]},
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.boiler").state == "unknown"
+
+
+async def test_nan_status_led_reads_unknown_not_off(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The status LED takes the same contract as the socket."""
+    coordinator = init_integration.runtime_data
+    coordinator._handle_websocket_message(
+        {
+            "type": "datapoint",
+            "data": {
+                "id": "idrock1-00e",
+                "values": [{"key": "status_led", "value": "NaN"}],
+            },
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.button_a_status_led").state == "unknown"


### PR DESCRIPTION
Six-agent repo-scope review (wire contracts, firmware evidence, quality scale, HA drift + CI, test mutation, product/UX). This PR lands the **P0** and the **P1** plus the cheap corrections; the larger proposals are reported separately.

## P0 — a `"NaN"` boolean datapoint read as **off**, not unknown

After `btmesh.state_acceptable_request_fails` (3) failed reads of a node, the middleware's `onResponseFail` sets `state.value = NaN` and pushes it; `composeDatapointByState` stringifies every value, so the literal `"NaN"` reaches the wire — and `/functions` keeps serving it, because the firmware's function assembly has no reachability filter. `light`, `switch` (socket + status LED) and `event` all tested `== "1"`, so that collapsed to `False`.

For a light or a socket, **off is indistinguishable from someone having switched the load off**: history and logbook record an off that never happened, and every `to: "off"` automation fires.

**This is field-observed, not theoretical.** The gateway's own archived middleware logs carry 55 `is not reachable` events in a single window and summary lines naming **up to 24 unreachable devices at once** — and every reboot leaves a window before each node has been read for the first time.

For the rocker it fired a phantom `depressed` edge on the entity *and* on the bus event device triggers listen to. Those states are `POLL_ONCE` and an empty value keeps them dirty, so a button that never answers would repeat that phantom every poll.

The asymmetry was self-documenting: every **numeric** reader already degrades to unknown on `"NaN"` (cover, sensor, binary_sensor, brightness, colour temperature), and `climate._SWITCH_TO_HVAC_ACTION` handles the **same `switch` wire key** correctly, with a comment naming `"NaN"` explicitly. Only the boolean extractors trusted the descriptor (`cdb_types_datapoints.json` promises range `["0","1"]`) over the implementation — the same failure mode that shipped the preset-`"none"` bug.

A shared `datapoint_bool` gives them the numeric readers' contract. A missing key now reads unknown too, for the same reason. Four regression tests, each verified to fail against the old code.

## P1 — reauth breaks on HA 2026.12

`async_step_reauth_finish` used `async_update_reload_and_abort` while the entry **always** carries an update listener. HA deprecated that pairing in 2026.6 (`config_entries.py` → `report_usage(..., breaks_in_ha_version="2026.12.0")`) and raises from 2026.12 — **before** the scheduled reload, so the fresh token would be stored while the coordinator kept the rejected one it cached at construction: reauth loops until a restart.

Reconfigure and zeroconf were already migrated to update-and-let-the-listener-reload; this was the last path that was not. Now `async_update_and_abort` (verified present on the 2025.12.4 floor too) plus a token arm in `async_reload_entry`.

**Nothing in CI could see it.** `report_usage` *logs*; it never calls `warnings.warn`, so even `-W error::DeprecationWarning` passes while a dated removal sits inside a fully green suite. An autouse fixture now fails any test that trips a report from `homeassistant.helpers.frame`. It only bites on a *loaded* entry — which no reauth test used, hence the new one.

## Also, from the same review

- `quality_scale.yaml`: `action-exceptions` was `exempt` ("registers no service actions"), but the rule explicitly counts **platform** actions, and all of ours already raise translated errors → `done`. The `repair-issues` comment claimed the issue is deleted "on the next successful connect"; it is deleted 30 s later via `_mark_session_stable`, deliberately, and the coordinator documents why.
- hassfest warned on **every** CI run: a dead `async_setup` returning `True` with no `CONFIG_SCHEMA`. Removed.
- The hub device now carries the `serial_number` the entry already stores.
- A *successful* WebSocket reconnect logged at WARNING; HA's own coordinator logs recovery at info.
- `docs/gateway-system-analysis.md` published the imaged gateway's real serial, MAC and mDNS hostname — the same three fields `diagnostics.py` redacts. Replaced with placeholders.

## Gates

450 passed, 35 snapshots unchanged (none unused), branch coverage 98.57 %, `mypy --strict` and `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaZuqywCaHbyu9dH6Uc3nH